### PR TITLE
run vs through authentication

### DIFF
--- a/vs/src/actor_mgr.rs
+++ b/vs/src/actor_mgr.rs
@@ -79,20 +79,6 @@ impl ActorMgr {
         Ok(())
     }
 
-    /// Add an adatpter called "magic" since it is not connected to any node.
-    /// We (the visa service) uses this to connect itself at startup.
-    ///
-    /// TODO: At some point we need to update our state to reflect that the visa service is docked to a node.
-    pub async fn add_magic_adapter(&self, actor: &Actor) -> Result<(), ServiceError> {
-        if actor.is_node() {
-            return Err(ServiceError::Internal(
-                "attempt to add node actor as adapter".into(),
-            ));
-        }
-        self.actor_db.add_actor(actor).await?;
-        Ok(())
-    }
-
     /// Add an adapter that is connected to a node.
     #[allow(dead_code)]
     pub async fn add_adapter_via_node(
@@ -109,6 +95,19 @@ impl ActorMgr {
         self.node_db
             .add_connected_adater(connected_to_node, &actor.get_zpr_addr().unwrap())
             .await?;
+        Ok(())
+    }
+
+    /// This is probably temporary: we use this to add the phantom visa service adapter.
+    /// We don't know what node it is attached to yet.
+    #[allow(dead_code)]
+    pub async fn add_adapter_no_node(&self, actor: &Actor) -> Result<(), ServiceError> {
+        if actor.is_node() {
+            return Err(ServiceError::Internal(
+                "attempt to add node actor as adapter".into(),
+            ));
+        }
+        self.actor_db.add_actor(actor).await?;
         Ok(())
     }
 
@@ -552,7 +551,7 @@ mod test {
             &["svc:auth", "svc:regular", "svc:unknown"],
             "adapter-auth",
         );
-        mgr.add_magic_adapter(&actor).await.unwrap();
+        mgr.add_adapter_no_node(&actor).await.unwrap();
 
         let auth_service = Service {
             id: "svc:auth".to_string(),
@@ -602,7 +601,7 @@ mod test {
             &["svc:auth"],
             "adapter-regular",
         );
-        mgr.add_magic_adapter(&actor).await.unwrap();
+        mgr.add_adapter_no_node(&actor).await.unwrap();
 
         let regular_service = Service {
             id: "svc:auth".to_string(),

--- a/vs/src/connection_control.rs
+++ b/vs/src/connection_control.rs
@@ -180,6 +180,32 @@ impl ConnectionControl {
         Ok(adapter_actor)
     }
 
+    pub async fn authenticate_visa_service(
+        &self,
+        asm: Arc<Assembly>,
+        claims: Vec<Claim>,
+    ) -> Result<Actor, ServiceError> {
+        let mut authd_claims = Vec::new();
+
+        authd_claims.push(
+            Attribute::builder(key::AUTHORITY)
+                .value(format!("fake_jwt_token:adapter:{}", config::VS_CN)),
+        );
+
+        for claim in claims {
+            authd_claims.push(Attribute::builder(claim.key).value(claim.value));
+        }
+
+        let policy = asm.policy_mgr.get_current();
+
+        // Ok checks out -- now run through policy.
+        let vs_actor = self
+            .authorize_connection(asm, &policy, &config::VS_CN, Vec::new(), authd_claims, 0)
+            .await?;
+
+        Ok(vs_actor)
+    }
+
     /// Preform authentication of the adapter credentials, then run through policy.
     async fn authenticate_adapter_rsa(
         &self,

--- a/vs/src/main.rs
+++ b/vs/src/main.rs
@@ -4,10 +4,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
-use libeval::actor::Actor;
-use libeval::attribute::{Attribute, ROLE_ADAPTER, key};
+use libeval::attribute::{ROLE_ADAPTER, key};
 use libeval::pio;
 
 mod actor_mgr;
@@ -41,12 +40,14 @@ use crate::connection_control::ConnectionControl;
 use crate::db::DbConnection;
 use crate::error::ServiceError;
 use crate::event_mgr::EventMgr;
+use crate::event_mgr::VsEvent;
 use crate::logging::enable_logging;
 use crate::logging::targets::MAIN;
 use crate::net_mgr::NetMgr;
 use crate::policy_mgr::PolicyMgr;
 use crate::visa_mgr::VisaMgr;
 use crate::vss_mgr::VssMgr;
+use zpr::vsapi_types::Claim;
 
 use redis::AsyncCommands;
 
@@ -118,7 +119,7 @@ async fn main() -> std::process::ExitCode {
     let (vreq_tx, vreq_rx) =
         mpsc::channel::<visareq_worker::VisaRequestJob>(config::VISA_REQUEST_QUEUE_DEPTH);
 
-    let actor_mgr = match create_actor_mgr(db_handle.clone(), &cfg.get_vs_addr()).await {
+    let actor_mgr = match create_actor_mgr(db_handle.clone()).await {
         Ok(adb) => adb,
         Err(e) => {
             error!(target: MAIN, "failed to instantiate actor database: {}", e);
@@ -186,6 +187,12 @@ async fn main() -> std::process::ExitCode {
         config::MAX_VISA_REQUEST_WORKERS,
     ));
 
+    // perform initial self-authorization
+    if let Err(e) = self_authorize(asm.clone(), &cfg.get_vs_addr()).await {
+        error!(target: MAIN, "self-authorization failed: {}", e);
+        return std::process::ExitCode::FAILURE;
+    }
+
     // TODO: Setup/launch the workers for the visa service. Those that will do the actual work
     // of generating visas, and all the housekeeping.
 
@@ -223,27 +230,39 @@ fn load_config(explicit: Option<&std::path::Path>) -> Result<VSConfig, ServiceEr
     }
 }
 
-async fn create_actor_mgr(
-    dbh: Arc<dyn DbConnection>,
-    vs_addr: &IpAddr,
-) -> Result<ActorMgr, ServiceError> {
+async fn create_actor_mgr(dbh: Arc<dyn DbConnection>) -> Result<ActorMgr, ServiceError> {
     let adb = db::ActorRepo::new(dbh.clone());
     let ndb = db::NodeRepo::new(dbh);
     let mgr = ActorMgr::new(adb, ndb);
-    // We are the visa service. As we say so it shall be.
-    // The odd thing here is that we do not know what node we are connected to yet.
-    let vs_actor = {
-        let mut vsa = Actor::new();
-        vsa.add_attribute(Attribute::builder(key::ZPR_ADDR).value(vs_addr.to_string()))?;
-        vsa.add_attribute(Attribute::builder(key::CN).value(config::VS_CN))?;
-        vsa.add_attribute(Attribute::builder(key::ROLE).value(ROLE_ADAPTER))?;
-        vsa.add_attribute(
-            Attribute::builder(key::SERVICES)
-                .values(vec!["/zpr/visaservice", "/zpr/visaservice/admin"]),
-        )?;
-        vsa.add_identity_key(0, key::CN)?;
-        vsa
-    };
-    mgr.add_magic_adapter(&vs_actor).await?;
     Ok(mgr)
+}
+
+// TODO: This belongs somewhere else. Must be run every time we load a new policy.
+//
+// Also this "authorizes" the visa service actor by fiat, but we do not yet know what
+// node the vs adapter is docked to.  We also have no way at the moment to tell the
+// vs what node it is docked to.
+//
+// One idea is to query our local ph (via ph-cli) and get the substrate address of
+// the docking node.  We can use that to find the node record.
+//
+async fn self_authorize(asm: Arc<Assembly>, vs_addr: &IpAddr) -> Result<(), ServiceError> {
+    let mut claims = Vec::new();
+    claims.push(Claim::new(key::ZPR_ADDR.into(), vs_addr.to_string()));
+    claims.push(Claim::new(key::CN.into(), config::VS_CN.into()));
+    claims.push(Claim::new(key::ROLE.into(), ROLE_ADAPTER.into()));
+
+    let actor = asm
+        .cc
+        .authenticate_visa_service(asm.clone(), claims)
+        .await?;
+
+    asm.actor_mgr.add_adapter_no_node(&actor).await?;
+
+    let evt = VsEvent::ActorJoins(vs_addr.clone());
+    if let Err(e) = asm.event_mgr.record_event(evt).await {
+        warn!(target: MAIN, "failed to record actor joins event for adapter {:?}: {}", actor.get_cn(), e);
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
Run visa service through the policy, picking up attributes and services that are attached to its actor.
This should fix an issue in integration tests where other actors cannot ping the visa service.

