### PR TITLE
check CN, print version, bump version 0.2.1

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= "0.2.0"
+VERSION ?= "0.2.1"
 PROJECT_NAME := vs
 PKG := "zpr.org/$(PROJECT_NAME)"
 PKG_LIST := $(shell go list ${PKG}/... | grep -v /vendor/)

--- a/core/cmd/vservice/main.go
+++ b/core/cmd/vservice/main.go
@@ -106,6 +106,7 @@ service using the visa service API.
 		if err != nil {
 			return fmt.Errorf("failed to initialize logging: %w", err)
 		}
+		serviceLog.Info(fmt.Sprintf("ZPR visa service v%s", ver.String()))
 
 		cert, err := tls.LoadX509KeyPair(config.VSCert, config.VSKey)
 		if err != nil {
@@ -118,6 +119,9 @@ service using the visa service API.
 			return fmt.Errorf("failed to load adapter certificate: %w", err)
 		}
 		cn := a_cert.Subject.CommonName
+		if cn != vservice.VisaServiceCN {
+			return fmt.Errorf("adapter certificate common name %q does not match required visa service common name %q", cn, vservice.VisaServiceCN)
+		}
 
 		authorityCert, err := loadCertFromFile(config.AuthorityCert)
 		if err != nil {

--- a/core/pkg/vservice/constants.go
+++ b/core/pkg/vservice/constants.go
@@ -36,6 +36,8 @@ const (
 	// ZPR hard coded visa service address.
 	VisaServiceAddress = "fd5a:5052::1"
 
+	VisaServiceCN = "vs.zpr"
+
 	// AdminPort is the admin control port for visa service
 	AdminPort = 8182 // TCP
 


### PR DESCRIPTION
- Do not start if the CN in the vs adapter certificate is not set to "vs.zpr"
- Print the version in the log.

Also bumped version to 0.2.1

Closes #9 
