### PR TITLE
remove repititon

### DIFF
--- a/admin-api-types/src/lib.rs
+++ b/admin-api-types/src/lib.rs
@@ -1,1 +1,2 @@
-pub mod admin_api_types;
+mod admin_api_types;
+pub use admin_api_types::*;

--- a/vs-admin/src/executor.rs
+++ b/vs-admin/src/executor.rs
@@ -9,7 +9,7 @@ use std::io::Read;
 use std::io::prelude::*;
 use std::path::Path;
 
-use admin_api_types::admin_api_types::{ListEntry, PolicyBundle};
+use admin_api_types::{ListEntry, PolicyBundle};
 
 use crate::vsclient::{RoleFilter, VsClient};
 

--- a/vs-admin/src/gui.rs
+++ b/vs-admin/src/gui.rs
@@ -12,7 +12,7 @@ use reqwest::tls::Certificate;
 use chrono::{DateTime, SecondsFormat, Utc};
 use std::time::{Duration, Instant};
 
-use admin_api_types::admin_api_types::{ActorDescriptor, ServiceDescriptor, VisaDescriptor};
+use admin_api_types::{ActorDescriptor, ServiceDescriptor, VisaDescriptor};
 
 use crate::vsclient::{RoleFilter, VsClient};
 

--- a/vs-admin/src/vsclient.rs
+++ b/vs-admin/src/vsclient.rs
@@ -4,11 +4,10 @@ use colored::Colorize;
 use reqwest;
 use reqwest::tls::Certificate;
 
-use admin_api_types::admin_api_types::reason_for;
-use admin_api_types::admin_api_types::{
+use admin_api_types::{
     ActorDescriptor, AuthRevokeDescriptor, CnEntry, ListEntry, NamedListEntry, PolicyBundle,
-    Revokes, ServiceDescriptor, VisaDescriptor,
-}; // TODO: get rid of this repetition of 'admin_api_types'
+    Revokes, ServiceDescriptor, VisaDescriptor, reason_for,
+};
 
 use crate::error::VsaError;
 

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -35,7 +35,7 @@ use crate::assembly::Assembly;
 use crate::db::Role;
 use crate::logging::targets::ADMIN;
 
-use admin_api_types::admin_api_types::{
+use admin_api_types::{
     ActorDescriptor, AuthRevokeDescriptor, CnEntry, ListEntry, NamedListEntry, PolicyBundle,
     Revokes, ServiceDescriptor, VisaDescriptor,
 };


### PR DESCRIPTION
It was irritating to write `use admin_api_types::admin_api_types::{blah}` so now you can just write `use admin_api_types::{blah}`.