### PR TITLE
session key to visa descriptor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,12 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 name = "admin-api-types"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "chrono",
  "colored",
  "reqwest",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/admin-api-types/Cargo.toml
+++ b/admin-api-types/Cargo.toml
@@ -8,3 +8,5 @@ chrono.workspace = true
 colored.workspace = true
 reqwest.workspace = true
 serde.workspace = true
+serde_json.workspace = true
+base64 = "0.22"

--- a/admin-api-types/src/admin_api_types.rs
+++ b/admin-api-types/src/admin_api_types.rs
@@ -87,6 +87,7 @@ pub struct VisaDescriptor {
     pub dest_port: u16,
     pub proto: String,
     pub signals: Vec<String>,
+    pub session_key: ApiKeySet,
 }
 
 impl PartialEq for VisaDescriptor {
@@ -161,6 +162,21 @@ impl fmt::Display for VisaDescriptor {
 
         Ok(())
     }
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct ApiKeySet {
+    pub format: ApiKeyFormat,
+    /// session key encrypted for ingress node to read
+    pub ingress_key: Vec<u8>,
+    /// session key encrypted for egress node to read
+    pub egress_key: Vec<u8>,
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub enum ApiKeyFormat {
+    #[default]
+    ZprKF01,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/admin-api-types/src/admin_api_types.rs
+++ b/admin-api-types/src/admin_api_types.rs
@@ -159,24 +159,72 @@ impl fmt::Display for VisaDescriptor {
         if !self.signals.is_empty() {
             write!(f, "  {} [{}]", "signals".dimmed(), self.signals.join(", "))?;
         }
+        write!(
+            f,
+            "{} {}",
+            "session_key ".dimmed(),
+            self.session_key,
+        )?;
 
         Ok(())
     }
 }
 
+// intentionally match the zpr::vsapi_types KeySet and KeyFormat, but 
+// reproduced here to prevent coupling of the API types from the internal types
 #[derive(Default, Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct ApiKeySet {
     pub format: ApiKeyFormat,
     /// session key encrypted for ingress node to read
+    #[serde(with = "base64_serde")]
     pub ingress_key: Vec<u8>,
     /// session key encrypted for egress node to read
+    #[serde(with = "base64_serde")]
     pub egress_key: Vec<u8>,
+}
+
+// Due to encryption, didn't want to leak too much information in the display, 
+// so only have the length of the keys
+impl fmt::Display for ApiKeySet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "[format: {}] [ingress_key: {}B] [egress_key: {}B)",
+            self.format,
+            self.ingress_key.len(),
+            self.egress_key.len()
+        )
+    }
 }
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub enum ApiKeyFormat {
     #[default]
     ZprKF01,
+}
+
+impl fmt::Display for ApiKeyFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ApiKeyFormat::ZprKF01 => write!(f, "ZprKF01"),
+        }
+    }
+}
+
+// Allows ingress_key and egress_key to be serialized as b64 encoded text, not as 
+// vectors, which would be more unwieldy
+mod base64_serde {
+    use base64::{engine::general_purpose::STANDARD, Engine};
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(bytes: &Vec<u8>, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&STANDARD.encode(bytes))
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
+        let s = String::deserialize(d)?;
+        STANDARD.decode(s).map_err(serde::de::Error::custom)
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -579,5 +627,45 @@ pub struct CnEntry {
 impl fmt::Display for CnEntry {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{} {}", format!("{}", "cn".dimmed()), self.cn)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn api_keyset_serializes_keys_as_base64() {
+        let ks = ApiKeySet {
+            format: ApiKeyFormat::ZprKF01,
+            ingress_key: vec![0xDE, 0xAD, 0xBE, 0xEF],
+            egress_key: vec![0xCA, 0xFE, 0xBA, 0xBE],
+        };
+
+        let json = serde_json::to_string(&ks).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        // Confirm they're strings, not arrays
+        assert!(v["ingress_key"].is_string());
+        assert!(v["egress_key"].is_string());
+
+        // Confirm the actual base64 values
+        assert_eq!(v["ingress_key"].as_str().unwrap(), "3q2+7w==");
+        assert_eq!(v["egress_key"].as_str().unwrap(), "yv66vg==");
+    }
+
+    #[test]
+    fn api_keyset_roundtrips_through_json() {
+        let original = ApiKeySet {
+            format: ApiKeyFormat::ZprKF01,
+            ingress_key: vec![0x01, 0x02, 0x03],
+            egress_key: vec![0xFF, 0xFE, 0xFD],
+        };
+
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: ApiKeySet = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(original, decoded);
     }
 }

--- a/admin-api-types/src/admin_api_types.rs
+++ b/admin-api-types/src/admin_api_types.rs
@@ -159,18 +159,13 @@ impl fmt::Display for VisaDescriptor {
         if !self.signals.is_empty() {
             write!(f, "  {} [{}]", "signals".dimmed(), self.signals.join(", "))?;
         }
-        write!(
-            f,
-            "{} {}",
-            "session_key ".dimmed(),
-            self.session_key,
-        )?;
+        write!(f, "{} {}", "session_key ".dimmed(), self.session_key,)?;
 
         Ok(())
     }
 }
 
-// intentionally match the zpr::vsapi_types KeySet and KeyFormat, but 
+// intentionally match the zpr::vsapi_types KeySet and KeyFormat, but
 // reproduced here to prevent coupling of the API types from the internal types
 #[derive(Default, Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct ApiKeySet {
@@ -183,13 +178,13 @@ pub struct ApiKeySet {
     pub egress_key: Vec<u8>,
 }
 
-// Due to encryption, didn't want to leak too much information in the display, 
+// Due to encryption, didn't want to leak too much information in the display,
 // so only have the length of the keys
 impl fmt::Display for ApiKeySet {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "[format: {}] [ingress_key: {}B] [egress_key: {}B)",
+            "[format: {}] [ingress_key: {}B] [egress_key: {}B]",
             self.format,
             self.ingress_key.len(),
             self.egress_key.len()
@@ -211,10 +206,10 @@ impl fmt::Display for ApiKeyFormat {
     }
 }
 
-// Allows ingress_key and egress_key to be serialized as b64 encoded text, not as 
+// Allows ingress_key and egress_key to be serialized as b64 encoded text, not as
 // vectors, which would be more unwieldy
 mod base64_serde {
-    use base64::{engine::general_purpose::STANDARD, Engine};
+    use base64::{Engine, engine::general_purpose::STANDARD};
     use serde::{Deserialize, Deserializer, Serializer};
 
     pub fn serialize<S: Serializer>(bytes: &Vec<u8>, s: S) -> Result<S::Ok, S::Error> {

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -25,7 +25,7 @@ use hyper::body::Incoming;
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use tower_service::Service;
 
-use zpr::vsapi_types::{DockPep, Visa};
+use zpr::vsapi_types::{DockPep, KeyFormat, KeySet, Visa};
 
 use rustls::ServerConfig;
 use rustls::pki_types::PrivateKeyDer;
@@ -42,8 +42,8 @@ use crate::db::Role;
 use crate::logging::targets::ADMIN;
 
 use admin_api_types::{
-    ActorDescriptor, AuthRevokeDescriptor, CnEntry, ListEntry, NamedListEntry, NodeRecordBrief,
-    PolicyBundle, Revokes, ServiceDescriptor, VisaDescriptor,
+    ActorDescriptor, ApiKeyFormat, ApiKeySet, AuthRevokeDescriptor, CnEntry, ListEntry,
+    NamedListEntry, NodeRecordBrief, PolicyBundle, Revokes, ServiceDescriptor, VisaDescriptor,
 };
 
 // Must use tokio RwLock here becuase we need state to be Send.
@@ -334,6 +334,7 @@ async fn get_visa(
                     dest_port: proto_deets.dest_port,
                     proto: proto_deets.protocol,
                     signals: metadata.signal_msgs.clone(),
+                    session_key: to_api_keyset(&visa.session_key),
                 };
                 return Ok(Json(vd));
             }
@@ -636,6 +637,20 @@ async fn add_revoke(EPath(id): EPath<String>) -> impl IntoResponse {
 
     let le = ListEntry { id: 0 };
     (StatusCode::OK, Json(le)).into_response()
+}
+
+fn to_api_keyset(ks: &KeySet) -> ApiKeySet {
+    ApiKeySet {
+        format: to_api_keyformat(&ks.format),
+        ingress_key: ks.ingress_key.clone(),
+        egress_key: ks.egress_key.clone(),
+    }
+}
+
+fn to_api_keyformat(kf: &KeyFormat) -> ApiKeyFormat {
+    match kf {
+        KeyFormat::ZprKF01 => ApiKeyFormat::ZprKF01,
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR exposes session keys in the admin API's visa endpoint. Specifically:
A new `ApiKeySet` type (with an `ApiKeyFormat` enum) is added to `admin-api-types`, mirroring the internal `KeySet`/`KeyFormat` types to keep the API boundary decoupled. The `VisaDescriptor` gains a `session_key` field populated via a conversion layer in `admin_service`. The encrypted key bytes are serialized as base64 strings rather than JSON integer arrays, using a custom `serde` module. Display impls are careful not to leak key material, showing only the format and byte lengths. Unit tests confirm the base64 wire format and round-trip correctness.