### PR TITLE
do not try to deallocate address that is not ours

### DIFF
--- a/vs/src/connection_control.rs
+++ b/vs/src/connection_control.rs
@@ -296,20 +296,26 @@ impl ConnectionControl {
         // Use AUTHORITY as one of the identity keys if present.
         let _ = authd_actor.add_identity_key(usize::MAX, key::AUTHORITY);
 
-        if let Some(addr) = authd_actor.get_zpr_addr() {
-            info!(target: CC, "authorized adapter cn {} with ZPR addr {}", adapter_cn, addr);
+        let actor_role = if authd_actor.is_node() {
+            Role::Node
         } else {
-            match asm.net_mgr.get_next_zpr_addr(Role::Adapter).await {
+            Role::Adapter
+        };
+
+        if let Some(addr) = authd_actor.get_zpr_addr() {
+            info!(target: CC, "authorized adapter/{actor_role:?} cn {} with ZPR addr {}", adapter_cn, addr);
+        } else {
+            match asm.net_mgr.get_next_zpr_addr(&actor_role).await {
                 Ok(addr) => {
                     authd_actor.add_attribute(
                         Attribute::builder(key::ZPR_ADDR)
                             .expires(SystemTime::now() + config::DEFAULT_AUTH_EXPIRATION)
                             .value(addr.to_string()),
                     )?;
-                    info!(target: CC, "authorized adapter cn {} assigned ZPR addr {}", adapter_cn, addr);
+                    info!(target: CC, "authorized adapter/{actor_role:?} cn {} assigned ZPR addr {}", adapter_cn, addr);
                 }
                 Err(e) => {
-                    error!(target: CC, "failed to assign ZPR addr to authorized adapter cn {}: {}", adapter_cn, e);
+                    error!(target: CC, "failed to assign ZPR addr to authorized adapter/{actor_role:?} cn {}: {}", adapter_cn, e);
                     return Err(ServiceError::Internal("address assignment failed".into()));
                 }
             }
@@ -373,8 +379,10 @@ impl ConnectionControl {
                             error!(target: CC, "failed to remove disconnected adapter with addr {adapter_addr} from actor db: {}", e);
                         }
                     };
-                    if let Err(s) = asm.net_mgr.release_zpr_addr(adapter_addr).await {
-                        error!(target: CC, "failed to release ZPR addr {adapter_addr} for orphaned adapter: {}", s);
+                    if asm.net_mgr.is_managed_address(&adapter_addr) {
+                        if let Err(s) = asm.net_mgr.release_zpr_addr(adapter_addr).await {
+                            error!(target: CC, "failed to release ZPR addr {adapter_addr} for orphaned adapter: {}", s);
+                        }
                     }
                 }
                 asm.actor_mgr.remove_node(&zpr_addr).await?;
@@ -390,8 +398,9 @@ impl ConnectionControl {
             error!(target: CC, "failed to remove visas for disconnected actor at addr {zpr_addr}: {}", e);
         }
 
-        asm.net_mgr.release_zpr_addr(zpr_addr).await?;
-
+        if asm.net_mgr.is_managed_address(&zpr_addr) {
+            asm.net_mgr.release_zpr_addr(zpr_addr).await?;
+        }
         Ok(())
     }
 }

--- a/vs/src/net_mgr.rs
+++ b/vs/src/net_mgr.rs
@@ -65,7 +65,7 @@ impl NetMgr {
     }
 
     /// Return an unused, random address in our network space.
-    pub async fn get_next_zpr_addr(&self, role: Role) -> Result<IpAddr, ServiceError> {
+    pub async fn get_next_zpr_addr(&self, role: &Role) -> Result<IpAddr, ServiceError> {
         let addr = match role {
             Role::Adapter => {
                 self.adapter_addrs
@@ -92,7 +92,8 @@ impl NetMgr {
         Ok(addr)
     }
 
-    /// Release a previously allocated address.
+    /// Release a previously allocated address, returns an error if the address
+    /// was not allocated by this manager.
     pub async fn release_zpr_addr(&self, addr: IpAddr) -> Result<(), ServiceError> {
         {
             let mut allocator = self.adapter_addrs.lock().unwrap();
@@ -109,6 +110,19 @@ impl NetMgr {
         Err(ServiceError::Internal(format!(
             "attempted to release address {addr} not managed by any allocator"
         )))
+    }
+
+    /// True if the address is within one of our managed networks.
+    /// Note that address may or may not be currently allocated.
+    pub fn is_managed_address(&self, addr: &IpAddr) -> bool {
+        match addr {
+            IpAddr::V4(ip4) => {
+                config::ADAPTER_BASE_V4NET.contains(ip4) || config::NODE_BASE_V4NET.contains(ip4)
+            }
+            IpAddr::V6(ip6) => {
+                config::ADAPTER_BASE_V6NET.contains(ip6) || config::NODE_BASE_V6NET.contains(ip6)
+            }
+        }
     }
 }
 
@@ -253,11 +267,11 @@ mod tests {
         let node_net = config::NODE_BASE_V6NET;
 
         let adapter_addr = mgr
-            .get_next_zpr_addr(Role::Adapter)
+            .get_next_zpr_addr(&Role::Adapter)
             .await
             .expect("failed to allocate adapter v6 addr");
         let node_addr = mgr
-            .get_next_zpr_addr(Role::Node)
+            .get_next_zpr_addr(&Role::Node)
             .await
             .expect("failed to allocate node v6 addr");
 
@@ -288,11 +302,11 @@ mod tests {
         let node_net = config::NODE_BASE_V4NET;
 
         let adapter_addr = mgr
-            .get_next_zpr_addr(Role::Adapter)
+            .get_next_zpr_addr(&Role::Adapter)
             .await
             .expect("failed to allocate adapter v4 addr");
         let node_addr = mgr
-            .get_next_zpr_addr(Role::Node)
+            .get_next_zpr_addr(&Role::Node)
             .await
             .expect("failed to allocate node v4 addr");
 

--- a/vs/src/vsapi_worker.rs
+++ b/vs/src/vsapi_worker.rs
@@ -317,6 +317,8 @@ impl VisaServiceImpl {
 }
 
 impl vsapi::visa_service::Server for VisaServiceImpl {
+    // Node connection request to the Visa Service.
+    // Currently the node must pass its ZPR_ADDRESS and AAA_PREFIX as connect params.
     async fn connect(
         self: Rc<Self>,
         params: vsapi::visa_service::ConnectParams,
@@ -802,8 +804,10 @@ impl vsapi::v_s_handle::Server for VSHandleImpl {
         {
             error!(target: API, "failed to add authenticated adapter {:?} to actor db: {}", actor.get_cn(), e);
 
-            if let Err(e) = self.asm.net_mgr.release_zpr_addr(actor_addr).await {
-                warn!(target: API, "failed to release adapter address {}: {}", actor_addr, e);
+            if self.asm.net_mgr.is_managed_address(&actor_addr) {
+                if let Err(e) = self.asm.net_mgr.release_zpr_addr(actor_addr).await {
+                    warn!(target: API, "failed to release adapter address {}: {}", actor_addr, e);
+                }
             }
 
             let mut err_builder = results.get().init_resp().init_error();


### PR DESCRIPTION
Add a check before calling release.

As I was looking into this I also noticed that the auth step was allocating an ADAPTER address without checking that the actor was actually in that role.  Now requests an address based on role.