### PR TITLE
populate node record brief

### DIFF
--- a/admin-api-types/src/admin_api_types.rs
+++ b/admin-api-types/src/admin_api_types.rs
@@ -328,37 +328,44 @@ impl fmt::Display for HostRecordBrief {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct NodeRecordBrief {
-    pub pending: u32,
-    pub last_contact: Option<i64>, // unix SECONDS
+    // Number of visas pending install on the node
+    pub pending_install: u32,
+    // Last time node was contacted by the visa service, 0 if there was no contact
+    pub last_contact: i64, // unix SECONDS
+    // Number of visa requests on the node
     pub visa_requests: u64,
+    // Number of calls to authorize_connect by the node
     pub connect_requests: u64,
+    // If the node is connected to the vss
     pub in_sync: bool,
+    // Approved visa requests
     pub approved_vreqs: u64,
+    // Denied visa requests
     pub denied_vreqs: u64,
-    pub last_vreq: Option<i64>, // unix SECONDS
+    // Time of last visa request, 0 if there was no request
+    pub last_vreq: i64, // unix SECONDS
+    // CNs of all adapters connected to the node
     pub adapters: Vec<String>,
+    // CNs of all other nodes connected to the node
     pub links: Vec<String>,
+    // IDs of all visas installed on the node
     pub visas: Vec<u64>,
+    // IDs of all pending visas on the node
     pub visas_enqueued: Vec<u64>,
-    pub revocations_enqueued_count: u64,
+    // Number of
+    pub pending_revocation: u32,
     pub vss_port: Option<u16>,
 }
 
 impl fmt::Display for NodeRecordBrief {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let last_contact = match self.last_contact {
-            Some(lc) => Some(DateTime::from_timestamp(lc, 0).unwrap()),
-            None => None,
-        };
-        let last_request = match self.last_vreq {
-            Some(lr) => Some(DateTime::from_timestamp(lr, 0).unwrap()),
-            None => None,
-        };
+        let last_contact = DateTime::from_timestamp(self.last_contact, 0).unwrap();
+        let last_vreq = DateTime::from_timestamp(self.last_vreq, 0).unwrap();
 
         write!(
             f,
             "{} {} {} {} {} {} {} {}",
-            format!("{}{}", "pending:".dimmed(), self.pending),
+            format!("{}{}", "pending installs:".dimmed(), self.pending_install),
             format!(
                 "{}{}",
                 "SYNC:".dimmed(),
@@ -371,9 +378,12 @@ impl fmt::Display for NodeRecordBrief {
             format!(
                 "{} {}",
                 "last_contact:".dimmed(),
-                match last_contact {
-                    Some(lc) => lc.to_rfc3339_opts(SecondsFormat::Secs, true).cyan(),
-                    None => "never".to_string().red(),
+                if self.last_contact == 0 {
+                    "never".to_string().red()
+                } else {
+                    last_contact
+                        .to_rfc3339_opts(SecondsFormat::Secs, true)
+                        .cyan()
                 }
             ),
             // '[vreqs: VAL' (vreqs_appr: VAL | vreqs_den: VAL) | vinstalled: [VAL, VAL, VAL] | venqueued: [VAL, VAL]]'
@@ -403,9 +413,10 @@ impl fmt::Display for NodeRecordBrief {
             format!(
                 "{} {}",
                 "last_request:".dimmed(),
-                match last_request {
-                    Some(lr) => lr.to_rfc3339_opts(SecondsFormat::Secs, true).cyan(),
-                    None => "never".to_string().red(),
+                if self.last_vreq == 0 {
+                    "never".to_string().red()
+                } else {
+                    last_vreq.to_rfc3339_opts(SecondsFormat::Secs, true).cyan()
                 }
             ),
             // [creqs: VAL | adapters: [VAL, VAL, VAL] | nodes: [VAL, VAL]]
@@ -419,8 +430,8 @@ impl fmt::Display for NodeRecordBrief {
             ),
             format!(
                 "{}{}",
-                "revocations_enqueued:".dimmed(),
-                self.revocations_enqueued_count
+                "pending revocations:".dimmed(),
+                self.pending_revocation
             ),
             format!(
                 "{}{}",

--- a/admin-api-types/src/admin_api_types.rs
+++ b/admin-api-types/src/admin_api_types.rs
@@ -295,15 +295,15 @@ pub struct NodeRecordBrief {
     pub visa_requests: u64,
     pub connect_requests: u64,
     pub in_sync: bool,
-    pub approved_reqs: u64,
-    pub denied_reqs: u64,
-    pub last_request: Option<i64>, // unix SECONDS
+    pub approved_vreqs: u64,
+    pub denied_vreqs: u64,
+    pub last_vreq: Option<i64>, // unix SECONDS
     pub adapters: Vec<String>,
     pub links: Vec<String>,
-    pub visas: Vec<String>,
-    pub visas_enqueued: Vec<String>,
+    pub visas: Vec<u64>,
+    pub visas_enqueued: Vec<u64>,
     pub revocations_enqueued_count: u64,
-    pub vss_port: u16,
+    pub vss_port: Option<u16>,
 }
 
 impl fmt::Display for NodeRecordBrief {
@@ -312,7 +312,7 @@ impl fmt::Display for NodeRecordBrief {
             Some(lc) => Some(DateTime::from_timestamp(lc, 0).unwrap()),
             None => None,
         };
-        let last_request = match self.last_request {
+        let last_request = match self.last_vreq {
             Some(lr) => Some(DateTime::from_timestamp(lr, 0).unwrap()),
             None => None,
         };
@@ -346,10 +346,10 @@ impl fmt::Display for NodeRecordBrief {
                     "[vreqs:".dimmed(),
                     self.visa_requests,
                     "(vreqs_appr".dimmed(),
-                    self.approved_reqs,
+                    self.approved_vreqs,
                     "|".dimmed(),
                     "vreqs_den".dimmed(),
-                    self.denied_reqs,
+                    self.denied_vreqs,
                     ")"
                 ),
                 "|".dimmed(),
@@ -384,7 +384,14 @@ impl fmt::Display for NodeRecordBrief {
                 "revocations_enqueued:".dimmed(),
                 self.revocations_enqueued_count
             ),
-            format!("{}{}", "vss_port:".dimmed(), self.vss_port),
+            format!(
+                "{}{}",
+                "vss_port:".dimmed(),
+                match self.vss_port {
+                    Some(port) => port.to_string(),
+                    None => "no vss".to_string(),
+                }
+            ),
         )
     }
 }

--- a/admin-api-types/src/admin_api_types.rs
+++ b/admin-api-types/src/admin_api_types.rs
@@ -331,7 +331,7 @@ pub struct NodeRecordBrief {
     // Number of visas pending install on the node
     pub pending_install: u32,
     // Last time node was contacted by the visa service, 0 if there was no contact
-    pub last_contact: i64, // unix SECONDS
+    pub last_contact: Option<i64>, // unix SECONDS
     // Number of visa requests on the node
     pub visa_requests: u64,
     // Number of calls to authorize_connect by the node
@@ -343,7 +343,7 @@ pub struct NodeRecordBrief {
     // Denied visa requests
     pub denied_vreqs: u64,
     // Time of last visa request, 0 if there was no request
-    pub last_vreq: i64, // unix SECONDS
+    pub last_vreq: Option<i64>, // unix SECONDS
     // CNs of all adapters connected to the node
     pub adapters: Vec<String>,
     // CNs of all other nodes connected to the node
@@ -352,15 +352,22 @@ pub struct NodeRecordBrief {
     pub visas: Vec<u64>,
     // IDs of all pending visas on the node
     pub visas_enqueued: Vec<u64>,
-    // Number of
+    // Number of visas pending revocation on the node
     pub pending_revocation: u32,
+    // Port of the VSS the node is connected to
     pub vss_port: Option<u16>,
 }
 
 impl fmt::Display for NodeRecordBrief {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let last_contact = DateTime::from_timestamp(self.last_contact, 0).unwrap();
-        let last_vreq = DateTime::from_timestamp(self.last_vreq, 0).unwrap();
+        let last_contact = match self.last_contact {
+            Some(lc) => Some(DateTime::from_timestamp(lc, 0).unwrap()),
+            None => None,
+        };
+        let last_vreq = match self.last_vreq {
+            Some(lr) => Some(DateTime::from_timestamp(lr, 0).unwrap()),
+            None => None,
+        };
 
         write!(
             f,
@@ -378,12 +385,9 @@ impl fmt::Display for NodeRecordBrief {
             format!(
                 "{} {}",
                 "last_contact:".dimmed(),
-                if self.last_contact == 0 {
-                    "never".to_string().red()
-                } else {
-                    last_contact
-                        .to_rfc3339_opts(SecondsFormat::Secs, true)
-                        .cyan()
+                match last_contact {
+                    Some(lc) => lc.to_rfc3339_opts(SecondsFormat::Secs, true).cyan(),
+                    None => "never".to_string().red(),
                 }
             ),
             // '[vreqs: VAL' (vreqs_appr: VAL | vreqs_den: VAL) | vinstalled: [VAL, VAL, VAL] | venqueued: [VAL, VAL]]'
@@ -413,10 +417,9 @@ impl fmt::Display for NodeRecordBrief {
             format!(
                 "{} {}",
                 "last_request:".dimmed(),
-                if self.last_vreq == 0 {
-                    "never".to_string().red()
-                } else {
-                    last_vreq.to_rfc3339_opts(SecondsFormat::Secs, true).cyan()
+                match last_vreq {
+                    Some(lr) => lr.to_rfc3339_opts(SecondsFormat::Secs, true).cyan(),
+                    None => "never".to_string().red(),
                 }
             ),
             // [creqs: VAL | adapters: [VAL, VAL, VAL] | nodes: [VAL, VAL]]

--- a/vs/src/actor_mgr.rs
+++ b/vs/src/actor_mgr.rs
@@ -776,10 +776,7 @@ mod test {
             .unwrap();
         cns.sort();
         assert_eq!(cns.len(), 3);
-        assert_eq!(
-            cns,
-            vec!["adapter-1", "adapter-2", "adapter-3"]
-        );
+        assert_eq!(cns, vec!["adapter-1", "adapter-2", "adapter-3"]);
     }
 
     #[tokio::test]

--- a/vs/src/actor_mgr.rs
+++ b/vs/src/actor_mgr.rs
@@ -227,6 +227,26 @@ impl ActorMgr {
             .collect())
     }
 
+    pub async fn get_adapter_cns_connected_to_node(
+        &self,
+        node_addr: &IpAddr,
+    ) -> Result<Vec<String>, ServiceError> {
+        let adapter_zpr_addrs = self.get_adapters_connected_to_node(node_addr).await?;
+
+        Ok(futures::future::join_all(
+            adapter_zpr_addrs
+                .iter()
+                .map(|addr| self.get_actor_by_zpr_addr(addr)),
+        )
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .flatten()
+        .filter_map(|actor| actor.get_cn().map(|cn| cn.to_string()))
+        .collect())
+    }
+
     /// Get the list of connected authentication services.
     pub async fn get_auth_services_list(
         &self,
@@ -706,5 +726,168 @@ mod test {
 
         let services = mgr.get_auth_services_list(asm).await.unwrap();
         assert!(services.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_adapter_cns_connected_to_node_single_adapter() {
+        let mgr = make_mgr();
+        let node_actor =
+            make_node_actor_defexp("fd5a:5052::20", "node-cn-1", "[fd5a:5052::120]:1234");
+        let adapter_actor = make_adapter_actor_defexp("fd5a:5052::21", "adapter-cn-1");
+        let node_addr: IpAddr = "fd5a:5052::20".parse().unwrap();
+
+        mgr.add_node(&node_actor, false).await.unwrap();
+        mgr.add_adapter_via_node(&adapter_actor, &node_addr)
+            .await
+            .unwrap();
+
+        let cns = mgr
+            .get_adapter_cns_connected_to_node(&node_addr)
+            .await
+            .unwrap();
+        assert_eq!(cns.len(), 1);
+        assert_eq!(cns[0], "adapter-cn-1");
+    }
+
+    #[tokio::test]
+    async fn test_get_adapter_cns_connected_to_node_multiple_adapters() {
+        let mgr = make_mgr();
+        let node_actor =
+            make_node_actor_defexp("fd5a:5052::20", "node-cn", "[fd5a:5052::120]:1234");
+        let adapter1 = make_adapter_actor_defexp("fd5a:5052::21", "adapter-1");
+        let adapter2 = make_adapter_actor_defexp("fd5a:5052::22", "adapter-2");
+        let adapter3 = make_adapter_actor_defexp("fd5a:5052::23", "adapter-3");
+        let node_addr: IpAddr = "fd5a:5052::20".parse().unwrap();
+
+        mgr.add_node(&node_actor, false).await.unwrap();
+        mgr.add_adapter_via_node(&adapter1, &node_addr)
+            .await
+            .unwrap();
+        mgr.add_adapter_via_node(&adapter2, &node_addr)
+            .await
+            .unwrap();
+        mgr.add_adapter_via_node(&adapter3, &node_addr)
+            .await
+            .unwrap();
+
+        let mut cns = mgr
+            .get_adapter_cns_connected_to_node(&node_addr)
+            .await
+            .unwrap();
+        cns.sort();
+        assert_eq!(cns.len(), 3);
+        assert_eq!(
+            cns,
+            vec!["adapter-1", "adapter-2", "adapter-3"]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_adapter_cns_connected_to_node_no_adapters() {
+        let mgr = make_mgr();
+        let node_actor =
+            make_node_actor_defexp("fd5a:5052::20", "node-cn", "[fd5a:5052::120]:1234");
+        let node_addr: IpAddr = "fd5a:5052::20".parse().unwrap();
+
+        mgr.add_node(&node_actor, false).await.unwrap();
+
+        let cns = mgr
+            .get_adapter_cns_connected_to_node(&node_addr)
+            .await
+            .unwrap();
+        assert!(cns.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_adapter_cns_connected_to_node_only_returns_own_adapters() {
+        // Two nodes, each with their own adapters — verify no cross-contamination.
+        let mgr = make_mgr();
+        let node_a = make_node_actor_defexp("fd5a:5052::20", "node-a", "[fd5a:5052::120]:1234");
+        let node_b = make_node_actor_defexp("fd5a:5052::21", "node-b", "[fd5a:5052::120]:1234");
+        let adapter_on_a = make_adapter_actor_defexp("fd5a:5052::22", "adapter-for-a");
+        let adapter_on_b = make_adapter_actor_defexp("fd5a:5052::23", "adapter-for-b");
+
+        let node_a_addr: IpAddr = "fd5a:5052::20".parse().unwrap();
+        let node_b_addr: IpAddr = "fd5a:5052::21".parse().unwrap();
+
+        mgr.add_node(&node_a, false).await.unwrap();
+        mgr.add_node(&node_b, false).await.unwrap();
+        mgr.add_adapter_via_node(&adapter_on_a, &node_a_addr)
+            .await
+            .unwrap();
+        mgr.add_adapter_via_node(&adapter_on_b, &node_b_addr)
+            .await
+            .unwrap();
+
+        let cns_a = mgr
+            .get_adapter_cns_connected_to_node(&node_a_addr)
+            .await
+            .unwrap();
+        assert_eq!(cns_a.len(), 1);
+        assert_eq!(cns_a[0], "adapter-for-a");
+
+        let cns_b = mgr
+            .get_adapter_cns_connected_to_node(&node_b_addr)
+            .await
+            .unwrap();
+        assert_eq!(cns_b.len(), 1);
+        assert_eq!(cns_b[0], "adapter-for-b");
+    }
+
+    #[tokio::test]
+    async fn test_get_adapter_cns_connected_to_node_after_removal() {
+        // Add two adapters, remove one, verify only the remaining CN is returned.
+        let mgr = make_mgr();
+        let node_actor =
+            make_node_actor_defexp("fd5a:5052::20", "node-cn-rm", "[fd5a:5052::120]:1234");
+        let adapter1 = make_adapter_actor_defexp("fd5a:5052::21", "keep-me");
+        let adapter2 = make_adapter_actor_defexp("fd5a:5052::22", "remove-me");
+        let node_addr: IpAddr = "fd5a:5052::20".parse().unwrap();
+        let remove_addr: IpAddr = "fd5a:5052::22".parse().unwrap();
+
+        mgr.add_node(&node_actor, false).await.unwrap();
+        mgr.add_adapter_via_node(&adapter1, &node_addr)
+            .await
+            .unwrap();
+        mgr.add_adapter_via_node(&adapter2, &node_addr)
+            .await
+            .unwrap();
+
+        // Sanity: both present before removal.
+        let mut cns = mgr
+            .get_adapter_cns_connected_to_node(&node_addr)
+            .await
+            .unwrap();
+        cns.sort();
+        assert_eq!(cns.len(), 2);
+
+        // Remove the actor record for adapter2.
+        mgr.remove_actor_by_zpr_addr(&remove_addr).await.unwrap();
+
+        // The node_db still has the ZPR address in its connected-adapters list,
+        // but the actor lookup will return None — the function should gracefully
+        // skip it via .flatten().
+        let cns = mgr
+            .get_adapter_cns_connected_to_node(&node_addr)
+            .await
+            .unwrap();
+        assert_eq!(cns.len(), 1);
+        assert_eq!(cns[0], "keep-me");
+    }
+
+    #[tokio::test]
+    async fn test_get_adapter_cns_connected_to_node_unknown_node() {
+        // Querying a node address that was never added should return an empty vec
+        // (or an error, depending on the NodeRepo implementation).
+        let mgr = make_mgr();
+        let unknown_addr: IpAddr = "fd5a:5052::99".parse().unwrap();
+
+        let result = mgr.get_adapter_cns_connected_to_node(&unknown_addr).await;
+        // With FakeDb this likely returns Ok(vec![]).
+        // If the implementation errors on unknown nodes, adjust to unwrap_err().
+        match result {
+            Ok(cns) => assert!(cns.is_empty()),
+            Err(_) => {} // Also acceptable — unknown node is not in DB.
+        }
     }
 }

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -30,18 +30,20 @@ use zpr::vsapi_types::DockPep;
 use rustls::ServerConfig;
 use rustls::pki_types::PrivateKeyDer;
 use serde::Deserialize;
+use std::time::SystemTime;
 use tokio::net::TcpListener;
 use tokio_rustls::TlsAcceptor;
 
 use crate::admin_apikeys::Permission;
 use crate::apikey::ApiKey;
 use crate::assembly::Assembly;
+use crate::counters::CounterType;
 use crate::db::Role;
 use crate::logging::targets::ADMIN;
 
 use admin_api_types::{
-    ActorDescriptor, AuthRevokeDescriptor, CnEntry, ListEntry, NamedListEntry, PolicyBundle,
-    Revokes, ServiceDescriptor, VisaDescriptor,
+    ActorDescriptor, AuthRevokeDescriptor, CnEntry, ListEntry, NamedListEntry, NodeRecordBrief,
+    PolicyBundle, Revokes, ServiceDescriptor, VisaDescriptor,
 };
 
 // Must use tokio RwLock here becuase we need state to be Send.
@@ -400,7 +402,7 @@ async fn get_actor(
         return Err(StatusCode::FORBIDDEN);
     }
 
-    match rstate.asm.actor_mgr.get_actor_by_cn(&cn).await {
+    match state.read().await.asm.actor_mgr.get_actor_by_cn(&cn).await {
         Err(_) => return Err(StatusCode::INTERNAL_SERVER_ERROR),
         Ok(opt_a) => match opt_a {
             None => Err(StatusCode::NOT_FOUND),
@@ -426,18 +428,103 @@ async fn get_actor(
                     None => "".to_string(),
                 };
 
+                let node_details = match is_node {
+                    true => Some(build_node_record_brief(rstate, actor).await?),
+                    false => None,
+                };
+
                 let descriptor = ActorDescriptor {
                     cn: cn.clone(),
                     ctime_secs: 0, // TODO: Not tracked yet
                     ident,
                     node: is_node,
                     zpr_addr: zpr_addr_str,
-                    node_details: None, // TODO
+                    node_details,
                 };
                 return Ok(Json(descriptor));
             }
         },
     }
+}
+
+async fn build_node_record_brief(
+    rstate: tokio::sync::RwLockReadGuard<'_, AdminState>,
+    actor: libeval::actor::Actor,
+) -> Result<NodeRecordBrief, StatusCode> {
+    let counters = rstate.asm.counters.clone();
+    let actor_mgr = rstate.asm.actor_mgr.clone();
+    let visa_mgr = &rstate.asm.visa_mgr;
+
+    let zpr_addr = match actor.get_zpr_addr() {
+        Some(addr) => addr,
+        None => return Err(StatusCode::INTERNAL_SERVER_ERROR),
+    };
+    let pending = visa_mgr
+        .get_pending_visas_for_node(zpr_addr)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .len() as u32;
+    let visa_requests = counters
+        .get_node_counter(zpr_addr, CounterType::VisaRequests)
+        .unwrap_or(0);
+    let connect_requests = counters
+        .get_node_counter(zpr_addr, CounterType::NodeConnectionsFailed)
+        .unwrap_or(0)
+        + counters
+            .get_node_counter(zpr_addr, CounterType::NodeConnectionsSuccess)
+            .unwrap_or(0);
+    let approved_vreqs = counters
+        .get_node_counter(zpr_addr, CounterType::VisaRequestsApproved)
+        .unwrap_or(0);
+    let denied_vreqs = counters
+        .get_node_counter(zpr_addr, CounterType::VisaRequestsDenied)
+        .unwrap_or(0);
+    let last_vreq = match rstate.asm.counters.get_last_request_time(zpr_addr) {
+        Some(st) => Some(st.duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs() as i64),
+        None => None,
+    };
+    let adapters = actor_mgr
+        .get_adapter_cns_connected_to_node(zpr_addr)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    // TODO I don't think we have connected nodes yet, since we don't yet have multi-node
+    let visas = visa_mgr
+        .get_installed_visa_ids_for_node(zpr_addr)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let visas_enqueued = visa_mgr
+        .get_pending_visa_ids_for_node(zpr_addr)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let revocations_enqueued_count = visa_mgr
+        .num_pending_revokes(zpr_addr)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let (vss_port, in_sync) = match actor_mgr
+        .get_node_vss(zpr_addr)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    {
+        Some(socket_addr) => (Some(socket_addr.port()), true),
+        None => (None, false),
+    };
+
+    Ok(NodeRecordBrief {
+        pending,
+        last_contact: Some(0), // TODO don't think we currently store last contact
+        visa_requests,
+        connect_requests,
+        in_sync,
+        approved_vreqs,
+        denied_vreqs,
+        last_vreq,
+        adapters,
+        links: Vec::new(), // TODO blocked on multi-node support
+        visas,
+        visas_enqueued,
+        revocations_enqueued_count,
+        vss_port,
+    })
 }
 
 async fn revoke_actor(EPath(cn): EPath<String>) -> impl IntoResponse {

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -486,8 +486,8 @@ async fn build_node_record_brief(
         .get_node_counter(zpr_addr, CounterType::VisaRequestsDenied)
         .unwrap_or(0);
     let last_vreq = match counters.get_last_request_time(zpr_addr) {
-        Some(st) => st.duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs() as i64,
-        None => 0,
+        Some(st) => Some(st.duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs() as i64),
+        None => None,
     };
     let adapters = actor_mgr
         .get_adapter_cns_connected_to_node(zpr_addr)
@@ -517,7 +517,7 @@ async fn build_node_record_brief(
 
     Ok(NodeRecordBrief {
         pending_install,
-        last_contact: 0, // TODO don't think we currently store last contact
+        last_contact: None, // TODO don't think we currently store last contact
         visa_requests,
         connect_requests: 0, // TODO blocked on tracking calls to authorize_connect
         in_sync,

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -413,7 +413,7 @@ async fn get_actor(
         return Err(StatusCode::FORBIDDEN);
     }
 
-    match state.read().await.asm.actor_mgr.get_actor_by_cn(&cn).await {
+    match rstate.asm.actor_mgr.get_actor_by_cn(&cn).await {
         Err(_) => return Err(StatusCode::INTERNAL_SERVER_ERROR),
         Ok(opt_a) => match opt_a {
             None => Err(StatusCode::NOT_FOUND),

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -408,12 +408,14 @@ async fn get_actor(
 ) -> Result<Json<ActorDescriptor>, StatusCode> {
     debug!(target: ADMIN, "GET /admin/actor/{}", cn);
     let rstate = state.read().await;
+    let asm = rstate.asm.clone();
+    drop(rstate);
 
     if !perm.can_read() {
         return Err(StatusCode::FORBIDDEN);
     }
 
-    match rstate.asm.actor_mgr.get_actor_by_cn(&cn).await {
+    match asm.actor_mgr.get_actor_by_cn(&cn).await {
         Err(_) => return Err(StatusCode::INTERNAL_SERVER_ERROR),
         Ok(opt_a) => match opt_a {
             None => Err(StatusCode::NOT_FOUND),
@@ -440,7 +442,7 @@ async fn get_actor(
                 };
 
                 let node_details = match is_node {
-                    true => Some(build_node_record_brief(rstate, actor).await?),
+                    true => Some(build_node_record_brief(&asm, actor).await?),
                     false => None,
                 };
 
@@ -459,40 +461,33 @@ async fn get_actor(
 }
 
 async fn build_node_record_brief(
-    rstate: tokio::sync::RwLockReadGuard<'_, AdminState>,
+    asm: &Assembly,
     actor: libeval::actor::Actor,
 ) -> Result<NodeRecordBrief, StatusCode> {
-    let counters = rstate.asm.counters.clone();
-    let actor_mgr = rstate.asm.actor_mgr.clone();
-    let visa_mgr = &rstate.asm.visa_mgr;
+    let counters = asm.counters.clone();
+    let actor_mgr = asm.actor_mgr.clone();
+    let visa_mgr = &asm.visa_mgr;
 
     let zpr_addr = match actor.get_zpr_addr() {
         Some(addr) => addr,
         None => return Err(StatusCode::INTERNAL_SERVER_ERROR),
     };
-    let pending = visa_mgr
-        .get_pending_visas_for_node(zpr_addr)
+    let pending_install = visa_mgr
+        .get_num_pending_install_visas(zpr_addr)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-        .len() as u32;
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     let visa_requests = counters
         .get_node_counter(zpr_addr, CounterType::VisaRequests)
         .unwrap_or(0);
-    let connect_requests = counters
-        .get_node_counter(zpr_addr, CounterType::NodeConnectionsFailed)
-        .unwrap_or(0)
-        + counters
-            .get_node_counter(zpr_addr, CounterType::NodeConnectionsSuccess)
-            .unwrap_or(0);
     let approved_vreqs = counters
         .get_node_counter(zpr_addr, CounterType::VisaRequestsApproved)
         .unwrap_or(0);
     let denied_vreqs = counters
         .get_node_counter(zpr_addr, CounterType::VisaRequestsDenied)
         .unwrap_or(0);
-    let last_vreq = match rstate.asm.counters.get_last_request_time(zpr_addr) {
-        Some(st) => Some(st.duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs() as i64),
-        None => None,
+    let last_vreq = match counters.get_last_request_time(zpr_addr) {
+        Some(st) => st.duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs() as i64,
+        None => 0,
     };
     let adapters = actor_mgr
         .get_adapter_cns_connected_to_node(zpr_addr)
@@ -507,8 +502,8 @@ async fn build_node_record_brief(
         .get_pending_visa_ids_for_node(zpr_addr)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    let revocations_enqueued_count = visa_mgr
-        .num_pending_revokes(zpr_addr)
+    let pending_revocation = visa_mgr
+        .get_num_pending_revoked_visas(zpr_addr)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     let (vss_port, in_sync) = match actor_mgr
@@ -521,10 +516,10 @@ async fn build_node_record_brief(
     };
 
     Ok(NodeRecordBrief {
-        pending,
-        last_contact: Some(0), // TODO don't think we currently store last contact
+        pending_install,
+        last_contact: 0, // TODO don't think we currently store last contact
         visa_requests,
-        connect_requests,
+        connect_requests: 0, // TODO blocked on tracking calls to authorize_connect
         in_sync,
         approved_vreqs,
         denied_vreqs,
@@ -533,7 +528,7 @@ async fn build_node_record_brief(
         links: Vec::new(), // TODO blocked on multi-node support
         visas,
         visas_enqueued,
-        revocations_enqueued_count,
+        pending_revocation,
         vss_port,
     })
 }

--- a/vs/src/counters.rs
+++ b/vs/src/counters.rs
@@ -35,6 +35,13 @@ impl Counters {
         self.per_node_counters.remove(node);
     }
 
+    pub fn get_node_counter(&self, node: &IpAddr, c: CounterType) -> Option<u64> {
+        match self.per_node_counters.get(node) {
+            Some(node_info) => Some(node_info.value().counters[c].get_count()),
+            None => None,
+        }
+    }
+
     pub fn update_request_time(&self, node: &IpAddr) {
         self.per_node_counters
             .entry(*node)

--- a/vs/src/db/visa.rs
+++ b/vs/src/db/visa.rs
@@ -319,6 +319,64 @@ impl VisaRepo {
         Ok(visas)
     }
 
+    /// Get the visa IDs for a node filtered by state, without loading the visa blobs.
+    pub async fn get_visa_ids_for_node_by_state(
+        &self,
+        node_addr: &IpAddr,
+        state: NodeVisaState,
+    ) -> Result<Vec<u64>, StoreError> {
+        let zaddr = ZAddr::from(node_addr);
+        let mut visa_ids = Vec::new();
+
+        let vkeys = self
+            .db
+            .scan_match_all(format!("{KEY_NODEVISA}:{zaddr}:*"))
+            .await?;
+
+        for key in &vkeys {
+            let state_str: String = self.db.hget(key, "state").await?.unwrap_or_default();
+            let entry_state: NodeVisaState = serde_json::from_str(&state_str)?;
+            if entry_state == state {
+                let parts: Vec<&str> = key.rsplitn(2, ':').collect();
+                if parts.len() != 2 {
+                    warn!(target: DB, "malformed nodevisa key: {}", key);
+                    continue;
+                }
+                let visa_id: u64 = parts[0].parse().map_err(|_| {
+                    StoreError::InvalidData(format!("invalid visa ID in nodevisa key: {}", key))
+                })?;
+                visa_ids.push(visa_id);
+            }
+        }
+
+        Ok(visa_ids)
+    }
+
+    /// Count the number of visas for a node that are in the given state.
+    pub async fn get_count_visas_for_node_by_state(
+        &self,
+        node_addr: &IpAddr,
+        state: NodeVisaState,
+    ) -> Result<u32, StoreError> {
+        let zaddr = ZAddr::from(node_addr);
+        let mut count = 0;
+
+        let vkeys = self
+            .db
+            .scan_match_all(format!("{KEY_NODEVISA}:{zaddr}:*"))
+            .await?;
+
+        for key in &vkeys {
+            let state_str: String = self.db.hget(key, "state").await?.unwrap_or_default();
+            let entry_state: NodeVisaState = serde_json::from_str(&state_str)?;
+            if entry_state == state {
+                count += 1;
+            }
+        }
+
+        Ok(count)
+    }
+
     /// Get the visa by ID.
     ///
     /// ## Errors
@@ -725,5 +783,49 @@ mod test {
             let decoded: VisaMetadata = serde_json::from_str(&json).unwrap();
             assert_eq!(decoded.direction, direction);
         }
+    }
+
+    #[tokio::test]
+    async fn test_get_visa_ids_for_node_by_state_filters_correctly() {
+        let db = Arc::new(FakeDb::new());
+        let repo = VisaRepo::new(db, 1).await.unwrap();
+        let node_addr: IpAddr = "fd5a:5052::20".parse().unwrap();
+
+        let visa_a = make_visa(10, Duration::from_secs(60));
+        let visa_b = make_visa(11, Duration::from_secs(60));
+
+        let metadata_a = VisaMetadata::new(node_addr, 0, String::new(), Direction::Forward);
+        repo.store_visa(&visa_a, metadata_a, NodeVisaState::PendingInstall)
+            .await
+            .unwrap();
+
+        let metadata_b = VisaMetadata::new(node_addr, 0, String::new(), Direction::Forward);
+        repo.store_visa(&visa_b, metadata_b, NodeVisaState::Installed)
+            .await
+            .unwrap();
+
+        let pending_ids = repo
+            .get_visa_ids_for_node_by_state(&node_addr, NodeVisaState::PendingInstall)
+            .await
+            .unwrap();
+        let pending_len = repo
+            .get_count_visas_for_node_by_state(&node_addr, NodeVisaState::PendingInstall)
+            .await
+            .unwrap();
+        assert_eq!(pending_len, 1);
+        assert_eq!(pending_ids.len(), 1);
+        assert_eq!(pending_ids[0], 10);
+
+        let installed_ids = repo
+            .get_visa_ids_for_node_by_state(&node_addr, NodeVisaState::Installed)
+            .await
+            .unwrap();
+        let installed_len = repo
+            .get_count_visas_for_node_by_state(&node_addr, NodeVisaState::PendingInstall)
+            .await
+            .unwrap();
+        assert_eq!(installed_len, 1);
+        assert_eq!(installed_ids.len(), 1);
+        assert_eq!(installed_ids[0], 11);
     }
 }

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -228,6 +228,50 @@ impl VisaMgr {
         Ok(visas)
     }
 
+    pub async fn get_pending_visa_ids_for_node(
+        &self,
+        node_addr: &IpAddr,
+    ) -> Result<Vec<u64>, ServiceError> {
+        Ok(self
+            .get_pending_visas_for_node(node_addr)
+            .await?
+            .iter()
+            .map(|v| v.issuer_id)
+            .collect())
+    }
+
+    pub async fn get_installed_visas_for_node(
+        &self,
+        node_addr: &IpAddr,
+    ) -> Result<Vec<Visa>, ServiceError> {
+        let visas = self
+            .repo
+            .get_visas_for_node_by_state(node_addr, db::NodeVisaState::Installed)
+            .await?;
+        Ok(visas)
+    }
+
+    pub async fn get_installed_visa_ids_for_node(
+        &self,
+        node_addr: &IpAddr,
+    ) -> Result<Vec<u64>, ServiceError> {
+        Ok(self
+            .get_installed_visas_for_node(node_addr)
+            .await?
+            .iter()
+            .map(|v| v.issuer_id)
+            .collect())
+    }
+
+    pub async fn num_pending_revokes(&self, node_addr: &IpAddr) -> Result<u64, ServiceError> {
+        let pending_revokes = self
+            .repo
+            .get_visas_for_node_by_state(node_addr, db::NodeVisaState::PendingRevoke)
+            .await?
+            .len();
+        Ok(pending_revokes as u64)
+    }
+
     /// Register that visa `visa_id` has been installed on node at ZPR address `node_addr`.
     pub async fn visa_installed(
         &self,

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -250,44 +250,44 @@ impl VisaMgr {
         &self,
         node_addr: &IpAddr,
     ) -> Result<Vec<u64>, ServiceError> {
-        Ok(self
-            .get_pending_visas_for_node(node_addr)
-            .await?
-            .iter()
-            .map(|v| v.issuer_id)
-            .collect())
-    }
-
-    pub async fn get_installed_visas_for_node(
-        &self,
-        node_addr: &IpAddr,
-    ) -> Result<Vec<Visa>, ServiceError> {
-        let visas = self
+        let visa_ids = self
             .repo
-            .get_visas_for_node_by_state(node_addr, db::NodeVisaState::Installed)
+            .get_visa_ids_for_node_by_state(node_addr, db::NodeVisaState::PendingInstall)
             .await?;
-        Ok(visas)
+        Ok(visa_ids)
     }
 
     pub async fn get_installed_visa_ids_for_node(
         &self,
         node_addr: &IpAddr,
     ) -> Result<Vec<u64>, ServiceError> {
-        Ok(self
-            .get_installed_visas_for_node(node_addr)
-            .await?
-            .iter()
-            .map(|v| v.issuer_id)
-            .collect())
+        let visa_ids = self
+            .repo
+            .get_visa_ids_for_node_by_state(node_addr, db::NodeVisaState::Installed)
+            .await?;
+        Ok(visa_ids)
     }
 
-    pub async fn num_pending_revokes(&self, node_addr: &IpAddr) -> Result<u64, ServiceError> {
+    pub async fn get_num_pending_install_visas(
+        &self,
+        node_addr: &IpAddr,
+    ) -> Result<u32, ServiceError> {
         let pending_revokes = self
             .repo
-            .get_visas_for_node_by_state(node_addr, db::NodeVisaState::PendingRevoke)
-            .await?
-            .len();
-        Ok(pending_revokes as u64)
+            .get_count_visas_for_node_by_state(node_addr, db::NodeVisaState::PendingInstall)
+            .await?;
+        Ok(pending_revokes)
+    }
+
+    pub async fn get_num_pending_revoked_visas(
+        &self,
+        node_addr: &IpAddr,
+    ) -> Result<u32, ServiceError> {
+        let pending_revokes = self
+            .repo
+            .get_count_visas_for_node_by_state(node_addr, db::NodeVisaState::PendingRevoke)
+            .await?;
+        Ok(pending_revokes)
     }
 
     /// Register that visa `visa_id` has been installed on node at ZPR address `node_addr`.


### PR DESCRIPTION
Populated the `NodeRecordBrief` struct in the `admin_service::get_actor` using a mix of new and existing functions.

Added new functions to get information needed for the `NodeRecordBrief`
- `actor_mgr::get_adapter_cns_connected_to_node`, including Claude-generated unit tests - gets all the CNs of the adapters connected to a given node
- `counters::get_node_counter` - to read individual node counts
- `visa_mgr::get_pending_visa_ids_for_node` - returns `Vec<String>` or error
- `visa_mgr::get_installed_visas_for_node` - returns `Vec<Visa>` or error
- `visa_mgr::get_installed_visa_ids_for_node` - returns `Vec<String>` or error
Also updated some of the types of values in `NodeRecordBrief` to more accurately reflect the types within the rest of the code.

`links` are left unfilled because we do not yet support multi-node