### PR TITLE
assign a ZPR addr to a connecting adapter

### DIFF
--- a/core/pkg/vservice/adb/actordb.go
+++ b/core/pkg/vservice/adb/actordb.go
@@ -1,6 +1,7 @@
 package adb
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"net/netip"
@@ -87,6 +88,7 @@ type ActorDB struct {
 	sync.RWMutex
 	actorsV6toHr map[Ipv6Addr]*HostRecord // Note we keep address in IPv6 format.
 	watcher      Watcher
+	addrCounter  uint64 // used to generate new addresses for actors
 }
 
 func (db *ActorDB) Dump(out logr.Logger) {
@@ -108,6 +110,7 @@ func NewActorDB(watcher Watcher) *ActorDB {
 	return &ActorDB{
 		actorsV6toHr: make(map[Ipv6Addr]*HostRecord),
 		watcher:      watcher,
+		addrCounter:  1,
 	}
 }
 
@@ -121,6 +124,22 @@ func (pr *PeerRecord) IsInSync() bool {
 	return (pr.State.WantPolicyVer > 0 || pr.State.WantConfigID > 0) &&
 		pr.State.WantPolicyVer == pr.State.LastPushPolicyVer &&
 		pr.State.WantConfigID == pr.State.LastPushConfigID
+}
+
+// TODO: This is just a placeholder/temporary function that returns incremental
+// IPv6 address in fd5a:5052:1:1::/64
+func (db *ActorDB) GetNextZPRAddress() netip.Addr {
+	addrBytes := [16]byte{
+		0xfd, 0x5a, 0x50, 0x52, // fd5a:5052
+		0x00, 0x01, 0x00, 0x01, // 0001:0001
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+	}
+	db.Lock()
+	defer db.Unlock()
+	binary.BigEndian.PutUint64(addrBytes[8:16], db.addrCounter)
+	db.addrCounter++
+	return netip.AddrFrom16(addrBytes)
 }
 
 func (db *ActorDB) Contains(addr netip.Addr) bool {

--- a/core/pkg/vservice/adb/actordb_test.go
+++ b/core/pkg/vservice/adb/actordb_test.go
@@ -45,3 +45,28 @@ func TestCloneNodesToBriefCopiesCounts(t *testing.T) {
 	}
 
 }
+
+func TestGetNextZPRAddress(t *testing.T) {
+	db := adb.NewActorDB(&DummyWatcher{})
+
+	// Test that GetNextZPRAddress returns a valid IPv6 address
+	addr1 := db.GetNextZPRAddress()
+	require.True(t, addr1.IsValid(), "GetNextZPRAddress should return a valid address")
+	require.True(t, addr1.Is6(), "GetNextZPRAddress should return an IPv6 address")
+
+	// Test that consecutive calls return different addresses
+	addr2 := db.GetNextZPRAddress()
+	require.True(t, addr2.IsValid(), "Second call should return a valid address")
+	require.True(t, addr2.Is6(), "Second call should return an IPv6 address")
+	require.NotEqual(t, addr1, addr2, "Consecutive calls should return different addresses")
+
+	// Test that we can get multiple unique addresses
+	addresses := make(map[netip.Addr]bool)
+	for i := 0; i < 10; i++ {
+		addr := db.GetNextZPRAddress()
+		require.True(t, addr.IsValid(), "Address should be valid")
+		require.True(t, addr.Is6(), "Address should be IPv6")
+		require.False(t, addresses[addr], "Address should be unique")
+		addresses[addr] = true
+	}
+}

--- a/core/pkg/vservice/connectioncontrol.go
+++ b/core/pkg/vservice/connectioncontrol.go
@@ -15,8 +15,10 @@ import (
 
 // ApproveConnection check connection against validation and policy.
 //
-// The EPID on the connection request is either a new one created by the node, or
-// one that the client has submitted at HELLO.
+// If the request includes a "zpr.addr" claim then that is considered a request
+// from the adapter. Note that it may be an address we have previously handed to
+// the actor/adapter.  If that claim is missing, and there is not a static address
+// set in policy, then we allocate a new address for the actor on successful validation.
 //
 // Set `bootstrap` true for self-authenticating `vs.zpr` -- the Visa Service actor.
 func (vs *VSInst) ApproveConnection(cr *vsapi.ConnectRequest, bootstrap bool) (*actor.Actor, error) {
@@ -138,8 +140,8 @@ func (vs *VSInst) validateCredentials(curpol *policy.Policy, cr *vsapi.ConnectRe
 		return nil, fmt.Errorf("exactly one authentication blob must be provided")
 	}
 
-	// The address assigned to the actor is either requested by the actor and propogated by the node
-	// into the actors claims, or it is assigned by the node, or it is not set at all (and must be set by policy).
+	// The address assigned to the actor is either requested by the actor and propagated here by the node
+	// via a zpr.addr claim, or it may be assigned in policy, finally we can just assign one ourselves.
 	var reqAddr netip.Addr
 	if epidClaim, found := cr.Claims[actor.KAttrEPID]; found {
 		reqAddr, err = netip.ParseAddr(epidClaim)
@@ -180,6 +182,12 @@ func (vs *VSInst) validateCredentials(curpol *policy.Policy, cr *vsapi.ConnectRe
 		return nil, fmt.Errorf("multiple authentication results not yet supported") // TODO
 	}
 	combinedAuth := authSuccesses[0]
+
+	if _, found := combinedAuth.Claims[actor.KAttrEPID]; !found {
+		// Need to assign an address.
+		zprAddr := vs.actorDB.GetNextZPRAddress()
+		combinedAuth.Claims[actor.KAttrEPID] = &actor.ClaimV{V: zprAddr.String(), Exp: combinedAuth.Expire}
+	}
 
 	combinedAuth.Claims[actor.KAttrAuthority] = &actor.ClaimV{V: strings.Join(combinedAuth.Prefixes, ","), Exp: combinedAuth.Expire}
 


### PR DESCRIPTION
Only if zpr.addr claim is not set.

This has hard-coded as a base address fd5a:5052:1:1::/64.  And then just increments a uint64 counter for each successive connect request.  This simple algorithm is to hold us over until next visa service.