### PR TITLE
config for fetching private dependency

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[net]
+git-fetch-with-cli = true
+


### PR DESCRIPTION
This fixes an issue where `make` fails to git clone `zpr-core` which it needs as a dependency. This happened even though git config was set as described at https://github.com/org-zpr/zpr-core/blob/main/README.md#build-notes. The same fix was already applied in zpr-core: https://github.com/org-zpr/zpr-core/pull/866.

The error I encountered is included below. Based on it, I speculate that cargo's git library tries to use SSH but can't; perhaps a mismatch with my version of OpenSSH (macOS) or perhaps I have some unusual entry in my `.ssh/known_hosts`.

```
$ make
/Library/Developer/CommandLineTools/usr/bin/make -C core all
go build  -ldflags="-X main.BuildVersion="0.7.0"" -o build/vservice -v "zpr.org/vs"/cmd/vservice
/Library/Developer/CommandLineTools/usr/bin/make -C vs-conform all
go build  -ldflags="-X main.BuildVersion="0.7.0"" -o build/vs-conform
/Library/Developer/CommandLineTools/usr/bin/make -C vs-admin all
cargo build --all-targets
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.14s
/Library/Developer/CommandLineTools/usr/bin/make -C vs all
cargo build --all-targets
    Updating crates.io index
    Updating git repository `https://github.com/org-zpr/zpr-core.git`
error: failed to get `zpr` as a dependency of package `vs v0.1.0 (/Users/michaelnestler/zpr-repos/org-zpr/zpr-visaservice/vs)`

Caused by:
  failed to load source for dependency `zpr`

Caused by:
  Unable to update https://github.com/org-zpr/zpr-core.git?tag=zpr-0.2.0#7308de36

Caused by:
  failed to fetch into: /Users/michaelnestler/.cargo/git/db/zpr-core-2b10f9b5a8607308

Caused by:
  revision 7308de36e64db88b1e5c4871a04bb52e9972b851 not found

Caused by:
  network failure seems to have happened
  if a proxy or similar is necessary `net.git-fetch-with-cli` may help here
  https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli

Caused by:
  error loading known_hosts: Failed to parse known hosts file; class=Ssh (23)
make[1]: *** [build] Error 101
make: *** [build-rs] Error 2
```