### PR TITLE
Mk/163 deets

### DIFF
--- a/admin-api-types/src/admin_api_types.rs
+++ b/admin-api-types/src/admin_api_types.rs
@@ -53,6 +53,13 @@ impl fmt::Display for PolicyBundle {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum VisaMatchDirection {
+    Forward,
+    Reverse,
+}
+
 #[derive(Serialize, Debug, Deserialize, Eq)]
 pub struct VisaDescriptor {
     pub id: u64,
@@ -61,12 +68,15 @@ pub struct VisaDescriptor {
     #[serde(rename = "created")]
     pub created_secs: u64, // seconds since the epoch
     pub policy_id: String,
+    pub zpl: String,
+    pub direction: VisaMatchDirection,
     pub requesting_node: String, // ZPR address
     pub source_addr: String,     // ZPR address
     pub dest_addr: String,       // ZPR address
     pub source_port: u16,
     pub dest_port: u16,
     pub proto: String,
+    pub signals: Vec<String>,
 }
 
 impl PartialEq for VisaDescriptor {
@@ -90,38 +100,56 @@ impl PartialOrd for VisaDescriptor {
 impl fmt::Display for VisaDescriptor {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let now = Utc::now();
-
         let dt_exp: DateTime<Utc> = DateTime::from_timestamp(self.expires_secs as i64, 0).unwrap();
-        let remain_exp = dt_exp.signed_duration_since(now);
         let dt_created: DateTime<Utc> =
             DateTime::from_timestamp(self.created_secs as i64, 0).unwrap();
+        let remain = dt_exp.signed_duration_since(now);
 
+        write!(f, "{} {}", "id".dimmed(), self.id)?;
         write!(
             f,
-            "{} {} {} {} {} {}  {}:{} {} {}:{}  {} {}  {} {}   {} {} {}{}:{:02}:{:02} {}",
-            format!("{}", "id".dimmed()),
-            self.id,
-            format!("{}", "requesting node".dimmed()),
-            self.requesting_node.yellow(),
-            format!("{}", "policy id".dimmed()),
-            self.policy_id,
-            format!("{}", self.source_addr).yellow(),
-            format!("{}", self.source_port).yellow(),
+            "  {} {}",
+            "requesting node".dimmed(),
+            self.requesting_node.yellow()
+        )?;
+        write!(f, "  {} {}", "policy id".dimmed(), self.policy_id)?;
+        write!(
+            f,
+            "  {} [{:?}] {}",
+            "zpl".dimmed(),
+            self.direction,
+            self.zpl.yellow()
+        )?;
+        write!(
+            f,
+            "  {}:{} {} {}:{}",
+            self.source_addr.yellow(),
+            self.source_port,
             "->".bold().green(),
-            format!("{}", self.dest_addr).yellow(),
-            format!("{}", self.dest_port).yellow(),
-            format!("{}", "proto".dimmed()),
-            self.proto,
-            format!("{}", "created".dimmed()),
-            dt_created.to_rfc3339_opts(SecondsFormat::Secs, true).cyan(),
-            format!("{}", "exp".dimmed()),
+            self.dest_addr.yellow(),
+            self.dest_port,
+        )?;
+        write!(f, "  {} {}", "proto".dimmed(), self.proto)?;
+        write!(
+            f,
+            "  {} {}",
+            "created".dimmed(),
+            dt_created.to_rfc3339_opts(SecondsFormat::Secs, true).cyan()
+        )?;
+        write!(
+            f,
+            "  {} {} ({}:{:02}:{:02} remain)",
+            "exp".dimmed(),
             dt_exp.to_rfc3339_opts(SecondsFormat::Secs, true).cyan(),
-            "(".dimmed(),
-            remain_exp.num_hours(),
-            remain_exp.num_minutes() % 60,
-            remain_exp.num_seconds() % 60,
-            format!("{}", "remain)".dimmed()),
-        )
+            remain.num_hours(),
+            remain.num_minutes() % 60,
+            remain.num_seconds() % 60,
+        )?;
+        if !self.signals.is_empty() {
+            write!(f, "  {} {:?}", "signals".dimmed(), self.signals)?;
+        }
+
+        Ok(())
     }
 }
 

--- a/admin-api-types/src/admin_api_types.rs
+++ b/admin-api-types/src/admin_api_types.rs
@@ -60,8 +60,18 @@ pub enum VisaMatchDirection {
     Reverse,
 }
 
+impl fmt::Display for VisaMatchDirection {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            VisaMatchDirection::Forward => write!(f, "forward"),
+            VisaMatchDirection::Reverse => write!(f, "reverse"),
+        }
+    }
+}
+
 #[derive(Serialize, Debug, Deserialize, Eq)]
 pub struct VisaDescriptor {
+    /// Policy reported version number
     pub id: u64,
     #[serde(rename = "expires")]
     pub expires_secs: u64, // seconds since the epoch
@@ -115,7 +125,7 @@ impl fmt::Display for VisaDescriptor {
         write!(f, "  {} {}", "policy id".dimmed(), self.policy_id)?;
         write!(
             f,
-            "  {} [{:?}] {}",
+            "  {} [{}] {}",
             "zpl".dimmed(),
             self.direction,
             self.zpl.yellow()
@@ -146,7 +156,7 @@ impl fmt::Display for VisaDescriptor {
             remain.num_seconds() % 60,
         )?;
         if !self.signals.is_empty() {
-            write!(f, "  {} {:?}", "signals".dimmed(), self.signals)?;
+            write!(f, "  {} [{}]", "signals".dimmed(), self.signals.join(", "))?;
         }
 
         Ok(())

--- a/libeval/src/eval.rs
+++ b/libeval/src/eval.rs
@@ -8,7 +8,7 @@ use zpr::vsapi_types::PacketDesc;
 use zpr::vsapi_types::vsapi_ip_number as ip_proto;
 
 use enumset::EnumSet;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fmt;
 use std::hash::{DefaultHasher, Hash, Hasher};
@@ -69,7 +69,7 @@ pub enum EvalError {
 
 /// A "hit" is a single matching permission or deny line in policy
 /// that matches against the actors and packet description.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[allow(dead_code)]
 pub struct Hit {
     /// Index into the policies for the matching policy.
@@ -103,7 +103,7 @@ impl Hit {
     }
 }
 
-#[derive(Serialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Direction {
     Forward,
     Reverse,
@@ -192,7 +192,7 @@ pub enum CommOpt {
     // others TBD?
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[allow(dead_code)]
 pub struct Signal {
     pub message: String,

--- a/libeval/src/policy.rs
+++ b/libeval/src/policy.rs
@@ -50,6 +50,7 @@ pub struct Policy {
     bootstrap_keys: HashMap<String, PKey<Public>>,
     join_policies: Vec<JPolicy>,
     services: HashMap<String, Service>,
+    cpol_sources: Vec<String>,
     serialized: Bytes,
 }
 
@@ -72,15 +73,17 @@ impl Policy {
 
         let policy = policy_reader.get_root::<policy_capnp::policy::Reader>()?;
 
-        let bootstrap_keys = Self::load_bootstrap_keys(&Policy::default(), &policy)?;
-        let join_policies = Self::load_join_policies(&Policy::default(), &policy)?;
-        let services = Self::load_services(&Policy::default(), &policy)?;
+        let bootstrap_keys = load_bootstrap_keys(&policy)?;
+        let join_policies = load_join_policies(&policy)?;
+        let services = load_services(&policy)?;
+        let cpol_sources = load_cpol_sources(&policy)?;
 
         Ok(Policy {
             policy_rdr: Some(Arc::new(policy_reader)),
             bootstrap_keys,
             join_policies,
             services,
+            cpol_sources,
             serialized,
             ..Default::default()
         })
@@ -178,76 +181,87 @@ impl Policy {
             .collect()
     }
 
-    fn load_bootstrap_keys(
-        &self,
-        policy: &policy_capnp::policy::Reader,
-    ) -> Result<HashMap<String, PKey<Public>>, PolicyError> {
-        let mut bootstrap_keys: HashMap<String, PKey<Public>> = HashMap::new();
-        if policy.has_keys() {
-            for key in policy.get_keys()?.iter() {
-                // Only take the key if it is for bootstrap.
-                let allows = key.get_key_allows()?;
-                for allowance in allows.iter() {
-                    if let Ok(aw) = allowance {
-                        if aw == policy_capnp::KeyAllowance::Bootstrap {
-                            let cn = key.get_id()?.to_string()?;
-                            if key.get_key_type()? != policy_capnp::KeyMaterialT::RsaPub {
-                                return Err(PolicyError::InvalidFormat(format!(
-                                    "Unsupported key type in bootstrap key for cn '{cn}': {:?}",
-                                    key.get_key_type()?
-                                )));
-                            }
-                            let key_der = key.get_key_data()?;
-                            let pkey = PKey::public_key_from_der(&key_der)?;
-                            bootstrap_keys.insert(cn.to_string(), pkey);
-                        }
-                    }
-                }
-            }
-        }
-        Ok(bootstrap_keys)
+    /// Get the ZPL source for the communication policy by policy index.
+    pub fn get_cpol_source(&self, idx: usize) -> Option<&str> {
+        self.cpol_sources.get(idx).map(|s| s.as_str())
     }
+}
 
-    // Load (cache) the set of join policies found in the binary policy object.
-    fn load_join_policies(
-        &self,
-        policy: &policy_capnp::policy::Reader,
-    ) -> Result<Vec<JPolicy>, PolicyError> {
-        let mut join_policies: Vec<JPolicy> = Vec::new();
-        if policy.has_join_policies() {
-            for jp_rdr in policy.get_join_policies()?.iter() {
-                let jp = JPolicy::try_from(jp_rdr)?;
-                join_policies.push(jp);
-            }
-        }
-        Ok(join_policies)
-    }
-
-    // Load (cache) the set of services found in the binary policy object. The services are
-    // stored in binary policy as part of the join policies but our join-policy loader doesn't
-    // fully load them since it doesn't need to.
-    fn load_services(
-        &self,
-        policy: &policy_capnp::policy::Reader,
-    ) -> Result<HashMap<String, Service>, PolicyError> {
-        let mut services = HashMap::new();
-        if policy.has_join_policies() {
-            for jp_rdr in policy.get_join_policies()?.iter() {
-                if jp_rdr.has_provides() {
-                    for svc_rdr in jp_rdr.get_provides()?.iter() {
-                        let svc = Service::try_from(svc_rdr)?;
-                        if let Some(previous) = services.insert(svc.id.clone(), svc) {
+fn load_bootstrap_keys(
+    policy: &policy_capnp::policy::Reader,
+) -> Result<HashMap<String, PKey<Public>>, PolicyError> {
+    let mut bootstrap_keys: HashMap<String, PKey<Public>> = HashMap::new();
+    if policy.has_keys() {
+        for key in policy.get_keys()?.iter() {
+            // Only take the key if it is for bootstrap.
+            let allows = key.get_key_allows()?;
+            for allowance in allows.iter() {
+                if let Ok(aw) = allowance {
+                    if aw == policy_capnp::KeyAllowance::Bootstrap {
+                        let cn = key.get_id()?.to_string()?;
+                        if key.get_key_type()? != policy_capnp::KeyMaterialT::RsaPub {
                             return Err(PolicyError::InvalidFormat(format!(
-                                "duplicate service id in policy: {}",
-                                previous.id
+                                "Unsupported key type in bootstrap key for cn '{cn}': {:?}",
+                                key.get_key_type()?
                             )));
                         }
+                        let key_der = key.get_key_data()?;
+                        let pkey = PKey::public_key_from_der(&key_der)?;
+                        bootstrap_keys.insert(cn.to_string(), pkey);
                     }
                 }
             }
         }
-        Ok(services)
     }
+    Ok(bootstrap_keys)
+}
+
+// Load (cache) the set of join policies found in the binary policy object.
+fn load_join_policies(policy: &policy_capnp::policy::Reader) -> Result<Vec<JPolicy>, PolicyError> {
+    let mut join_policies: Vec<JPolicy> = Vec::new();
+    if policy.has_join_policies() {
+        for jp_rdr in policy.get_join_policies()?.iter() {
+            let jp = JPolicy::try_from(jp_rdr)?;
+            join_policies.push(jp);
+        }
+    }
+    Ok(join_policies)
+}
+
+fn load_cpol_sources(policy: &policy_capnp::policy::Reader) -> Result<Vec<String>, PolicyError> {
+    let mut cpol_sources = Vec::new();
+    if policy.has_com_policies() {
+        for cp_rdr in policy.get_com_policies()?.iter() {
+            let zpl = cp_rdr.get_zpl()?.to_string()?;
+            cpol_sources.push(zpl);
+        }
+    }
+    Ok(cpol_sources)
+}
+
+// Load (cache) the set of services found in the binary policy object. The services are
+// stored in binary policy as part of the join policies but our join-policy loader doesn't
+// fully load them since it doesn't need to.
+fn load_services(
+    policy: &policy_capnp::policy::Reader,
+) -> Result<HashMap<String, Service>, PolicyError> {
+    let mut services = HashMap::new();
+    if policy.has_join_policies() {
+        for jp_rdr in policy.get_join_policies()?.iter() {
+            if jp_rdr.has_provides() {
+                for svc_rdr in jp_rdr.get_provides()?.iter() {
+                    let svc = Service::try_from(svc_rdr)?;
+                    if let Some(previous) = services.insert(svc.id.clone(), svc) {
+                        return Err(PolicyError::InvalidFormat(format!(
+                            "duplicate service id in policy: {}",
+                            previous.id
+                        )));
+                    }
+                }
+            }
+        }
+    }
+    Ok(services)
 }
 
 #[cfg(test)]

--- a/libeval/src/policy.rs
+++ b/libeval/src/policy.rs
@@ -271,12 +271,30 @@ mod test {
     use std::env;
     use std::path::PathBuf;
 
+    use zpr::policy::v1 as policy_capnp;
+
     const MIN_COMPILER_VERSION: Version = Version(0, 9, 2);
 
     fn read_policy_from_test_file(filename: &str) -> Policy {
         let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
         let fpath = PathBuf::from(manifest_dir).join("test-data").join(filename);
         load_policy(&fpath, MIN_COMPILER_VERSION).unwrap()
+    }
+
+    /// Build a Policy from a list of ZPL source strings by constructing a capnp
+    /// policy message in memory, without needing a compiled policy file.
+    fn policy_with_cpol_sources(zpls: &[&str]) -> Policy {
+        let mut msg = capnp::message::Builder::new_default();
+        {
+            let mut policy = msg.init_root::<policy_capnp::policy::Builder>();
+            let mut coms = policy.reborrow().init_com_policies(zpls.len() as u32);
+            for (i, zpl) in zpls.iter().enumerate() {
+                coms.reborrow().get(i as u32).set_zpl(zpl);
+            }
+        }
+        let mut bytes: Vec<u8> = Vec::new();
+        capnp::serialize::write_message(&mut bytes, &msg).unwrap();
+        Policy::new_from_policy_bytes(Bytes::from(bytes)).unwrap()
     }
 
     #[test]
@@ -302,5 +320,35 @@ mod test {
                 "expected to find bootstrap key for cn '{cn}'"
             );
         }
+    }
+
+    #[test]
+    /// get_cpol_source returns the expected ZPL string for known indices when the
+    /// policy contains communication policies.
+    fn test_get_cpol_source_returns_zpl_for_known_index() {
+        let zpls = ["allow all traffic.", "deny all traffic."];
+        let policy = policy_with_cpol_sources(&zpls);
+
+        assert_eq!(policy.get_cpol_source(0), Some("allow all traffic."));
+        assert_eq!(policy.get_cpol_source(1), Some("deny all traffic."));
+    }
+
+    #[test]
+    /// get_cpol_source returns None when the requested index is out of bounds.
+    fn test_get_cpol_source_out_of_bounds_returns_none() {
+        let zpls = ["allow all traffic."];
+        let policy = policy_with_cpol_sources(&zpls);
+
+        assert!(policy.get_cpol_source(1).is_none());
+        assert!(policy.get_cpol_source(99).is_none());
+    }
+
+    #[test]
+    /// get_cpol_source returns None for any index on an empty policy that has no
+    /// communication policies.
+    fn test_get_cpol_source_empty_policy_returns_none() {
+        let policy = Policy::new_empty();
+
+        assert!(policy.get_cpol_source(0).is_none());
     }
 }

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -300,39 +300,23 @@ async fn get_visa(
     debug!(target: ADMIN, "GET /admin/visas/{}", id);
     let rstate = state.read().await;
 
-    match rstate.asm.visa_mgr.get_visa_by_id(id).await {
+    match rstate.asm.visa_mgr.get_visa_with_metadata_by_id(id).await {
         Err(e) => {
             error!(target: ADMIN, "error getting visa {}: {}", id, e);
             return Err(StatusCode::INTERNAL_SERVER_ERROR);
         }
-        Ok(opt_visa) => match opt_visa {
+        Ok(opt_visa_and_md) => match opt_visa_and_md {
             None => Err(StatusCode::NOT_FOUND),
-            Some(visa) => {
+            Some(visa_and_md) => {
+                let visa = &visa_and_md.visa;
+                let metadata = &visa_and_md.metadata;
                 let (source_port, dest_port) = ports_from_pep(&visa.dock_pep);
 
-                let (ctime, requesting_node) = match rstate
-                    .asm
-                    .visa_mgr
-                    .get_visa_metadata_by_id(visa.issuer_id)
-                    .await
-                {
-                    Ok(metadata) => match metadata {
-                        Some(md) => (md.ctime, md.requesting_node.to_string()),
-                        None => (0, "".to_string()),
-                    },
-                    Err(e) => {
-                        error!(
-                            target: ADMIN,
-                            "error getting visa metadata for visa {}: {}", id, e
-                        );
-                        (0, "".to_string())
-                    }
-                };
                 let vd = VisaDescriptor {
                     id: visa.issuer_id,
                     expires_secs: system_time_to_unix_seconds(visa.expires),
-                    created_secs: ctime,
-                    requesting_node,
+                    created_secs: metadata.ctime,
+                    requesting_node: metadata.requesting_node.to_string(),
                     policy_id: "0".into(), // TODO: not tracked yet
                     source_addr: visa.source_addr.to_string(),
                     dest_addr: visa.dest_addr.to_string(),
@@ -618,7 +602,7 @@ mod tests {
         // Add a visa.
         let v = asm
             .visa_mgr
-            .create_visa(&node_addr, &pdesc, &hit)
+            .create_visa(&node_addr, &pdesc, &hit, "", 0)
             .await
             .unwrap();
 
@@ -665,17 +649,17 @@ mod tests {
 
         let v0 = asm
             .visa_mgr
-            .create_visa(&node_addr, &pdesc0, &hit)
+            .create_visa(&node_addr, &pdesc0, &hit, "", 0)
             .await
             .unwrap();
         let v1 = asm
             .visa_mgr
-            .create_visa(&node_addr, &pdesc1, &hit)
+            .create_visa(&node_addr, &pdesc1, &hit, "", 0)
             .await
             .unwrap();
         let v2 = asm
             .visa_mgr
-            .create_visa(&node_addr, &pdesc2, &hit)
+            .create_visa(&node_addr, &pdesc2, &hit, "", 0)
             .await
             .unwrap();
 

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -317,12 +317,22 @@ async fn get_visa(
                     expires_secs: system_time_to_unix_seconds(visa.expires),
                     created_secs: metadata.ctime,
                     requesting_node: metadata.requesting_node.to_string(),
-                    policy_id: "0".into(), // TODO: not tracked yet
+                    policy_id: metadata.policy_version.to_string(),
+                    zpl: metadata.zpl.to_string(),
+                    direction: match metadata.direction {
+                        libeval::eval::Direction::Forward => {
+                            admin_api_types::VisaMatchDirection::Forward
+                        }
+                        libeval::eval::Direction::Reverse => {
+                            admin_api_types::VisaMatchDirection::Reverse
+                        }
+                    },
                     source_addr: visa.source_addr.to_string(),
                     dest_addr: visa.dest_addr.to_string(),
                     source_port,
                     dest_port,
                     proto: "TCP".into(),
+                    signals: metadata.signal_msgs.clone(),
                 };
                 return Ok(Json(vd));
             }

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -25,7 +25,7 @@ use hyper::body::Incoming;
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use tower_service::Service;
 
-use zpr::vsapi_types::DockPep;
+use zpr::vsapi_types::{DockPep, Visa};
 
 use rustls::ServerConfig;
 use rustls::pki_types::PrivateKeyDer;
@@ -62,6 +62,13 @@ struct RoleFilter {
 enum ActorRole {
     Node,
     Adapter,
+}
+
+struct ProtocolDetails {
+    /// Human readable protocol name, e.g. "TCP", "UDP", "ICMP"
+    protocol: String,
+    source_port: u16,
+    dest_port: u16,
 }
 
 /// Blocking start of the admin server.
@@ -281,14 +288,6 @@ fn system_time_to_unix_seconds(st: std::time::SystemTime) -> u64 {
     }
 }
 
-fn ports_from_pep(pep: &DockPep) -> (u16, u16) {
-    match pep {
-        DockPep::TCP(tu_pep) => (tu_pep.source_port, tu_pep.dest_port),
-        DockPep::UDP(tu_pep) => (tu_pep.source_port, tu_pep.dest_port),
-        DockPep::ICMP(icmp_pep) => (icmp_pep.icmp_type as u16, icmp_pep.icmp_code as u16),
-    }
-}
-
 async fn get_visa(
     Extension(perm): Extension<Permission>,
     State(state): State<SharedState>,
@@ -310,7 +309,7 @@ async fn get_visa(
             Some(visa_and_md) => {
                 let visa = &visa_and_md.visa;
                 let metadata = &visa_and_md.metadata;
-                let (source_port, dest_port) = ports_from_pep(&visa.dock_pep);
+                let proto_deets = protocol_details_for_visa(visa);
 
                 let vd = VisaDescriptor {
                     id: visa.issuer_id,
@@ -329,14 +328,32 @@ async fn get_visa(
                     },
                     source_addr: visa.source_addr.to_string(),
                     dest_addr: visa.dest_addr.to_string(),
-                    source_port,
-                    dest_port,
-                    proto: "TCP".into(),
+                    source_port: proto_deets.source_port,
+                    dest_port: proto_deets.dest_port,
+                    proto: proto_deets.protocol,
                     signals: metadata.signal_msgs.clone(),
                 };
                 return Ok(Json(vd));
             }
         },
+    }
+}
+
+fn protocol_details_for_visa(visa: &Visa) -> ProtocolDetails {
+    let (proto_name, source_port, dest_port) = match &visa.dock_pep {
+        DockPep::ICMP(icmp_pep) => (
+            "ICMP".to_string(),
+            icmp_pep.icmp_type as u16,
+            icmp_pep.icmp_code as u16,
+        ),
+        DockPep::UDP(tu_pep) => ("UDP".to_string(), tu_pep.source_port, tu_pep.dest_port),
+        DockPep::TCP(tu_pep) => ("TCP".to_string(), tu_pep.source_port, tu_pep.dest_port),
+    };
+
+    ProtocolDetails {
+        protocol: proto_name,
+        source_port,
+        dest_port,
     }
 }
 

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -562,9 +562,10 @@ mod tests {
     use super::*;
 
     use crate::apikey::ApiKey;
+    use admin_api_types::VisaMatchDirection;
     use axum::body::Body;
     use http_body_util::BodyExt;
-    use libeval::eval::{Direction, Hit};
+    use libeval::eval::{Direction, Hit, Signal};
     use std::net::IpAddr;
     use tower::ServiceExt;
     use zpr::vsapi_types::PacketDesc;
@@ -877,6 +878,152 @@ mod tests {
         let actors_adapters: Vec<CnEntry> = serde_json::from_slice(&body_adapters).unwrap();
         assert_eq!(actors_adapters.len(), 1);
         assert_eq!(actors_adapters[0].cn, "adapter-1");
+    }
+
+    #[tokio::test]
+    async fn test_get_visa_not_found() {
+        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let api_key = setup_test_api_key(&asm);
+        let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
+        let app = admin_app(shared_state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/admin/visas/9999")
+                    .header("X-API-Key", &api_key)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_get_visa_fields_forward_no_signal() {
+        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let api_key = setup_test_api_key(&asm);
+
+        let node_addr: IpAddr = "fd5a:5052:90de::1".parse().unwrap();
+        let pdesc =
+            PacketDesc::new_tcp("fd5a:5052:3000::1", "fd5a:5052:3000::2", 12345, 80).unwrap();
+        let zpl_str = "permit tcp from groupA to groupB port 80";
+        let policy_version: u64 = 42;
+        let hit = Hit::new_no_signal(0, Direction::Forward);
+
+        let v = asm
+            .visa_mgr
+            .create_visa(&node_addr, &pdesc, &hit, zpl_str, policy_version)
+            .await
+            .unwrap();
+
+        let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
+        let app = admin_app(shared_state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(&format!("/admin/visas/{}", v.issuer_id))
+                    .header("X-API-Key", &api_key)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let vd: VisaDescriptor = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(vd.id, v.issuer_id);
+        assert_eq!(vd.policy_id, "42");
+        assert_eq!(vd.zpl, zpl_str);
+        assert_eq!(vd.direction, VisaMatchDirection::Forward);
+        assert!(vd.signals.is_empty());
+
+        // Verify JSON encodes direction as lowercase string.
+        let raw: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(raw["direction"], "forward");
+    }
+
+    #[tokio::test]
+    async fn test_get_visa_direction_reverse() {
+        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let api_key = setup_test_api_key(&asm);
+
+        let node_addr: IpAddr = "fd5a:5052:90de::1".parse().unwrap();
+        let pdesc =
+            PacketDesc::new_tcp("fd5a:5052:3000::1", "fd5a:5052:3000::2", 12345, 80).unwrap();
+        let hit = Hit::new_no_signal(0, Direction::Reverse);
+
+        let v = asm
+            .visa_mgr
+            .create_visa(&node_addr, &pdesc, &hit, "", 0)
+            .await
+            .unwrap();
+
+        let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
+        let app = admin_app(shared_state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(&format!("/admin/visas/{}", v.issuer_id))
+                    .header("X-API-Key", &api_key)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let vd: VisaDescriptor = serde_json::from_slice(&body).unwrap();
+        assert_eq!(vd.direction, VisaMatchDirection::Reverse);
+
+        let raw: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(raw["direction"], "reverse");
+    }
+
+    #[tokio::test]
+    async fn test_get_visa_with_signal() {
+        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let api_key = setup_test_api_key(&asm);
+
+        let node_addr: IpAddr = "fd5a:5052:90de::1".parse().unwrap();
+        let pdesc =
+            PacketDesc::new_tcp("fd5a:5052:3000::1", "fd5a:5052:3000::2", 12345, 80).unwrap();
+        let signal = Signal {
+            message: "alert: suspicious traffic".to_string(),
+            service: "svc1".to_string(),
+        };
+        let hit = Hit::new_with_signal(0, Direction::Forward, signal);
+
+        let v = asm
+            .visa_mgr
+            .create_visa(&node_addr, &pdesc, &hit, "", 0)
+            .await
+            .unwrap();
+
+        let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
+        let app = admin_app(shared_state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(&format!("/admin/visas/{}", v.issuer_id))
+                    .header("X-API-Key", &api_key)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let vd: VisaDescriptor = serde_json::from_slice(&body).unwrap();
+        assert_eq!(vd.signals, vec!["alert: suspicious traffic".to_string()]);
     }
 
     #[tokio::test]

--- a/vs/src/db/visa.rs
+++ b/vs/src/db/visa.rs
@@ -405,7 +405,6 @@ mod test {
     use crate::db::DbConnection;
     use crate::db::db_fake::FakeDb;
     use crate::test_helpers::make_visa;
-    use libeval::eval::Direction;
 
     #[tokio::test]
     async fn test_store_and_get_visas_by_state() {

--- a/vs/src/db/visa.rs
+++ b/vs/src/db/visa.rs
@@ -15,6 +15,7 @@ use std::time::{Duration, SystemTime};
 use tracing::{debug, error, warn};
 
 use ::zpr::vsapi::v1 as vsapi;
+use libeval::eval::Direction;
 use zpr::vsapi_types::Visa;
 use zpr::write_to::WriteTo;
 
@@ -35,10 +36,15 @@ pub enum NodeVisaState {
     Revoked,
 }
 
+/// Metadata around an issued visa.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VisaMetadata {
     pub requesting_node: IpAddr,
     pub ctime: u64, // unix timestamp (seconds since epoch)
+    pub policy_version: u64,
+    pub zpl: String,
+    pub signal_msgs: Vec<String>, // note we do not keep the signal destination
+    pub direction: Direction,
 }
 
 pub struct VisaRepo {
@@ -46,13 +52,21 @@ pub struct VisaRepo {
 }
 
 impl VisaMetadata {
-    pub fn new(requesting_node: IpAddr) -> Self {
+    /// `requesting_node` is the node that requested the visa.
+    /// `pver` is the policy version that was in effect at the time of the visa request.
+    /// `zpl` is the ZPL is a copy of the ZPL line that matched in policy.
+    /// `direction` is the direction of the match as reported by the hit.
+    pub fn new(requesting_node: IpAddr, pver: u64, zpl: String, direction: Direction) -> Self {
         VisaMetadata {
             requesting_node,
             ctime: SystemTime::now()
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .unwrap_or(Duration::ZERO)
                 .as_secs() as u64,
+            policy_version: pver,
+            zpl,
+            signal_msgs: Vec::new(),
+            direction,
         }
     }
 }
@@ -134,11 +148,10 @@ impl VisaRepo {
     ///
     pub async fn store_visa(
         &self,
-        requesting_node: &IpAddr,
         visa: &Visa,
+        metadata: VisaMetadata,
         nstate: NodeVisaState,
     ) -> Result<(), StoreError> {
-        let metadata = VisaMetadata::new(*requesting_node);
         match self.try_store_visa(&metadata, visa, nstate).await {
             Ok(_) => Ok(()),
             Err(e) => {
@@ -392,6 +405,7 @@ mod test {
     use crate::db::DbConnection;
     use crate::db::db_fake::FakeDb;
     use crate::test_helpers::make_visa;
+    use libeval::eval::Direction;
 
     #[tokio::test]
     async fn test_store_and_get_visas_by_state() {
@@ -400,7 +414,8 @@ mod test {
         let node_addr: IpAddr = "fd5a:5052::1".parse().unwrap();
         let visa = make_visa(42, Duration::from_secs(60));
 
-        repo.store_visa(&node_addr, &visa, NodeVisaState::PendingInstall)
+        let metadata = VisaMetadata::new(node_addr, 0, String::new(), Direction::Forward);
+        repo.store_visa(&visa, metadata, NodeVisaState::PendingInstall)
             .await
             .unwrap();
 
@@ -459,7 +474,8 @@ mod test {
         let node_addr: IpAddr = "fd5a:5052::3".parse().unwrap();
         let visa = make_visa(7, Duration::from_secs(60));
 
-        repo.store_visa(&node_addr, &visa, NodeVisaState::Installed)
+        let metadata = VisaMetadata::new(node_addr, 0, String::new(), Direction::Forward);
+        repo.store_visa(&visa, metadata, NodeVisaState::Installed)
             .await
             .unwrap();
 
@@ -482,8 +498,9 @@ mod test {
         let mut visa = make_visa(8, Duration::from_secs(1));
         visa.expires = SystemTime::now() - Duration::from_secs(1);
 
+        let metadata = VisaMetadata::new(node_addr, 0, String::new(), Direction::Forward);
         let err = repo
-            .store_visa(&node_addr, &visa, NodeVisaState::PendingInstall)
+            .store_visa(&visa, metadata, NodeVisaState::PendingInstall)
             .await
             .unwrap_err();
         match err {
@@ -499,7 +516,8 @@ mod test {
         let node_addr: IpAddr = "fd5a:5052::5".parse().unwrap();
         let visa = make_visa(9, Duration::from_secs(5));
 
-        repo.store_visa(&node_addr, &visa, NodeVisaState::PendingInstall)
+        let metadata = VisaMetadata::new(node_addr, 0, String::new(), Direction::Forward);
+        repo.store_visa(&visa, metadata, NodeVisaState::PendingInstall)
             .await
             .unwrap();
 
@@ -523,10 +541,12 @@ mod test {
         let visa_a = make_visa(10, Duration::from_secs(60));
         let visa_b = make_visa(11, Duration::from_secs(60));
 
-        repo.store_visa(&node_addr, &visa_a, NodeVisaState::PendingInstall)
+        let metadata_a = VisaMetadata::new(node_addr, 0, String::new(), Direction::Forward);
+        repo.store_visa(&visa_a, metadata_a, NodeVisaState::PendingInstall)
             .await
             .unwrap();
-        repo.store_visa(&node_addr, &visa_b, NodeVisaState::PendingInstall)
+        let metadata_b = VisaMetadata::new(node_addr, 0, String::new(), Direction::Forward);
+        repo.store_visa(&visa_b, metadata_b, NodeVisaState::PendingInstall)
             .await
             .unwrap();
 
@@ -550,15 +570,27 @@ mod test {
         let visa_b = make_visa(5, Duration::from_secs(60));
         let visa_c = make_visa(42, Duration::from_secs(60));
 
-        repo.store_visa(&node_addr, &visa_a, NodeVisaState::PendingInstall)
-            .await
-            .unwrap();
-        repo.store_visa(&node_addr, &visa_b, NodeVisaState::PendingInstall)
-            .await
-            .unwrap();
-        repo.store_visa(&node_addr, &visa_c, NodeVisaState::PendingInstall)
-            .await
-            .unwrap();
+        repo.store_visa(
+            &visa_a,
+            VisaMetadata::new(node_addr, 0, String::new(), Direction::Forward),
+            NodeVisaState::PendingInstall,
+        )
+        .await
+        .unwrap();
+        repo.store_visa(
+            &visa_b,
+            VisaMetadata::new(node_addr, 0, String::new(), Direction::Forward),
+            NodeVisaState::PendingInstall,
+        )
+        .await
+        .unwrap();
+        repo.store_visa(
+            &visa_c,
+            VisaMetadata::new(node_addr, 0, String::new(), Direction::Forward),
+            NodeVisaState::PendingInstall,
+        )
+        .await
+        .unwrap();
 
         let mut ids = repo.list_visa_ids().await.unwrap();
         ids.sort_unstable();
@@ -573,7 +605,8 @@ mod test {
         let node_addr: IpAddr = "fd5a:5052::8".parse().unwrap();
         let visa = make_visa(77, Duration::from_secs(60));
 
-        repo.store_visa(&node_addr, &visa, NodeVisaState::PendingInstall)
+        let metadata = VisaMetadata::new(node_addr, 0, String::new(), Direction::Forward);
+        repo.store_visa(&visa, metadata, NodeVisaState::PendingInstall)
             .await
             .unwrap();
 
@@ -602,7 +635,8 @@ mod test {
         let node_addr: IpAddr = "fd5a:5052::9".parse().unwrap();
         let visa = make_visa(88, Duration::from_secs(60));
 
-        repo.store_visa(&node_addr, &visa, NodeVisaState::PendingInstall)
+        let stored_metadata = VisaMetadata::new(node_addr, 0, String::new(), Direction::Forward);
+        repo.store_visa(&visa, stored_metadata, NodeVisaState::PendingInstall)
             .await
             .unwrap();
 

--- a/vs/src/db/visa.rs
+++ b/vs/src/db/visa.rs
@@ -656,4 +656,75 @@ mod test {
             other => panic!("unexpected error: {:?}", other),
         }
     }
+
+    /// Verifies that a VisaMetadata with non-default values for all new fields
+    /// survives a serialize → deserialize round-trip with all fields intact.
+    #[test]
+    fn test_visa_metadata_round_trip() {
+        let node_addr: IpAddr = "fd5a:5052::10".parse().unwrap();
+        let original = VisaMetadata {
+            requesting_node: node_addr,
+            ctime: 1_700_000_000,
+            policy_version: 42,
+            zpl: "permit src any dst any".to_string(),
+            signal_msgs: vec!["sig-a".to_string(), "sig-b".to_string()],
+            direction: Direction::Reverse,
+        };
+
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: VisaMetadata = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(decoded.requesting_node, original.requesting_node);
+        assert_eq!(decoded.ctime, original.ctime);
+        assert_eq!(decoded.policy_version, original.policy_version);
+        assert_eq!(decoded.zpl, original.zpl);
+        assert_eq!(decoded.signal_msgs, original.signal_msgs);
+        assert_eq!(decoded.direction, original.direction);
+    }
+
+    /// Verifies that signal_msgs is preserved correctly when non-empty across
+    /// a serialize → deserialize round-trip.
+    #[test]
+    fn test_visa_metadata_signal_msgs_preserved() {
+        let node_addr: IpAddr = "fd5a:5052::12".parse().unwrap();
+        let signals = vec![
+            "msg-1".to_string(),
+            "msg-2".to_string(),
+            "msg-3".to_string(),
+        ];
+        let original = VisaMetadata {
+            requesting_node: node_addr,
+            ctime: 1_700_000_001,
+            policy_version: 1,
+            zpl: String::new(),
+            signal_msgs: signals.clone(),
+            direction: Direction::Forward,
+        };
+
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: VisaMetadata = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(decoded.signal_msgs, signals);
+    }
+
+    /// Verifies that Direction::Forward and Direction::Reverse each survive a
+    /// serialize → deserialize round-trip without being altered.
+    #[test]
+    fn test_visa_metadata_direction_round_trip_both_variants() {
+        let node_addr: IpAddr = "fd5a:5052::13".parse().unwrap();
+
+        for direction in [Direction::Forward, Direction::Reverse] {
+            let original = VisaMetadata {
+                requesting_node: node_addr,
+                ctime: 1_700_000_002,
+                policy_version: 0,
+                zpl: String::new(),
+                signal_msgs: Vec::new(),
+                direction,
+            };
+            let json = serde_json::to_string(&original).unwrap();
+            let decoded: VisaMetadata = serde_json::from_str(&json).unwrap();
+            assert_eq!(decoded.direction, direction);
+        }
+    }
 }

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -24,6 +24,11 @@ pub struct VisaMgr {
     repo: db::VisaRepo,
 }
 
+pub struct VisaWithMetadata {
+    pub visa: Visa,
+    pub metadata: db::VisaMetadata,
+}
+
 impl VisaMgr {
     pub fn new(db: db::VisaRepo) -> Self {
         VisaMgr { repo: db }
@@ -143,6 +148,8 @@ impl VisaMgr {
         requesting_node: &IpAddr,
         pdesc: &PacketDesc,
         hit: &Hit,
+        source_zpl: impl Into<String>,
+        policy_version: u64,
     ) -> Result<Visa, ServiceError> {
         let expiration_time = std::time::SystemTime::now()
             .checked_add(config::DEFAULT_VISA_EXPIRATION)
@@ -198,6 +205,17 @@ impl VisaMgr {
         };
 
         let visa_id = self.repo.get_next_visa_id().await?;
+
+        let mut metadata = db::VisaMetadata::new(
+            requesting_node.clone(),
+            policy_version,
+            source_zpl.into(),
+            hit.direction,
+        );
+        if let Some(sig) = hit.signal.as_ref() {
+            metadata.signal_msgs.push(sig.message.clone());
+        }
+
         let visa = Visa {
             issuer_id: visa_id,
             config: 0,
@@ -210,7 +228,7 @@ impl VisaMgr {
         };
 
         self.repo
-            .store_visa(requesting_node, &visa, db::NodeVisaState::PendingInstall)
+            .store_visa(&visa, metadata, db::NodeVisaState::PendingInstall)
             .await?;
 
         info!("created visa {visa_id}");
@@ -285,20 +303,18 @@ impl VisaMgr {
         Ok(visa_ids)
     }
 
-    pub async fn get_visa_by_id(&self, visa_id: u64) -> Result<Option<Visa>, ServiceError> {
-        match self.repo.get_visa_by_id(visa_id).await {
-            Ok(visa) => Ok(Some(visa)),
-            Err(StoreError::NotFound(_)) => Ok(None),
-            Err(e) => Err(ServiceError::from(e)),
-        }
-    }
-
-    pub async fn get_visa_metadata_by_id(
+    /// Shorthand and slightly more race-condition safe way of calling `get_visa_by_id` and `get_visa_metadata_by_id`.
+    /// Returns None if either the visa or the metadata is not found.
+    pub async fn get_visa_with_metadata_by_id(
         &self,
         visa_id: u64,
-    ) -> Result<Option<db::VisaMetadata>, ServiceError> {
-        match self.repo.get_visa_metadata_by_id(visa_id).await {
-            Ok(md) => Ok(Some(md)),
+    ) -> Result<Option<VisaWithMetadata>, ServiceError> {
+        match self.repo.get_visa_by_id(visa_id).await {
+            Ok(visa) => match self.repo.get_visa_metadata_by_id(visa_id).await {
+                Ok(md) => Ok(Some(VisaWithMetadata { visa, metadata: md })),
+                Err(StoreError::NotFound(_)) => Ok(None),
+                Err(e) => Err(ServiceError::from(e)),
+            },
             Err(StoreError::NotFound(_)) => Ok(None),
             Err(e) => Err(ServiceError::from(e)),
         }
@@ -340,8 +356,11 @@ mod tests {
         let node_addr: IpAddr = NODE_ADDR.parse().unwrap();
         let visa = make_visa(1, std::time::Duration::from_secs(60));
 
+        let metadata =
+            db::VisaMetadata::new(node_addr.clone(), 0, "zpl".to_string(), Direction::Forward);
+
         mgr.repo
-            .store_visa(&node_addr, &visa, db::NodeVisaState::Installed)
+            .store_visa(&visa, metadata, db::NodeVisaState::Installed)
             .await
             .unwrap();
 
@@ -388,9 +407,11 @@ mod tests {
         let mgr = make_mgr().await;
         let node_addr: IpAddr = NODE_ADDR.parse().unwrap();
         let visa = make_visa(2, std::time::Duration::from_secs(60));
+        let metadata =
+            db::VisaMetadata::new(node_addr.clone(), 0, "zpl".to_string(), Direction::Forward);
 
         mgr.repo
-            .store_visa(&node_addr, &visa, db::NodeVisaState::Installed)
+            .store_visa(&visa, metadata, db::NodeVisaState::Installed)
             .await
             .unwrap();
 
@@ -416,9 +437,11 @@ mod tests {
         let mgr = make_mgr().await;
         let node_addr: IpAddr = NODE_ADDR.parse().unwrap();
         let visa = make_visa(3, std::time::Duration::from_secs(60));
+        let metadata =
+            db::VisaMetadata::new(node_addr.clone(), 0, "zpl".to_string(), Direction::Forward);
 
         mgr.repo
-            .store_visa(&node_addr, &visa, db::NodeVisaState::PendingInstall)
+            .store_visa(&visa, metadata, db::NodeVisaState::PendingInstall)
             .await
             .unwrap();
 

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -311,6 +311,7 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
             Ok(VisaDecision::Deny(DenyCode::NoMatch))
         }
         EvalDecision::Allow(hits) => {
+            debug_assert!(!hits.is_empty(), "allow decision with no hits"); // should never happen.
             let policy_version = policy.get_version().unwrap_or(0);
             // TODO: For now we pick the first hit.
             let zpl = policy

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -289,7 +289,7 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
     let dest_actor = dest_actor.unwrap();
 
     let policy = asm.policy_mgr.get_current();
-    let ctx = EvalContext::new(policy);
+    let ctx = EvalContext::new(policy.clone());
     let decision = match ctx.eval_request(&source_actor, &dest_actor, &job.packet_desc) {
         Ok(decision) => decision,
         Err(e) => {
@@ -311,10 +311,21 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
             Ok(VisaDecision::Deny(DenyCode::NoMatch))
         }
         EvalDecision::Allow(hits) => {
+            let policy_version = policy.get_version().unwrap_or(0);
             // TODO: For now we pick the first hit.
+            let zpl = policy
+                .get_cpol_source(hits[0].match_idx)
+                .unwrap_or("")
+                .to_string();
             match asm
                 .visa_mgr
-                .create_visa(&job.requesting_node, &job.packet_desc, &hits[0])
+                .create_visa(
+                    &job.requesting_node,
+                    &job.packet_desc,
+                    &hits[0],
+                    zpl,
+                    policy_version,
+                )
                 .await
             {
                 Ok(visa) => Ok(VisaDecision::Allow(visa)),


### PR DESCRIPTION
Enriches visa metadata — both stored in the DB and returned by the admin API — with:
-  the ZPL policy line that triggered the match, 
- the match direction (forward/reverse), 
- the policy version at issuance time, and 
- any signal messages from the hit. 

The `VisaDescriptor` API type and `VisaMetadata` DB struct both grow these fields; `create_visa` and `store_visa` signatures are updated accordingly, and a new `get_visa_with_metadata_by_id` helper replaces two separate calls. `Policy` gains a `cpol_sources` cache and `get_cpol_source()` accessor so the worker can look up the ZPL string by hit index.
