### PR TITLE
i64 for unix seconds to systemtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3740,6 +3740,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
+ "serde_with",
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ rand = "0.9.2"
 reqwest = "0.13.1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
+serde_with = { version = "3.18.0", default-features = false, features = ["std", "macros", "base64", "chrono"] }
 thiserror = "2.0.18"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.20"

--- a/admin-api-types/Cargo.toml
+++ b/admin-api-types/Cargo.toml
@@ -9,4 +9,4 @@ colored.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-serde_with = { version = "3.18.0", default-features = false, features = ["std", "macros", "base64", "chrono"] }
+serde_with.workspace = true

--- a/admin-api-types/src/admin_api_types.rs
+++ b/admin-api-types/src/admin_api_types.rs
@@ -64,14 +64,17 @@ impl fmt::Display for VisaMatchDirection {
     }
 }
 
+#[serde_as]
 #[derive(Serialize, Debug, Deserialize, Eq)]
 pub struct VisaDescriptor {
     /// Policy reported version number
     pub id: u64,
     #[serde(rename = "expires")]
-    pub expires_secs: u64, // seconds since the epoch
+    #[serde_as(as = "TimestampSeconds<i64>")]
+    pub expires_secs: SystemTime,
     #[serde(rename = "created")]
-    pub created_secs: u64, // seconds since the epoch
+    #[serde_as(as = "TimestampSeconds<i64>")]
+    pub created_secs: SystemTime,
     pub policy_id: String,
     pub zpl: String,
     pub direction: VisaMatchDirection,
@@ -106,10 +109,9 @@ impl PartialOrd for VisaDescriptor {
 impl fmt::Display for VisaDescriptor {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let now = Utc::now();
-        let dt_exp: DateTime<Utc> =
-            DateTime::from_timestamp(self.expires_secs as i64, 0).unwrap_or(DateTime::UNIX_EPOCH);
-        let dt_created: DateTime<Utc> =
-            DateTime::from_timestamp(self.created_secs as i64, 0).unwrap_or(DateTime::UNIX_EPOCH);
+        let dt_exp: DateTime<Utc> = self.expires_secs.into();
+        let dt_created: DateTime<Utc> = self.created_secs.into();
+
         let remain = dt_exp.signed_duration_since(now);
 
         write!(f, "{} {}  ", "id:".dimmed(), self.id)?;
@@ -217,16 +219,19 @@ impl fmt::Display for Revokes {
     }
 }
 
+#[serde_as]
 #[derive(Debug, Serialize, Deserialize, Eq)]
 pub struct ActorDescriptor {
     pub cn: String,
     #[serde(rename = "created")]
-    pub ctime_secs: u64, // seconds since the epoch
+    #[serde_as(as = "TimestampSeconds<i64>")]
+    pub ctime_secs: SystemTime,
     pub ident: String,
     pub node: bool,
     pub zpr_addr: String,
     pub attrs: Vec<ApiAttribute>,
-    pub auth_exp: Option<u64>, // seconds since epoch
+    #[serde_as(as = "Option<TimestampSeconds<i64>>")]
+    pub auth_exp: Option<SystemTime>,
     pub node_details: Option<NodeRecordBrief>,
 }
 
@@ -250,12 +255,9 @@ impl PartialOrd for ActorDescriptor {
 
 impl fmt::Display for ActorDescriptor {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let ts: DateTime<Utc> =
-            DateTime::from_timestamp(self.ctime_secs as i64, 0).unwrap_or(DateTime::UNIX_EPOCH);
+        let ts: DateTime<Utc> = self.ctime_secs.into();
         let auth_exp = match self.auth_exp {
-            Some(ae) => {
-                Some(DateTime::from_timestamp(ae as i64, 0).unwrap_or(DateTime::UNIX_EPOCH))
-            }
+            Some(ae) => Some(DateTime::<Utc>::from(ae)),
             None => None,
         };
         write!(
@@ -335,10 +337,12 @@ impl fmt::Display for ServiceDescriptor {
     }
 }
 
+#[serde_as]
 #[derive(Debug, Serialize, Deserialize, Eq)]
 #[allow(dead_code)]
 pub struct HostRecordBrief {
-    pub ctime: i64, // unix SECONDS (not millis)
+    #[serde_as(as = "TimestampSeconds<i64>")]
+    pub ctime: SystemTime,
     pub cn: String,
     pub zpr_addr: String,
     pub ident: String,
@@ -365,8 +369,7 @@ impl PartialOrd for HostRecordBrief {
 
 impl fmt::Display for HostRecordBrief {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let ts: DateTime<Utc> =
-            DateTime::from_timestamp(self.ctime, 0).unwrap_or(DateTime::UNIX_EPOCH);
+        let ts: DateTime<Utc> = self.ctime.into();
         writeln!(
             f,
             "{} ({} {}) @ {} {}",
@@ -383,12 +386,14 @@ impl fmt::Display for HostRecordBrief {
     }
 }
 
+#[serde_as]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct NodeRecordBrief {
     // Number of visas pending install on the node
     pub pending_install: u32,
     // Last time node was contacted by the visa service, 0 if there was no contact
-    pub last_contact: Option<i64>, // unix SECONDS
+    #[serde_as(as = "Option<TimestampSeconds<i64>>")]
+    pub last_contact: Option<SystemTime>,
     // Number of visa requests on the node
     pub visa_requests: u64,
     // Number of calls to authorize_connect by the node
@@ -400,7 +405,8 @@ pub struct NodeRecordBrief {
     // Denied visa requests
     pub denied_vreqs: u64,
     // Time of last visa request, 0 if there was no request
-    pub last_vreq: Option<i64>, // unix SECONDS
+    #[serde_as(as = "Option<TimestampSeconds<i64>>")]
+    pub last_vreq: Option<SystemTime>,
     // CNs of all adapters connected to the node
     pub adapters: Vec<String>,
     // CNs of all other nodes connected to the node
@@ -418,11 +424,11 @@ pub struct NodeRecordBrief {
 impl fmt::Display for NodeRecordBrief {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let last_contact = match self.last_contact {
-            Some(lc) => Some(DateTime::from_timestamp(lc, 0).unwrap_or(DateTime::UNIX_EPOCH)),
+            Some(lc) => Some(DateTime::<Utc>::from(lc)),
             None => None,
         };
         let last_vreq = match self.last_vreq {
-            Some(lr) => Some(DateTime::from_timestamp(lr, 0).unwrap_or(DateTime::UNIX_EPOCH)),
+            Some(lr) => Some(DateTime::<Utc>::from(lr)),
             None => None,
         };
         write!(
@@ -507,10 +513,12 @@ impl fmt::Display for NodeRecordBrief {
     }
 }
 
+#[serde_as]
 #[derive(Debug, Deserialize, Eq)]
 #[allow(dead_code)]
 pub struct ServiceRecord {
-    pub ctime: i64, // unix SECONDS (not millis)
+    #[serde_as(as = "TimestampSeconds<i64>")]
+    pub ctime: SystemTime,
     pub cn: String,
     pub zpr_addr: String,
     pub ident: String,

--- a/admin-api-types/src/admin_api_types.rs
+++ b/admin-api-types/src/admin_api_types.rs
@@ -69,12 +69,10 @@ impl fmt::Display for VisaMatchDirection {
 pub struct VisaDescriptor {
     /// Policy reported version number
     pub id: u64,
-    #[serde(rename = "expires")]
     #[serde_as(as = "TimestampSeconds<i64>")]
-    pub expires_secs: SystemTime,
-    #[serde(rename = "created")]
+    pub expires: SystemTime,
     #[serde_as(as = "TimestampSeconds<i64>")]
-    pub created_secs: SystemTime,
+    pub created: SystemTime,
     pub policy_id: String,
     pub zpl: String,
     pub direction: VisaMatchDirection,
@@ -109,8 +107,8 @@ impl PartialOrd for VisaDescriptor {
 impl fmt::Display for VisaDescriptor {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let now = Utc::now();
-        let dt_exp: DateTime<Utc> = self.expires_secs.into();
-        let dt_created: DateTime<Utc> = self.created_secs.into();
+        let dt_exp: DateTime<Utc> = self.expires.into();
+        let dt_created: DateTime<Utc> = self.created.into();
 
         let remain = dt_exp.signed_duration_since(now);
 
@@ -225,7 +223,7 @@ pub struct ActorDescriptor {
     pub cn: String,
     #[serde(rename = "created")]
     #[serde_as(as = "TimestampSeconds<i64>")]
-    pub ctime_secs: SystemTime,
+    pub ctime: SystemTime,
     pub ident: String,
     pub node: bool,
     pub zpr_addr: String,
@@ -255,7 +253,7 @@ impl PartialOrd for ActorDescriptor {
 
 impl fmt::Display for ActorDescriptor {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let ts: DateTime<Utc> = self.ctime_secs.into();
+        let ts: DateTime<Utc> = self.ctime.into();
         let auth_exp = match self.auth_exp {
             Some(ae) => Some(DateTime::<Utc>::from(ae)),
             None => None,
@@ -404,7 +402,7 @@ pub struct NodeRecordBrief {
     pub approved_vreqs: u64,
     // Denied visa requests
     pub denied_vreqs: u64,
-    // Time of last visa request, 0 if there was no request
+    // Time of last visa request, None if there was no request
     #[serde_as(as = "Option<TimestampSeconds<i64>>")]
     pub last_vreq: Option<SystemTime>,
     // CNs of all adapters connected to the node
@@ -702,6 +700,139 @@ mod tests {
         let json = serde_json::to_string(&original).unwrap();
         let decoded: ApiAttribute = serde_json::from_str(&json).unwrap();
 
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn visa_descriptor_serializes_timestamps_as_integer_seconds() {
+        let vd = VisaDescriptor {
+            id: 42,
+            expires: SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(9000),
+            created: SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1000),
+            policy_id: "pol".to_string(),
+            zpl: "zpl".to_string(),
+            direction: VisaMatchDirection::Forward,
+            requesting_node: "fd5a::1".to_string(),
+            source_addr: "fd5a::2".to_string(),
+            dest_addr: "fd5a::3".to_string(),
+            source_port: 80,
+            dest_port: 443,
+            proto: "TCP".to_string(),
+            signals: vec![],
+            session_key: ApiKeySet::default(),
+        };
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&vd).unwrap()).unwrap();
+        assert_eq!(v["expires"].as_i64().unwrap(), 9000);
+        assert_eq!(v["created"].as_i64().unwrap(), 1000);
+    }
+
+    #[test]
+    fn visa_descriptor_deserializes_timestamps_from_integer_seconds() {
+        let json = r#"{
+            "id": 1, "expires": 9000, "created": 1000,
+            "policy_id": "p", "zpl": "z", "direction": "forward",
+            "requesting_node": "fd5a::1", "source_addr": "fd5a::2", "dest_addr": "fd5a::3",
+            "source_port": 80, "dest_port": 443, "proto": "TCP", "signals": [],
+            "session_key": {"format": "ZprKF01", "ingress_key": "AAEC", "egress_key": "AAEC"}
+        }"#;
+        let vd: VisaDescriptor = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            vd.expires,
+            SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(9000)
+        );
+        assert_eq!(
+            vd.created,
+            SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1000)
+        );
+    }
+
+    #[test]
+    fn actor_descriptor_serializes_timestamps_as_integer_seconds() {
+        let ad = ActorDescriptor {
+            cn: "test.cn".to_string(),
+            ctime: SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(5000),
+            ident: "ident".to_string(),
+            node: false,
+            zpr_addr: "fd5a::1".to_string(),
+            attrs: vec![],
+            auth_exp: Some(SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(7000)),
+            node_details: None,
+        };
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&ad).unwrap()).unwrap();
+        assert_eq!(v["created"].as_i64().unwrap(), 5000);
+        assert_eq!(v["auth_exp"].as_i64().unwrap(), 7000);
+    }
+
+    #[test]
+    fn actor_descriptor_none_auth_exp_serializes_as_null() {
+        let ad = ActorDescriptor {
+            cn: "test.cn".to_string(),
+            ctime: SystemTime::UNIX_EPOCH,
+            ident: "ident".to_string(),
+            node: false,
+            zpr_addr: "fd5a::1".to_string(),
+            attrs: vec![],
+            auth_exp: None,
+            node_details: None,
+        };
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&ad).unwrap()).unwrap();
+        assert!(v["auth_exp"].is_null());
+    }
+
+    fn make_node_record_brief(
+        last_contact: Option<SystemTime>,
+        last_vreq: Option<SystemTime>,
+    ) -> NodeRecordBrief {
+        NodeRecordBrief {
+            pending_install: 0,
+            last_contact,
+            visa_requests: 0,
+            connect_requests: 0,
+            in_sync: false,
+            approved_vreqs: 0,
+            denied_vreqs: 0,
+            last_vreq,
+            adapters: vec![],
+            links: vec![],
+            visas: vec![],
+            visas_enqueued: vec![],
+            pending_revocation: 0,
+            vss_port: None,
+        }
+    }
+
+    #[test]
+    fn node_record_brief_serializes_timestamps_as_integer_seconds() {
+        let nb = make_node_record_brief(
+            Some(SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(2000)),
+            Some(SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(3000)),
+        );
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&nb).unwrap()).unwrap();
+        assert_eq!(v["last_contact"].as_i64().unwrap(), 2000);
+        assert_eq!(v["last_vreq"].as_i64().unwrap(), 3000);
+    }
+
+    #[test]
+    fn node_record_brief_none_timestamps_serialize_as_null() {
+        let nb = make_node_record_brief(None, None);
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&nb).unwrap()).unwrap();
+        assert!(v["last_contact"].is_null());
+        assert!(v["last_vreq"].is_null());
+    }
+
+    #[test]
+    fn node_record_brief_roundtrips_through_json() {
+        let original = make_node_record_brief(
+            Some(SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1234567890)),
+            None,
+        );
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: NodeRecordBrief = serde_json::from_str(&json).unwrap();
         assert_eq!(original, decoded);
     }
 }

--- a/vs-admin/src/gui.rs
+++ b/vs-admin/src/gui.rs
@@ -279,7 +279,7 @@ impl Gui {
         let rows = self.actors.iter().map(|actor| {
             let cn = actor.cn.clone();
             let zpr_addr = actor.zpr_addr.clone();
-            let ts: DateTime<Utc> = DateTime::from_timestamp(actor.ctime_secs as i64, 0).unwrap();
+            let ts: DateTime<Utc> = actor.ctime_secs.into();
             let join_date = ts.to_rfc3339_opts(SecondsFormat::Secs, true);
             let flag = if actor.node {
                 "[node]".light_magenta()
@@ -349,7 +349,7 @@ impl Gui {
         }
 
         let rows = self.visas.iter().map(|vrec| {
-            let dt: DateTime<Utc> = DateTime::from_timestamp(vrec.expires_secs as i64, 0).unwrap();
+            let dt: DateTime<Utc> = vrec.expires_secs.into();
 
             let idstr = format!("{}", vrec.id);
             let expstr = dt.to_rfc3339_opts(SecondsFormat::Secs, true);

--- a/vs-admin/src/gui.rs
+++ b/vs-admin/src/gui.rs
@@ -279,7 +279,7 @@ impl Gui {
         let rows = self.actors.iter().map(|actor| {
             let cn = actor.cn.clone();
             let zpr_addr = actor.zpr_addr.clone();
-            let ts: DateTime<Utc> = actor.ctime_secs.into();
+            let ts: DateTime<Utc> = actor.ctime.into();
             let join_date = ts.to_rfc3339_opts(SecondsFormat::Secs, true);
             let flag = if actor.node {
                 "[node]".light_magenta()
@@ -349,7 +349,7 @@ impl Gui {
         }
 
         let rows = self.visas.iter().map(|vrec| {
-            let dt: DateTime<Utc> = vrec.expires_secs.into();
+            let dt: DateTime<Utc> = vrec.expires.into();
 
             let idstr = format!("{}", vrec.id);
             let expstr = dt.to_rfc3339_opts(SecondsFormat::Secs, true);

--- a/vs/Cargo.toml
+++ b/vs/Cargo.toml
@@ -39,6 +39,7 @@ rustls = "0.23.36"
 rustls-pemfile = "2"
 serde.workspace = true
 serde_json.workspace = true
+serde_with.workspace = true
 thiserror.workspace = true
 tokio = { version = "1.48.0", features = ["full", "test-util"] }
 tokio-rustls = "0.26.4"

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -30,7 +30,7 @@ use zpr::vsapi_types::{DockPep, KeyFormat, KeySet, Visa};
 use rustls::ServerConfig;
 use rustls::pki_types::PrivateKeyDer;
 use serde::Deserialize;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 use tokio::net::TcpListener;
 use tokio_rustls::TlsAcceptor;
 
@@ -284,13 +284,6 @@ async fn get_visas(
     }
 }
 
-fn system_time_to_unix_seconds(st: std::time::SystemTime) -> u64 {
-    match st.duration_since(std::time::UNIX_EPOCH) {
-        Ok(dur) => dur.as_secs() as u64,
-        Err(_) => 0,
-    }
-}
-
 async fn get_visa(
     Extension(perm): Extension<Permission>,
     State(state): State<SharedState>,
@@ -316,8 +309,8 @@ async fn get_visa(
 
                 let vd = VisaDescriptor {
                     id: visa.issuer_id,
-                    expires_secs: system_time_to_unix_seconds(visa.expires),
-                    created_secs: metadata.ctime,
+                    expires_secs: visa.expires,
+                    created_secs: SystemTime::UNIX_EPOCH + Duration::from_secs(metadata.ctime),
                     requesting_node: metadata.requesting_node.to_string(),
                     policy_id: metadata.policy_version.to_string(),
                     zpl: metadata.zpl.to_string(),
@@ -445,14 +438,7 @@ async fn get_actor(
 
                 let attrs = actor.attrs_iter().map(|a| to_api_attribute(a)).collect();
 
-                let auth_exp = match actor.get_authentication_expiration() {
-                    Some(st) => Some(
-                        st.duration_since(SystemTime::UNIX_EPOCH)
-                            .unwrap_or_default()
-                            .as_secs(),
-                    ),
-                    None => None,
-                };
+                let auth_exp = actor.get_authentication_expiration();
 
                 let node_details = match is_node {
                     true => Some(build_node_record_brief(&asm, actor).await?),
@@ -461,7 +447,7 @@ async fn get_actor(
 
                 let descriptor = ActorDescriptor {
                     cn: cn.clone(),
-                    ctime_secs: 0, // TODO: Not tracked yet
+                    ctime_secs: SystemTime::UNIX_EPOCH, // TODO: Not tracked yet
                     ident,
                     node: is_node,
                     zpr_addr: zpr_addr_str,
@@ -500,10 +486,7 @@ async fn build_node_record_brief(
     let denied_vreqs = counters
         .get_node_counter(zpr_addr, CounterType::VisaRequestsDenied)
         .unwrap_or(0);
-    let last_vreq = match counters.get_last_request_time(zpr_addr) {
-        Some(st) => Some(st.duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs() as i64),
-        None => None,
-    };
+    let last_vreq = counters.get_last_request_time(zpr_addr);
     let adapters = actor_mgr
         .get_adapter_cns_connected_to_node(zpr_addr)
         .await

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -30,7 +30,7 @@ use zpr::vsapi_types::{DockPep, KeyFormat, KeySet, Visa};
 use rustls::ServerConfig;
 use rustls::pki_types::PrivateKeyDer;
 use serde::Deserialize;
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 use tokio::net::TcpListener;
 use tokio_rustls::TlsAcceptor;
 
@@ -309,8 +309,8 @@ async fn get_visa(
 
                 let vd = VisaDescriptor {
                     id: visa.issuer_id,
-                    expires_secs: visa.expires,
-                    created_secs: SystemTime::UNIX_EPOCH + Duration::from_secs(metadata.ctime),
+                    expires: visa.expires,
+                    created: metadata.ctime,
                     requesting_node: metadata.requesting_node.to_string(),
                     policy_id: metadata.policy_version.to_string(),
                     zpl: metadata.zpl.to_string(),
@@ -447,7 +447,7 @@ async fn get_actor(
 
                 let descriptor = ActorDescriptor {
                     cn: cn.clone(),
-                    ctime_secs: SystemTime::UNIX_EPOCH, // TODO: Not tracked yet
+                    ctime: SystemTime::UNIX_EPOCH, // TODO: Not tracked yet
                     ident,
                     node: is_node,
                     zpr_addr: zpr_addr_str,

--- a/vs/src/db/visa.rs
+++ b/vs/src/db/visa.rs
@@ -40,7 +40,7 @@ pub enum NodeVisaState {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VisaMetadata {
     pub requesting_node: IpAddr,
-    pub ctime: u64, // unix timestamp (seconds since epoch)
+    pub ctime: SystemTime,
     pub policy_version: u64,
     pub zpl: String,
     pub signal_msgs: Vec<String>, // note we do not keep the signal destination
@@ -59,10 +59,7 @@ impl VisaMetadata {
     pub fn new(requesting_node: IpAddr, pver: u64, zpl: String, direction: Direction) -> Self {
         VisaMetadata {
             requesting_node,
-            ctime: SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap_or(Duration::ZERO)
-                .as_secs() as u64,
+            ctime: SystemTime::now(),
             policy_version: pver,
             zpl,
             signal_msgs: Vec::new(),
@@ -699,7 +696,7 @@ mod test {
 
         let metadata = repo.get_visa_metadata_by_id(88).await.unwrap();
         assert_eq!(metadata.requesting_node, node_addr);
-        assert!(metadata.ctime > 0);
+        assert!(metadata.ctime > SystemTime::UNIX_EPOCH);
     }
 
     #[tokio::test]
@@ -721,7 +718,7 @@ mod test {
         let node_addr: IpAddr = "fd5a:5052::10".parse().unwrap();
         let original = VisaMetadata {
             requesting_node: node_addr,
-            ctime: 1_700_000_000,
+            ctime: SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000),
             policy_version: 42,
             zpl: "permit src any dst any".to_string(),
             signal_msgs: vec!["sig-a".to_string(), "sig-b".to_string()],
@@ -751,7 +748,7 @@ mod test {
         ];
         let original = VisaMetadata {
             requesting_node: node_addr,
-            ctime: 1_700_000_001,
+            ctime: SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_001),
             policy_version: 1,
             zpl: String::new(),
             signal_msgs: signals.clone(),
@@ -773,7 +770,7 @@ mod test {
         for direction in [Direction::Forward, Direction::Reverse] {
             let original = VisaMetadata {
                 requesting_node: node_addr,
-                ctime: 1_700_000_002,
+                ctime: SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_002),
                 policy_version: 0,
                 zpl: String::new(),
                 signal_msgs: Vec::new(),

--- a/vs/src/db/visa.rs
+++ b/vs/src/db/visa.rs
@@ -16,6 +16,7 @@ use tracing::{debug, error, warn};
 
 use ::zpr::vsapi::v1 as vsapi;
 use libeval::eval_result::Direction;
+use serde_with::{TimestampSeconds, serde_as};
 use zpr::vsapi_types::Visa;
 use zpr::write_to::WriteTo;
 
@@ -37,9 +38,11 @@ pub enum NodeVisaState {
 }
 
 /// Metadata around an issued visa.
+#[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VisaMetadata {
     pub requesting_node: IpAddr,
+    #[serde_as(as = "TimestampSeconds<i64>")]
     pub ctime: SystemTime,
     pub policy_version: u64,
     pub zpl: String,


### PR DESCRIPTION
Replaces `u64`/`i64` unix-second fields across admin API types with `SystemTime`, using `serde_with`'s `TimestampSeconds<i64>` to preserve the JSON wire format (integer seconds since epoch).