### PR TITLE
self-signed-blob sends sig as bytes (not b64)

### DIFF
--- a/libeval/Cargo.lock
+++ b/libeval/Cargo.lock
@@ -854,8 +854,8 @@ dependencies = [
 
 [[package]]
 name = "zpr"
-version = "0.7.1"
-source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.7.1#acd350c8331a0c028b2226a2577ab7cfaae9de25"
+version = "0.7.2"
+source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.7.2#7602d3ea396110449829ef81b0ce6d95735874b9"
 dependencies = [
  "capnp",
  "capnpc",

--- a/vs-admin/Cargo.lock
+++ b/vs-admin/Cargo.lock
@@ -2930,8 +2930,8 @@ checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
 
 [[package]]
 name = "zpr"
-version = "0.7.1"
-source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.7.1#acd350c8331a0c028b2226a2577ab7cfaae9de25"
+version = "0.7.2"
+source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.7.2#7602d3ea396110449829ef81b0ce6d95735874b9"
 dependencies = [
  "capnp",
  "capnpc",

--- a/vs/src/auth.rs
+++ b/vs/src/auth.rs
@@ -1,4 +1,3 @@
-use base64::prelude::*;
 use openssl::hash::MessageDigest;
 use openssl::pkey::{PKey, Public};
 use openssl::sign::Verifier;
@@ -13,7 +12,7 @@ pub fn verify_ss_blob_signature(
     ssb: &SelfSignedBlob,
     pubkey: PKey<Public>,
 ) -> Result<bool, CryptoError> {
-    let input_signature = BASE64_STANDARD.decode(&ssb.signature)?;
+    let input_signature = &ssb.signature;
     let content = [
         &ssb.timestamp.to_be_bytes()[..],
         cn.as_bytes(),

--- a/zpt/Cargo.lock
+++ b/zpt/Cargo.lock
@@ -1550,8 +1550,8 @@ checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
 
 [[package]]
 name = "zpr"
-version = "0.7.1"
-source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.7.1#acd350c8331a0c028b2226a2577ab7cfaae9de25"
+version = "0.7.2"
+source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.7.2#7602d3ea396110449829ef81b0ce6d95735874b9"
 dependencies = [
  "capnp",
  "capnpc",


### PR DESCRIPTION
Fix bug where we were attempting to base64 decode a binary value.