### PR TITLE
Mk/196 topo prep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ Rust workspace with main crate `vs` (visa service) and supporting crates:
 - Then run `cargo fmt -- --check` and fix formatting.
 - Run `cargo test` when tests exist or are relevant.
 - For refactors/renames, search usages across all crates in this workspace.
-- If a plan file exists (e.g. `PLAN.md`), follow it exactly unless the user approves scope changes.
+- Never patch a failing test you didn't write unless explicitly told to do so.
+- Any functions written (include tests) should have a brief comment explaining what they do.
 
 ## Project Note
 - ZPR addresses are IPv6 and must use prefix `fd5a:5052`.

--- a/libeval/src/attribute.rs
+++ b/libeval/src/attribute.rs
@@ -56,6 +56,13 @@ pub struct Attribute {
     expires_at: SystemTime,
 }
 
+/// TBD. Placeholder for that which is used to match link attributes based on policy.
+/// For example, a ZPL constrainted attribute might be "location:spain" and in that
+/// case the AttrMatch would indicates that we are looking for a "location"
+/// key with a "spain" value.
+#[derive(Debug, Clone, Serialize, Hash, Eq, PartialEq)]
+pub struct AttrMatch {} // TODO
+
 pub struct AttributeBuilder {
     key: String,
     expires_at: SystemTime,

--- a/libeval/src/attribute.rs
+++ b/libeval/src/attribute.rs
@@ -12,9 +12,6 @@ pub mod key {
     /// used to be called EPID
     pub const ZPR_ADDR: &str = "zpr.addr";
 
-    /// Set to "true" for phantom actors used for performing authentication.
-    pub const ZPR_PHANTOM: &str = "zpr.phantom";
-
     /// Dock ZPR address
     pub const CONNECT_VIA: &str = "zpr.connect_via";
 

--- a/libeval/src/attribute.rs
+++ b/libeval/src/attribute.rs
@@ -12,6 +12,9 @@ pub mod key {
     /// used to be called EPID
     pub const ZPR_ADDR: &str = "zpr.addr";
 
+    /// Set to "true" for phantom actors used for performing authentication.
+    pub const ZPR_PHANTOM: &str = "zpr.phantom";
+
     /// Dock ZPR address
     pub const CONNECT_VIA: &str = "zpr.connect_via";
 

--- a/libeval/src/eval_result.rs
+++ b/libeval/src/eval_result.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-use crate::route::{Route, RouteResidualEvaluator};
+use crate::route::{Route, RoutePredicate, RouteResidualEvaluator};
 
 /// The result of an initial evaluation of policy against a communicating pair of
 /// actors and a description of the packet.  This may need further route-based
@@ -75,6 +75,10 @@ pub struct Hit {
     /// If there is a signal attached to this permission it is returned here.
     pub signal: Option<Signal>,
 
+    /// If the hit includes a route constraint, it is returned here.
+    /// Only used/valid in partial results (from pass 1).
+    pub route_predicate: Option<RoutePredicate>,
+
     /// If this was evaluated over a route it is returned here.
     pub route: Option<Route>,
 }
@@ -98,6 +102,7 @@ impl Hit {
             match_idx: index,
             direction,
             signal: None,
+            route_predicate: None,
             route: None,
         }
     }
@@ -108,6 +113,7 @@ impl Hit {
             match_idx: index,
             direction,
             signal: Some(signal),
+            route_predicate: None,
             route: None,
         }
     }

--- a/libeval/src/eval_result.rs
+++ b/libeval/src/eval_result.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-use crate::route::{Route, RoutePredicate, RouteResidualEvaluator};
+use crate::eval_route::RouteResidualEvaluator;
+use crate::route::{Route, RoutePredicate};
 
 /// The result of an initial evaluation of policy against a communicating pair of
 /// actors and a description of the packet.  This may need further route-based

--- a/libeval/src/eval_result.rs
+++ b/libeval/src/eval_result.rs
@@ -75,7 +75,7 @@ pub struct Hit {
     /// If there is a signal attached to this permission it is returned here.
     pub signal: Option<Signal>,
 
-    /// If this was evaluated a route it is returned here.
+    /// If this was evaluated over a route it is returned here.
     pub route: Option<Route>,
 }
 

--- a/libeval/src/eval_route.rs
+++ b/libeval/src/eval_route.rs
@@ -21,8 +21,8 @@ pub trait TopologyQueryApi {
 #[allow(dead_code)]
 #[derive(Debug)]
 pub struct RouteResidualEvaluator {
-    src_actor: Actor,        // cloned from phase 1
-    dst_actor: Actor,        // cloned from phase 1
+    src_actor: Actor, // cloned from phase 1 (TBD - actually we could just copy over the attrributes that matched policy...)
+    dst_actor: Actor, // cloned from phase 1
     packet_desc: PacketDesc, // cloned from phase 1
     candidate_allow_hits: Vec<Hit>,
     candidate_deny_hits: Vec<Hit>,

--- a/libeval/src/eval_route.rs
+++ b/libeval/src/eval_route.rs
@@ -1,0 +1,107 @@
+//! The second phase policy evaluator which takes route constraints into consideration.
+
+use zpr::vsapi_types::PacketDesc;
+
+use crate::actor::Actor;
+use crate::attribute::AttrMatch;
+use crate::error::EvalError;
+use crate::eval_result::{FinalEvalResult, Hit};
+use crate::route::{LinkId, Route};
+
+/// Simple interface into the ZPR network topology that the route residual evaluator uses
+/// to evaluate routes.
+pub trait TopologyQueryApi {
+    fn link_has_attr(&self, link_id: &LinkId, attr: &AttrMatch) -> bool;
+}
+
+/// This evaluator is returned during policy evaluation if we get hits that depend on
+/// route constraints.
+///
+/// Not implemented yet as we don't even have ZPL for expressing link constraints.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct RouteResidualEvaluator {
+    src_actor: Actor,        // cloned from phase 1
+    dst_actor: Actor,        // cloned from phase 1
+    packet_desc: PacketDesc, // cloned from phase 1
+    candidate_allow_hits: Vec<Hit>,
+    candidate_deny_hits: Vec<Hit>,
+    hint: Option<RouteHint>,
+}
+
+/// An optional route hint can be used by the Router to cull the set of possible routes.
+/// The hint is conservative and may match more routes than are strictly possible by policy.
+/// Not all policies will be able to provide a hint, and in that case all routes need
+/// to be evaluated.
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct RouteHint {
+    /// No links at all (direct connection between source and destination).
+    pub direct_only: bool,
+
+    /// Must have links (i.e. cannot be direct).
+    pub require_linked_path: bool,
+
+    /// Route is candidate if any link on the path matches
+    pub any_link_has: Vec<AttrMatch>,
+
+    /// Route is candidate if no link on the path matches
+    pub no_link_has: Vec<AttrMatch>,
+
+    /// Route is candidate if all links on the path match
+    pub all_links_have: Vec<AttrMatch>,
+}
+
+impl RouteResidualEvaluator {
+    /// An optional coarse hint that can be used to prune routes.
+    pub fn hint(&self) -> Option<&RouteHint> {
+        self.hint.as_ref()
+    }
+
+    /// Evaluate a single candidate route against policy.
+    ///
+    /// We have previously done an eval call on the EvalContext. So we know that the actors
+    /// match.  But we may still need to hold on to the relevant actor attributes to make
+    /// the evaluation.  The assumption is that everything we need in the residual is populated
+    /// in it when it is created.
+    ///
+    /// Example:
+    ///    allow admins to access services over secure links.
+    ///    allow employees to access services. # implied: over any link.
+    ///    never allow admins to access services over insecure links.
+    ///
+    /// When this is called with a route to "services" over "insecure" link.
+    /// We need to know if the actor is an admin or just an employee.
+    pub fn eval_route(
+        &self,
+        _route: &Route,
+        _topology: &impl TopologyQueryApi,
+    ) -> Result<FinalEvalResult, EvalError> {
+        Err(EvalError::InternalError(
+            "route evaluation not implemented".to_string(),
+        ))
+
+        // General approach idea:
+        // - For each deny candidate hit evaluate its RoutePredicate against the route and re-check any actor condifitions
+        //   using our cached actors.  If any deny fires this will be a deny (but I think we want to return ALL the denies that fire).
+        // - For each allow candidate hit evaluate its RoutePredicate as above, collect any passing hits and return an allow.
+        // - Else a deny with NO MATCH.
+    }
+
+    /// Evaluate multiple candidate routes against policy.
+    ///
+    /// This is a helper that just calls eval_route for each route and then combines the results.
+    /// The final result is deny if any of the routes deny, and allow if any of the routes allow, else a deny with NO MATCH.
+    ///
+    /// I think we want the VS to use this function so that we can centralize the policy picking logic here.
+    ///
+    /// TODO: Consider maing `eval_route` private and only exposing this function.
+    pub fn eval_routes(
+        &self,
+        _routes: &[Route],
+        _topology: &impl TopologyQueryApi,
+    ) -> Result<FinalEvalResult, EvalError> {
+        Err(EvalError::InternalError(
+            "route evaluation not implemented".to_string(),
+        ))
+    }
+}

--- a/libeval/src/lib.rs
+++ b/libeval/src/lib.rs
@@ -3,6 +3,7 @@ pub mod attribute;
 pub mod error;
 pub mod eval;
 pub mod eval_result;
+pub mod eval_route;
 pub mod joinpolicy;
 pub mod logging;
 pub mod pio;

--- a/libeval/src/route.rs
+++ b/libeval/src/route.rs
@@ -1,20 +1,10 @@
 use serde::Serialize;
 use std::net::IpAddr;
 
-use crate::error::EvalError;
-use crate::eval_result::FinalEvalResult;
-
-#[derive(Debug)]
-pub struct RouteResidualEvaluator {
-    predicate: RoutePredicate,
-    hint: Option<RouteHint>,
-}
-
-#[derive(Debug, Clone, Serialize, Hash, Eq, PartialEq)]
-pub struct AttrMatch {} // TODO
+use crate::attribute::AttrMatch;
 
 // Answers the question: "Is this route allowed?".
-// Note these are extracted from policy duing first pass.
+// Note these are extracted from policy duing first pass and attached to hits.
 //
 // TODO: Investigate why we really need Serialize on this. Is it for ZPT?
 #[derive(Debug, Serialize)]
@@ -29,38 +19,12 @@ pub enum RoutePredicate {
     Or(Vec<RoutePredicate>),
 }
 
-/// An optional route hint can be used by the Router to cull the set of possible routes.
-/// The hint is conservative and may match more routes than are strictly possible by policy.
-/// Not all policies will be able to provide a hint, and in that case all routes need
-/// to be evaluated.
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
-pub struct RouteHint {
-    /// No links at all (direct connection between source and destination).
-    pub direct_only: bool,
-
-    /// Must have links (i.e. cannot be direct).
-    pub require_linked_path: bool,
-
-    /// Route is candidate if any link on the path matches
-    pub any_link_has: Vec<AttrMatch>,
-
-    /// Route is candidate if no link on the path matches
-    pub no_link_has: Vec<AttrMatch>,
-
-    /// Route is candidate if all links on the path match
-    pub all_links_have: Vec<AttrMatch>,
-}
-
-/// Simple interface into the ZPR network topology that the route residual evaluator uses
-/// to evaluate routes.
-pub trait TopologyQueryApi {
-    fn link_has_attr(&self, link_id: &LinkId, attr: &AttrMatch) -> bool;
-}
-
+/// A route is an ordered sequence of links between nodes.
 #[derive(Debug, Serialize, Clone)]
 pub struct Route {
     pub kind: RouteKind,
     pub links: Vec<LinkId>,
+    /// Sum of the individual link costs.
     pub cost: u32,
 }
 
@@ -72,7 +36,10 @@ pub struct LinkId(pub String);
 
 #[derive(Debug, Serialize, Clone)]
 pub enum RouteKind {
-    DirectSameNode { node_id: NodeId },
+    /// Not even a route - adapaters are connected to the same node.
+    DirectSameNode {
+        node_id: NodeId,
+    },
     Multihop,
 }
 
@@ -101,58 +68,12 @@ impl From<&str> for LinkId {
 }
 
 impl Route {
+    /// True if no links need to be traversed (hop count of zero).
     pub fn is_direct(&self) -> bool {
         matches!(self.kind, RouteKind::DirectSameNode { .. })
     }
 
     pub fn hop_count(&self) -> usize {
         self.links.len()
-    }
-}
-
-impl RouteResidualEvaluator {
-    /// An optional coarse hint that can be used to prune routes.
-    pub fn hint(&self) -> Option<&RouteHint> {
-        self.hint.as_ref()
-    }
-
-    // Evaluate a single candidate route against policy.
-    //
-    // We have previously done an eval call on the EvalContext. So we know that the actors
-    // match.  But we may still need to hold on to the relevant actor attributes to make
-    // the evaluation.  The assumption is that everything we need in the residual is populated
-    // in it when it is created.
-    //
-    // Example:
-    //    allow admins to access services over secure links.
-    //    allow employees to access services. # implied: over any link.
-    //    never allow admins to access services over insecure links.
-    //
-    // When this is called with a route to "services" over "insecure" link.
-    // We need to know if the actor is an admin or just an employee.
-    pub fn eval_route(
-        &self,
-        _route: &Route,
-        _topology: &impl TopologyQueryApi,
-    ) -> Result<FinalEvalResult, EvalError> {
-        Err(EvalError::InternalError(
-            "route evaluation not implemented".to_string(),
-        ))
-    }
-
-    // Evaluate multiple candidate routes against policy.
-    //
-    // This also applies the default logic to the matches:
-    // - if we match a NEVER that is a final DENY (there may be multiple hits).
-    // - if we don't match any NEVERs and we match multiple ALLOWs we return a final allow (with all the hits).
-    // - Else, we return a NoMatch
-    pub fn eval_routes(
-        &self,
-        _routes: &[Route],
-        _topology: &impl TopologyQueryApi,
-    ) -> Result<FinalEvalResult, EvalError> {
-        Err(EvalError::InternalError(
-            "route evaluation not implemented".to_string(),
-        ))
     }
 }

--- a/libeval/src/route.rs
+++ b/libeval/src/route.rs
@@ -1,31 +1,146 @@
 use serde::Serialize;
+use std::fmt;
+use std::net::IpAddr;
 
-use crate::actor::Actor;
 use crate::error::EvalError;
 use crate::eval_result::FinalEvalResult;
 
-use zpr::vsapi_types::PacketDesc;
+#[derive(Debug)]
+pub struct RouteResidualEvaluator {
+    predicate: RoutePredicate,
+    hint: Option<RouteHint>,
+}
 
 #[derive(Debug)]
-pub struct RouteResidualEvaluator {/* TBD */}
+pub struct AttrMatch {} // TODO
 
-#[derive(Serialize, Debug)]
-pub struct Route {/* TBD */}
+// Answers the question: "Is this route allowed?".
+#[derive(Debug)]
+pub enum RoutePredicate {
+    True,
+    DirectOnly,
+    RequireLinkedPath,
+    AnyLinkHas(AttrMatch),
+    NoLinkHas(AttrMatch),
+    AllLinksHave(AttrMatch),
+    And(Vec<RoutePredicate>),
+    Or(Vec<RoutePredicate>),
+}
+
+/// An optional route hint can be used by the Router to cull the set of possible routes.
+/// The hint is conservative and may match more routes than are strictly possible by policy.
+/// Not all policies will be able to provide a hint, and in that case all routes need
+/// to be evaluated.
+#[derive(Debug)]
+pub struct RouteHint {
+    /// No links at all (direct connection between source and destination).
+    pub direct_only: bool,
+
+    /// Must have links (i.e. cannot be direct).
+    pub require_linked_path: bool,
+
+    /// Route is candidate if any link on the path matches
+    pub any_link_has: Vec<AttrMatch>,
+
+    /// Route is candidate if no link on the path matches
+    pub no_link_has: Vec<AttrMatch>,
+
+    /// Route is candidate if all links on the path match
+    pub all_links_have: Vec<AttrMatch>,
+}
+
+/// Simple interface into the ZPR network topology that the route residual evaluator uses
+/// to evaluate routes.
+pub trait TopologyQueryApi {
+    fn link_has_attr(&self, link_id: &LinkId, attr: &AttrMatch) -> bool;
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct Route {
+    pub kind: RouteKind,
+    pub links: Vec<LinkId>,
+    pub cost: u32,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq, Hash)]
+pub struct NodeId(pub String);
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq, Hash)]
+pub struct LinkId(pub String);
+
+#[derive(Debug, Serialize, Clone)]
+pub enum RouteKind {
+    DirectSameNode { node_id: NodeId },
+    Multihop,
+}
+
+impl From<IpAddr> for NodeId {
+    fn from(addr: IpAddr) -> Self {
+        NodeId(addr.to_string())
+    }
+}
+
+impl From<&IpAddr> for NodeId {
+    fn from(addr: &IpAddr) -> Self {
+        NodeId(addr.to_string())
+    }
+}
+
+impl From<&str> for NodeId {
+    fn from(s: &str) -> Self {
+        NodeId(s.to_string())
+    }
+}
+
+impl From<&str> for LinkId {
+    fn from(s: &str) -> Self {
+        LinkId(s.to_string())
+    }
+}
+
+impl Route {
+    pub fn is_direct(&self) -> bool {
+        matches!(self.kind, RouteKind::DirectSameNode { .. })
+    }
+
+    pub fn hop_count(&self) -> usize {
+        self.links.len()
+    }
+}
 
 impl RouteResidualEvaluator {
+    /// An optional coarse hint that can be used to prune routes.
+    pub fn hint(&self) -> Option<&RouteHint> {
+        self.hint.as_ref()
+    }
+
+    // Evaluate a single candidate route against policy.
+    //
+    // note that source_actor, dest_actor, packet_desc should already be here since we have
+    // previously done a policy eval call.
     pub fn eval_route(
         &self,
-        _src_actor: &Actor,
-        _dst_actor: &Actor,
-        _request: &PacketDesc,
         _route: &Route,
+        _topology: &impl TopologyQueryApi,
     ) -> Result<FinalEvalResult, EvalError> {
         Err(EvalError::InternalError(
             "route evaluation not implemented".to_string(),
         ))
     }
 
-    // TODO: Maybe expose a "route-selector" which could be use in
-    // context of topology to prune available routes to only those
-    // that match required attributes.
+    // Evaluate multiple candidate routes against policy.
+    //
+    // This also applies the default logic to the matches:
+    // - if we match a NEVER that is a final DENY (there may be multiple hits).
+    // - if we don't match any NEVERs and we match multiple ALLOWs we return a final allow (with all the hits).
+    // - Else, we return a NoMatch
+    pub fn eval_routes(
+        &self,
+        _routes: &[Route],
+        _topology: &impl TopologyQueryApi,
+    ) -> Result<FinalEvalResult, EvalError> {
+        Err(EvalError::InternalError(
+            "route evaluation not implemented".to_string(),
+        ))
+    }
 }

--- a/libeval/src/route.rs
+++ b/libeval/src/route.rs
@@ -1,5 +1,4 @@
 use serde::Serialize;
-use std::fmt;
 use std::net::IpAddr;
 
 use crate::error::EvalError;
@@ -11,11 +10,14 @@ pub struct RouteResidualEvaluator {
     hint: Option<RouteHint>,
 }
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Serialize, Hash, Eq, PartialEq)]
 pub struct AttrMatch {} // TODO
 
 // Answers the question: "Is this route allowed?".
-#[derive(Debug)]
+// Note these are extracted from policy duing first pass.
+//
+// TODO: Investigate why we really need Serialize on this. Is it for ZPT?
+#[derive(Debug, Serialize)]
 pub enum RoutePredicate {
     True,
     DirectOnly,
@@ -116,8 +118,18 @@ impl RouteResidualEvaluator {
 
     // Evaluate a single candidate route against policy.
     //
-    // note that source_actor, dest_actor, packet_desc should already be here since we have
-    // previously done a policy eval call.
+    // We have previously done an eval call on the EvalContext. So we know that the actors
+    // match.  But we may still need to hold on to the relevant actor attributes to make
+    // the evaluation.  The assumption is that everything we need in the residual is populated
+    // in it when it is created.
+    //
+    // Example:
+    //    allow admins to access services over secure links.
+    //    allow employees to access services. # implied: over any link.
+    //    never allow admins to access services over insecure links.
+    //
+    // When this is called with a route to "services" over "insecure" link.
+    // We need to know if the actor is an admin or just an employee.
     pub fn eval_route(
         &self,
         _route: &Route,

--- a/libeval/src/route.rs
+++ b/libeval/src/route.rs
@@ -11,7 +11,7 @@ pub struct RouteResidualEvaluator {
     hint: Option<RouteHint>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct AttrMatch {} // TODO
 
 // Answers the question: "Is this route allowed?".
@@ -31,7 +31,7 @@ pub enum RoutePredicate {
 /// The hint is conservative and may match more routes than are strictly possible by policy.
 /// Not all policies will be able to provide a hint, and in that case all routes need
 /// to be evaluated.
-#[derive(Debug)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct RouteHint {
     /// No links at all (direct connection between source and destination).
     pub direct_only: bool,
@@ -62,7 +62,7 @@ pub struct Route {
     pub cost: u32,
 }
 
-#[derive(Debug, Serialize, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Serialize, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct NodeId(pub String);
 
 #[derive(Debug, Serialize, Clone, PartialEq, Eq, Hash)]

--- a/vs/src/actor_mgr.rs
+++ b/vs/src/actor_mgr.rs
@@ -1,6 +1,7 @@
 //! Actor manager. Manages nodes too.
 //!
 
+use dashmap::DashMap;
 use libeval::actor::Actor;
 use libeval::attribute::key;
 use std::collections::{HashMap, HashSet};
@@ -13,6 +14,7 @@ use zpr::policy_types::{Scope, ServiceType};
 use zpr::vsapi_types::ServiceDescriptor;
 
 use crate::assembly::Assembly;
+use crate::config;
 use crate::counters::Counters;
 use crate::db;
 use crate::db::ServiceEntry;
@@ -23,6 +25,7 @@ pub struct ActorMgr {
     actor_db: db::ActorRepo,
     node_db: db::NodeRepo,
     counters: Arc<Counters>,
+    connection_table: DashMap<IpAddr, IpAddr>, // adapter_zpr_addr -> docking_node_zpr_addr
 }
 
 pub struct ServiceDetail {
@@ -49,6 +52,7 @@ impl ActorMgr {
             actor_db: actor_repo,
             node_db: node_repo,
             counters,
+            connection_table: DashMap::new(),
         }
     }
 
@@ -81,6 +85,20 @@ impl ActorMgr {
 
             if let Err(e) = self.node_db.clear_node_vss(node_addr).await {
                 warn!(target: ACTOR, "refresh_state: failed to clear VSS info for node at {}: {}", node_addr, e);
+            }
+
+            match self.node_db.get_connected_adapters(node_addr).await {
+                Ok(adapters) => {
+                    for adapter_addr in adapters {
+                        self.connection_table.insert(adapter_addr, *node_addr);
+                    }
+                }
+                Err(StoreError::NotFound(_)) => {
+                    // No connected adapters, that's fine.
+                }
+                Err(e) => {
+                    warn!(target: ACTOR, "refresh_state: failed to get connected adapters for node at {}: {}", node_addr, e);
+                }
             }
         }
 
@@ -127,8 +145,14 @@ impl ActorMgr {
 
     /// Use [ActorMgr::remove_actor_by_zpr_addr] to remove actor records which apply to both nodes and adapters.
     /// Use this function here in addition to remove node state.
+    ///
+    /// Also updates our internal connection table.
     pub async fn remove_node(&self, node_addr: &IpAddr) -> Result<(), ServiceError> {
         self.node_db.remove_node(node_addr).await?;
+
+        // Remove any connections that point to this node.
+        self.connection_table.retain(|_, v| v != node_addr);
+
         self.counters.remove_node_info(node_addr);
         Ok(())
     }
@@ -158,7 +182,7 @@ impl ActorMgr {
     }
 
     /// Add an adapter that is connected to a node.
-    #[allow(dead_code)]
+    /// Also updates our in-memory connection table.
     pub async fn add_adapter_via_node(
         &self,
         actor: &Actor,
@@ -169,23 +193,50 @@ impl ActorMgr {
                 "attempt to add node actor as adapter".into(),
             ));
         }
+
+        let Some(adapter_addr) = actor.get_zpr_addr() else {
+            return Err(ServiceError::Internal(format!(
+                "attempt to add adapter actor without ZPR address: CN={:?}",
+                actor.get_cn()
+            )));
+        };
+
         self.actor_db.add_actor(actor).await?;
         self.node_db
-            .add_connected_adater(connected_to_node, &actor.get_zpr_addr().unwrap())
+            .add_connected_adater(connected_to_node, adapter_addr)
             .await?;
+
+        self.connection_table
+            .insert(*adapter_addr, *connected_to_node);
+
         Ok(())
     }
 
-    /// This is probably temporary: we use this to add the phantom visa service adapter.
+    /// Hack: we use this to add the phantom visa service adapter.
     /// We don't know what node it is attached to yet.
-    #[allow(dead_code)]
-    pub async fn add_adapter_no_node(&self, actor: &Actor) -> Result<(), ServiceError> {
+    pub async fn hack_add_adapter_no_node(&self, actor: &Actor) -> Result<(), ServiceError> {
         if actor.is_node() {
             return Err(ServiceError::Internal(
                 "attempt to add node actor as adapter".into(),
             ));
         }
         self.actor_db.add_actor(actor).await?;
+        Ok(())
+    }
+
+    // Hack: this sets the docking node for the visa service adapter.
+    // TODO: Need a better way to do this. Perhaps talking to the local adapter directly? Perhaps our docking
+    // node can send a message over the vsapi (like a connection_request?).
+    pub async fn hack_set_vs_docking_node(
+        &self,
+        node_zpr_addr: &IpAddr,
+    ) -> Result<(), ServiceError> {
+        let vs_zpr_addr = IpAddr::V6(config::VS_ZPR_ADDR);
+        self.node_db
+            .add_connected_adater(node_zpr_addr, &vs_zpr_addr)
+            .await?;
+
+        self.connection_table.insert(vs_zpr_addr, *node_zpr_addr);
         Ok(())
     }
 
@@ -211,7 +262,9 @@ impl ActorMgr {
 
     /// Remove actor state from the database. If removing a node, also call [ActorMgr::remove_node].
     pub async fn remove_actor_by_zpr_addr(&self, zpra: &IpAddr) -> Result<(), ServiceError> {
-        Ok(self.actor_db.rm_actor_by_zpr_addr(zpra).await?)
+        self.actor_db.rm_actor_by_zpr_addr(zpra).await?;
+        self.connection_table.remove(zpra);
+        Ok(())
     }
 
     /// Returns ZPR addresses of adapters (NOT nodes) connected to the given node.
@@ -225,6 +278,24 @@ impl ActorMgr {
             .await?
             .into_iter()
             .collect())
+    }
+
+    /// Get the node address that the actor is "docked" to.  This only works for
+    /// "adapter" role actors (a "node" actor is considered to be docked to itself).
+    ///
+    /// Returns NONE if we cannot determine a docking node ZPR address.
+    pub fn get_docking_node_for_actor(&self, actor: &Actor) -> Option<IpAddr> {
+        if actor.is_node() {
+            None
+        } else {
+            if let Some(actor_addr) = actor.get_zpr_addr() {
+                self.connection_table
+                    .get(actor_addr)
+                    .map(|entry| *entry.value())
+            } else {
+                None
+            }
+        }
     }
 
     pub async fn get_adapter_cns_connected_to_node(
@@ -656,7 +727,7 @@ mod test {
             &["svc:auth", "svc:regular", "svc:unknown"],
             "adapter-auth",
         );
-        mgr.add_adapter_no_node(&actor).await.unwrap();
+        mgr.hack_add_adapter_no_node(&actor).await.unwrap();
 
         let auth_service = Service {
             id: "svc:auth".to_string(),
@@ -706,7 +777,7 @@ mod test {
             &["svc:auth"],
             "adapter-regular",
         );
-        mgr.add_adapter_no_node(&actor).await.unwrap();
+        mgr.hack_add_adapter_no_node(&actor).await.unwrap();
 
         let regular_service = Service {
             id: "svc:auth".to_string(),

--- a/vs/src/actor_mgr.rs
+++ b/vs/src/actor_mgr.rs
@@ -284,13 +284,14 @@ impl ActorMgr {
             .collect())
     }
 
-    /// Get the node address that the actor is "docked" to.  This only works for
-    /// "adapter" role actors (a "node" actor is considered to be docked to itself).
+    /// Get the node address that the actor is "docked" to.
+    /// A "node" actor is considered to be docked to itself (returns the actors own address
+    /// in this case).
     ///
     /// Returns NONE if we cannot determine a docking node ZPR address.
     pub fn get_docking_node_for_actor(&self, actor: &Actor) -> Option<IpAddr> {
         if actor.is_node() {
-            None
+            actor.get_zpr_addr().copied()
         } else {
             if let Some(actor_addr) = actor.get_zpr_addr() {
                 self.connection_table
@@ -540,7 +541,8 @@ mod test {
     use crate::counters::Counters;
     use crate::db::{ActorRepo, FakeDb, NodeRepo};
     use crate::test_helpers::{
-        make_actor_with_services_defexp, make_adapter_actor_defexp, make_node_actor_defexp,
+        make_actor_defexp, make_actor_with_services_defexp, make_adapter_actor_defexp,
+        make_node_actor_defexp,
     };
 
     use bytes::Bytes;
@@ -961,5 +963,206 @@ mod test {
             Ok(cns) => assert!(cns.is_empty()),
             Err(_) => {} // Also acceptable — unknown node is not in DB.
         }
+    }
+
+    // --- connection table / get_docking_node_for_actor tests ---
+
+    #[tokio::test]
+    async fn test_get_docking_node_for_node_actor_returns_self() {
+        let mgr = make_mgr();
+        let node_addr: IpAddr = "fd5a:5052::30".parse().unwrap();
+        let node_actor =
+            make_node_actor_defexp("fd5a:5052::30", "node-self", "[fd5a:5052::130]:1234");
+
+        mgr.add_node(&node_actor, false).await.unwrap();
+
+        let docking = mgr.get_docking_node_for_actor(&node_actor);
+        assert_eq!(docking, Some(node_addr));
+    }
+
+    #[tokio::test]
+    async fn test_get_docking_node_for_adapter_with_connection_returns_node() {
+        let mgr = make_mgr();
+        let node_addr: IpAddr = "fd5a:5052::31".parse().unwrap();
+        let node_actor =
+            make_node_actor_defexp("fd5a:5052::31", "node-dock", "[fd5a:5052::131]:1234");
+        let adapter_actor = make_adapter_actor_defexp("fd5a:5052::32", "adapter-dock");
+
+        mgr.add_node(&node_actor, false).await.unwrap();
+        mgr.add_adapter_via_node(&adapter_actor, &node_addr)
+            .await
+            .unwrap();
+
+        let docking = mgr.get_docking_node_for_actor(&adapter_actor);
+        assert_eq!(docking, Some(node_addr));
+    }
+
+    #[tokio::test]
+    async fn test_get_docking_node_for_adapter_not_in_connection_table_returns_none() {
+        let mgr = make_mgr();
+        // Adapter added to actor DB but NOT via a node (so no connection_table entry).
+        let adapter_actor = make_adapter_actor_defexp("fd5a:5052::33", "adapter-orphan");
+        mgr.hack_add_adapter_no_node(&adapter_actor).await.unwrap();
+
+        let docking = mgr.get_docking_node_for_actor(&adapter_actor);
+        assert_eq!(docking, None);
+    }
+
+    #[test]
+    fn test_get_docking_node_for_actor_without_zpr_addr_returns_none() {
+        let mgr = make_mgr();
+        // Actor with no ZPR_ADDR attribute at all.
+        let actor = make_actor_defexp(&[
+            (
+                libeval::attribute::key::ROLE,
+                libeval::attribute::ROLE_ADAPTER,
+            ),
+            (libeval::attribute::key::CN, "no-addr-actor"),
+        ]);
+
+        let docking = mgr.get_docking_node_for_actor(&actor);
+        assert_eq!(docking, None);
+    }
+
+    #[tokio::test]
+    async fn test_remove_actor_clears_connection_table_entry() {
+        let mgr = make_mgr();
+        let node_addr: IpAddr = "fd5a:5052::34".parse().unwrap();
+        let adapter_addr: IpAddr = "fd5a:5052::35".parse().unwrap();
+        let node_actor =
+            make_node_actor_defexp("fd5a:5052::34", "node-rm-ct", "[fd5a:5052::134]:1234");
+        let adapter_actor = make_adapter_actor_defexp("fd5a:5052::35", "adapter-rm-ct");
+
+        mgr.add_node(&node_actor, false).await.unwrap();
+        mgr.add_adapter_via_node(&adapter_actor, &node_addr)
+            .await
+            .unwrap();
+
+        // Confirm the entry is present before removal.
+        assert_eq!(
+            mgr.get_docking_node_for_actor(&adapter_actor),
+            Some(node_addr)
+        );
+
+        mgr.remove_actor_by_zpr_addr(&adapter_addr).await.unwrap();
+
+        // Entry must be gone from the connection table after removal.
+        assert_eq!(mgr.get_docking_node_for_actor(&adapter_actor), None);
+    }
+
+    #[tokio::test]
+    async fn test_remove_node_clears_adapters_from_connection_table() {
+        let mgr = make_mgr();
+        let node_addr: IpAddr = "fd5a:5052::36".parse().unwrap();
+        let node_actor =
+            make_node_actor_defexp("fd5a:5052::36", "node-rm-node", "[fd5a:5052::136]:1234");
+        let adapter1 = make_adapter_actor_defexp("fd5a:5052::37", "adapter-rm-1");
+        let adapter2 = make_adapter_actor_defexp("fd5a:5052::38", "adapter-rm-2");
+
+        mgr.add_node(&node_actor, false).await.unwrap();
+        mgr.add_adapter_via_node(&adapter1, &node_addr)
+            .await
+            .unwrap();
+        mgr.add_adapter_via_node(&adapter2, &node_addr)
+            .await
+            .unwrap();
+
+        assert_eq!(mgr.get_docking_node_for_actor(&adapter1), Some(node_addr));
+        assert_eq!(mgr.get_docking_node_for_actor(&adapter2), Some(node_addr));
+
+        mgr.remove_node(&node_addr).await.unwrap();
+
+        // Both adapter entries must be purged from the connection table.
+        assert_eq!(mgr.get_docking_node_for_actor(&adapter1), None);
+        assert_eq!(mgr.get_docking_node_for_actor(&adapter2), None);
+    }
+
+    #[tokio::test]
+    async fn test_remove_node_does_not_affect_other_nodes_connections() {
+        let mgr = make_mgr();
+        let node_a_addr: IpAddr = "fd5a:5052::39".parse().unwrap();
+        let node_b_addr: IpAddr = "fd5a:5052::40".parse().unwrap();
+        let node_a = make_node_actor_defexp("fd5a:5052::39", "node-a-rm", "[fd5a:5052::139]:1234");
+        let node_b = make_node_actor_defexp("fd5a:5052::40", "node-b-rm", "[fd5a:5052::140]:1234");
+        let adapter_a = make_adapter_actor_defexp("fd5a:5052::41", "adapter-on-a");
+        let adapter_b = make_adapter_actor_defexp("fd5a:5052::42", "adapter-on-b");
+
+        mgr.add_node(&node_a, false).await.unwrap();
+        mgr.add_node(&node_b, false).await.unwrap();
+        mgr.add_adapter_via_node(&adapter_a, &node_a_addr)
+            .await
+            .unwrap();
+        mgr.add_adapter_via_node(&adapter_b, &node_b_addr)
+            .await
+            .unwrap();
+
+        mgr.remove_node(&node_a_addr).await.unwrap();
+
+        // adapter_a's entry is gone, but adapter_b's entry (on node_b) must remain.
+        assert_eq!(mgr.get_docking_node_for_actor(&adapter_a), None);
+        assert_eq!(
+            mgr.get_docking_node_for_actor(&adapter_b),
+            Some(node_b_addr)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_hack_set_vs_docking_node_updates_connection_table() {
+        let mgr = make_mgr();
+        let node_addr: IpAddr = "fd5a:5052::43".parse().unwrap();
+        let node_actor =
+            make_node_actor_defexp("fd5a:5052::43", "node-vs-hack", "[fd5a:5052::143]:1234");
+        let vs_addr = IpAddr::V6(crate::config::VS_ZPR_ADDR);
+
+        mgr.add_node(&node_actor, false).await.unwrap();
+        mgr.hack_set_vs_docking_node(&node_addr).await.unwrap();
+
+        // The VS adapter should now resolve to node_addr in the connection table.
+        let vs_actor = make_actor_defexp(&[
+            (
+                libeval::attribute::key::ROLE,
+                libeval::attribute::ROLE_ADAPTER,
+            ),
+            (libeval::attribute::key::CN, "visa-service"),
+            (libeval::attribute::key::ZPR_ADDR, &vs_addr.to_string()),
+        ]);
+        let docking = mgr.get_docking_node_for_actor(&vs_actor);
+        assert_eq!(docking, Some(node_addr));
+    }
+
+    #[tokio::test]
+    async fn test_refresh_state_populates_connection_table() {
+        // Set up state via one manager instance, then verify a fresh manager's
+        // refresh_state repopulates the connection table from the DB.
+        let db = Arc::new(crate::db::FakeDb::new());
+        let actor_repo = crate::db::ActorRepo::new(db.clone());
+        let node_repo = crate::db::NodeRepo::new(db.clone());
+        let mgr1 = ActorMgr::new(actor_repo, node_repo, Arc::new(Counters::default()));
+
+        let node_addr: IpAddr = "fd5a:5052::44".parse().unwrap();
+        let node_actor =
+            make_node_actor_defexp("fd5a:5052::44", "node-refresh", "[fd5a:5052::144]:1234");
+        let adapter_actor = make_adapter_actor_defexp("fd5a:5052::45", "adapter-refresh");
+
+        mgr1.add_node(&node_actor, false).await.unwrap();
+        mgr1.add_adapter_via_node(&adapter_actor, &node_addr)
+            .await
+            .unwrap();
+
+        // Create a fresh manager over the same DB (no in-memory connection_table).
+        let actor_repo2 = crate::db::ActorRepo::new(db.clone());
+        let node_repo2 = crate::db::NodeRepo::new(db.clone());
+        let mgr2 = ActorMgr::new(actor_repo2, node_repo2, Arc::new(Counters::default()));
+
+        // Before refresh the connection table is empty.
+        assert_eq!(mgr2.get_docking_node_for_actor(&adapter_actor), None);
+
+        mgr2.refresh_state().await.unwrap();
+
+        // After refresh the adapter should resolve to its node.
+        assert_eq!(
+            mgr2.get_docking_node_for_actor(&adapter_actor),
+            Some(node_addr)
+        );
     }
 }

--- a/vs/src/actor_mgr.rs
+++ b/vs/src/actor_mgr.rs
@@ -214,6 +214,8 @@ impl ActorMgr {
 
     /// Hack: we use this to add the phantom visa service adapter.
     /// We don't know what node it is attached to yet.
+    ///
+    /// See https://github.com/org-zpr/zpr-visaservice/issues/195
     pub async fn hack_add_adapter_no_node(&self, actor: &Actor) -> Result<(), ServiceError> {
         if actor.is_node() {
             return Err(ServiceError::Internal(
@@ -224,9 +226,11 @@ impl ActorMgr {
         Ok(())
     }
 
-    // Hack: this sets the docking node for the visa service adapter.
-    // TODO: Need a better way to do this. Perhaps talking to the local adapter directly? Perhaps our docking
-    // node can send a message over the vsapi (like a connection_request?).
+    /// Hack: this sets the docking node for the visa service adapter.
+    /// TODO: Need a better way to do this. Perhaps talking to the local adapter directly? Perhaps our docking
+    /// node can send a message over the vsapi (like a connection_request?).
+    ///
+    /// See https://github.com/org-zpr/zpr-visaservice/issues/195
     pub async fn hack_set_vs_docking_node(
         &self,
         node_zpr_addr: &IpAddr,

--- a/vs/src/actor_mgr.rs
+++ b/vs/src/actor_mgr.rs
@@ -26,6 +26,12 @@ pub struct ActorMgr {
     node_db: db::NodeRepo,
     counters: Arc<Counters>,
     connection_table: DashMap<IpAddr, IpAddr>, // adapter_zpr_addr -> docking_node_zpr_addr
+
+    /// Maps AAA address → (docking_node, expiry). Registered on the request side when an
+    /// unauthenticated adapter contacts an auth service. Looked up on the response side to
+    /// find the correct docking node (which differs from job.requesting_node in multi-node
+    /// setups). Evicted when the adapter authenticates or on lazy expiry at lookup time.
+    aaa_table: DashMap<IpAddr, (IpAddr, SystemTime)>,
 }
 
 pub struct ServiceDetail {
@@ -53,6 +59,7 @@ impl ActorMgr {
             node_db: node_repo,
             counters,
             connection_table: DashMap::new(),
+            aaa_table: DashMap::new(),
         }
     }
 
@@ -212,7 +219,7 @@ impl ActorMgr {
         Ok(())
     }
 
-    /// Hack: we use this to add the phantom visa service adapter.
+    /// Hack: we use this to add the unauthenticated visa service adapter.
     /// We don't know what node it is attached to yet.
     ///
     /// See https://github.com/org-zpr/zpr-visaservice/issues/195
@@ -301,6 +308,42 @@ impl ActorMgr {
                 None
             }
         }
+    }
+
+    /// Register the docking node for an AAA actor. Called on the request side when an
+    /// unauthenticated adapter (using an AAA address) contacts an auth service. Multiple
+    /// requests for the same address overwrite the entry harmlessly — the docking node for
+    /// a given AAA subnet cannot change.
+    ///
+    /// Not persisted. If we restart we loose in-flight AAA request tracking, but that
+    /// should be ok since the actors can just retry authentication.
+    pub fn register_aaa(&self, aaa_addr: IpAddr, docking_node: IpAddr, expiry: SystemTime) {
+        self.aaa_table.insert(aaa_addr, (docking_node, expiry));
+    }
+
+    /// Look up the docking node for an AAA actor. Returns None if the entry is missing or
+    /// expired (lazy eviction on lookup).
+    ///
+    /// TODO: Longer term we will need to clean up this AAA table. Ok for now until we
+    /// figure out how AAA addresses will be used. There is talk of using this as some sort
+    /// of "adapter identity" addresses.
+    /// See issue: https://github.com/org-zpr/zpr-visaservice/issues/200
+    pub fn get_docking_node_for_aaa(&self, aaa_addr: &IpAddr) -> Option<IpAddr> {
+        let result = match self.aaa_table.get(aaa_addr) {
+            Some(entry) => {
+                let (docking_node, expiry) = entry.value();
+                if *expiry > SystemTime::now() {
+                    Some(*docking_node)
+                } else {
+                    None
+                }
+            }
+            None => None,
+        };
+        if result.is_none() {
+            self.aaa_table.remove(aaa_addr);
+        }
+        result
     }
 
     pub async fn get_adapter_cns_connected_to_node(

--- a/vs/src/actor_mgr.rs
+++ b/vs/src/actor_mgr.rs
@@ -338,21 +338,15 @@ impl ActorMgr {
     /// of "adapter identity" addresses.
     /// See issue: https://github.com/org-zpr/zpr-visaservice/issues/200
     pub fn get_docking_node_for_aaa(&self, aaa_addr: &IpAddr) -> Option<IpAddr> {
-        let result = match self.aaa_table.get(aaa_addr) {
-            Some(entry) => {
-                let (docking_node, expiry) = entry.value();
-                if *expiry > SystemTime::now() {
-                    Some(*docking_node)
-                } else {
-                    None
-                }
+        let now = SystemTime::now();
+        match self.aaa_table.get(aaa_addr) {
+            Some(entry) if entry.value().1 > now => Some(entry.value().0),
+            _ => {
+                self.aaa_table
+                    .remove_if(aaa_addr, |_, (_, expiry)| *expiry <= now); // rechecks the entry while holding write lock
+                None
             }
-            None => None,
-        };
-        if result.is_none() {
-            self.aaa_table.remove(aaa_addr);
         }
-        result
     }
 
     pub async fn get_adapter_cns_connected_to_node(

--- a/vs/src/actor_mgr.rs
+++ b/vs/src/actor_mgr.rs
@@ -25,7 +25,7 @@ pub struct ActorMgr {
     actor_db: db::ActorRepo,
     node_db: db::NodeRepo,
     counters: Arc<Counters>,
-    connection_table: DashMap<IpAddr, IpAddr>, // adapter_zpr_addr -> docking_node_zpr_addr
+    connection_table: Arc<DashMap<IpAddr, IpAddr>>, // adapter_zpr_addr -> docking_node_zpr_addr
 
     /// Maps AAA address → (docking_node, expiry). Registered on the request side when an
     /// unauthenticated adapter contacts an auth service. Looked up on the response side to
@@ -58,7 +58,7 @@ impl ActorMgr {
             actor_db: actor_repo,
             node_db: node_repo,
             counters,
-            connection_table: DashMap::new(),
+            connection_table: Arc::new(DashMap::new()),
             aaa_table: DashMap::new(),
         }
     }
@@ -157,8 +157,17 @@ impl ActorMgr {
     pub async fn remove_node(&self, node_addr: &IpAddr) -> Result<(), ServiceError> {
         self.node_db.remove_node(node_addr).await?;
 
-        // Remove any connections that point to this node.
-        self.connection_table.retain(|_, v| v != node_addr);
+        // Remove any connections that point to this node.  Could be slow to iterate if
+        // this is large, so this is run in spawn_blocking to avoid blocking the async runtime.
+        tokio::task::spawn_blocking({
+            let connection_table_ptr = self.connection_table.clone();
+            let node_addr = *node_addr;
+            move || {
+                connection_table_ptr.retain(|_, v| v != &node_addr);
+            }
+        })
+        .await
+        .unwrap();
 
         self.counters.remove_node_info(node_addr);
         Ok(())

--- a/vs/src/assembly.rs
+++ b/vs/src/assembly.rs
@@ -11,6 +11,7 @@ use crate::db::DbConnection;
 use crate::event_mgr::EventMgr;
 use crate::net_mgr::NetMgr;
 use crate::policy_mgr::PolicyMgr;
+use crate::router::Router;
 use crate::visa_mgr::VisaMgr;
 use crate::vss_mgr::VssMgr;
 
@@ -29,6 +30,7 @@ pub struct Assembly {
     pub net_mgr: Arc<NetMgr>,
     pub event_mgr: EventMgr,
     pub admin_api_keys: Arc<ReloadableApiKeys>,
+    pub router: Router,
 }
 
 impl Assembly {
@@ -120,6 +122,7 @@ pub mod tests {
             net_mgr: Arc::new(NetMgr::new_v6().expect("failed to create NetMgr")),
             event_mgr: EventMgr::new(event_tx),
             admin_api_keys: Arc::new(ReloadableApiKeys::default()),
+            router: Router::new(),
         }
     }
 }

--- a/vs/src/connection_control.rs
+++ b/vs/src/connection_control.rs
@@ -350,7 +350,7 @@ impl ConnectionControl {
         Ok(authd_actor)
     }
 
-    /// Disconnect logic. Cleans up actor database and visas.
+    /// Disconnect logic. Cleans up actor database and visas. Updates router.
     pub async fn disconnect(
         &self,
         asm: Arc<Assembly>,
@@ -377,6 +377,7 @@ impl ConnectionControl {
 
         if let Some(actor) = maybe_actor {
             if actor.is_node() {
+                asm.router.remove_node(&zpr_addr);
                 if let Some(vss_hndl) = asm.vss_mgr.get_handle(&zpr_addr) {
                     if let Err(e) = vss_hndl.stop().await {
                         error!(target: CC, "failed to stop VSS worker for disconnected node at addr {zpr_addr}: {}", e);

--- a/vs/src/error.rs
+++ b/vs/src/error.rs
@@ -60,15 +60,6 @@ pub enum ServiceError {
 
     #[error("admin key error: {0}")]
     AdminKeyError(String),
-
-    #[error("topology error: {0}")]
-    Topology(String),
-
-    #[error("topology: node exists: {0}")]
-    TopologyNodeExists(String),
-
-    #[error("topology: link exists: {0}")]
-    TopologyLinkExists(String),
 }
 
 #[derive(Debug, Error)]
@@ -135,6 +126,22 @@ pub enum VssSyncError {
 
     #[error("timeout: {0}")]
     Timeout(String),
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Error)]
+pub enum TopologyError {
+    #[error("node already exists: {0}")]
+    NodeExists(String),
+
+    #[error("link already exists: {0}")]
+    LinkExists(String),
+
+    #[error("link to self is not allowed: {0}")]
+    LinkToSelf(String),
+
+    #[error("node not found: {0}")]
+    NodeNotFound(String),
 }
 
 impl From<ApiResponseError> for VssSyncError {

--- a/vs/src/error.rs
+++ b/vs/src/error.rs
@@ -60,6 +60,15 @@ pub enum ServiceError {
 
     #[error("admin key error: {0}")]
     AdminKeyError(String),
+
+    #[error("topology error: {0}")]
+    Topology(String),
+
+    #[error("topology: node exists: {0}")]
+    TopologyNodeExists(String),
+
+    #[error("topology: link exists: {0}")]
+    TopologyLinkExists(String),
 }
 
 #[derive(Debug, Error)]

--- a/vs/src/event_mgr.rs
+++ b/vs/src/event_mgr.rs
@@ -115,6 +115,7 @@ async fn handle_actor_leaves(
     // The disconnect call updates our state database.
     // Could be we just lost a single adapter, or we lost a node and all adapters connected.
     // TODO: In future we may want to not wipe state so quickly? What if this is temporary (for node)?
+    // TODO: What are the implications for VS if this next call errors out?
     asm.cc.disconnect(asm.clone(), actor_addr, reason).await?;
 
     if !prev_auth_services.is_empty() {

--- a/vs/src/main.rs
+++ b/vs/src/main.rs
@@ -392,7 +392,7 @@ async fn self_authorize(asm: Arc<Assembly>, vs_addr: &IpAddr) -> Result<(), Serv
         .authenticate_visa_service(asm.clone(), claims)
         .await?;
 
-    asm.actor_mgr.add_adapter_no_node(&actor).await?;
+    asm.actor_mgr.hack_add_adapter_no_node(&actor).await?;
 
     let evt = VsEvent::ActorJoins(vs_addr.clone());
     if let Err(e) = asm.event_mgr.record_event(evt).await {

--- a/vs/src/main.rs
+++ b/vs/src/main.rs
@@ -27,6 +27,7 @@ mod logging;
 mod net_mgr;
 mod packet;
 mod policy_mgr;
+mod router;
 mod signal_worker;
 mod visa_mgr;
 mod visareq_worker;
@@ -51,6 +52,7 @@ use crate::logging::enable_logging;
 use crate::logging::targets::MAIN;
 use crate::net_mgr::NetMgr;
 use crate::policy_mgr::PolicyMgr;
+use crate::router::Router;
 use crate::visa_mgr::VisaMgr;
 use crate::vss_mgr::VssMgr;
 
@@ -283,6 +285,7 @@ async fn main() -> std::process::ExitCode {
         net_mgr: Arc::new(net_mgr),
         event_mgr: EventMgr::new(event_tx),
         admin_api_keys: Arc::new(admin_api_keys),
+        router: Router::new(),
     });
 
     js.spawn_local(signal_worker::launch(asm.clone()));

--- a/vs/src/router.rs
+++ b/vs/src/router.rs
@@ -26,36 +26,31 @@ use crate::error::TopologyError;
 ///
 /// ### Targeted invalidation
 ///
-/// Instead of flushing the entire cache on every topology change, `RouterInner` maintains two
-/// reverse indices:
+/// `RouterInner` maintains one reverse index:
 ///
 /// - **`link_to_cache_keys`** — maps each `LinkId` → set of cache keys whose routes traverse
 ///   that link.  `remove_link` uses this to evict only the entries that actually use the
-///   removed link.
+///   removed link.  `remove_node` uses it transitively via the node's incident links.
 ///
-/// - **`node_to_cache_keys`** — maps each `NodeId` → set of cache keys whose routes pass
-///   through that node (as src, dst, or intermediate hop).  `add_link(a, b)` uses this to
-///   evict only entries touching node a or b — a new link a-b cannot improve any path that
-///   doesn't already go through a or b, so this is exact, not merely conservative.
-///   `remove_node` also uses it to find all entries that route through the removed node.
-///
-/// Both indices are populated in `get_routes` at cache-insert time and cleaned up atomically
+/// The index is populated in `get_routes` at cache-insert time and cleaned up atomically
 /// by `RouterInner::invalidate_keys` whenever entries are evicted.
+///
+/// ### add_link always flushes the full cache
+///
+/// Targeted invalidation on link *removal* is exact: any affected route must traverse the
+/// removed link, so `link_to_cache_keys` identifies the precise affected set.
+///
+/// Link *addition* is different.  A new link a-b can create routes for pairs (x, y) whose
+/// previously cached routes never touched a or b at all (e.g. x→a and b→y existed but
+/// a-b did not, so the only cached route was direct x→y).  Determining which pairs could
+/// gain new routes would require a full graph traversal — no cheaper exact answer exists.
+/// `add_link` therefore flushes the entire route cache.
 ///
 /// ### Ordering constraint
 ///
 /// `invalidate_keys` walks `topology.edges` to resolve a `LinkId` → `(node_a, node_b)` for
-/// node-index cleanup.  It must therefore be called **before** the topology mutation that
-/// removes the link/node, otherwise those entries are gone and the node-index leaks stale
-/// `HashSet` entries.
-///
-/// ### Empty-result entries
-///
-/// When `compute_routes` returns an empty `Vec` (nodes exist but are currently unreachable),
-/// the empty result is still cached so we don't keep re-running DFS.  Because there are no
-/// link IDs to walk, the insertion code registers the key directly under
-/// `node_to_cache_keys[src]` and `node_to_cache_keys[dst]`.  This ensures that a subsequent
-/// `add_link` touching either endpoint will correctly evict the stale "unreachable" entry.
+/// link-index cleanup.  It must therefore be called **before** the topology mutation that
+/// removes the link/node, otherwise those entries are gone and the index leaks stale entries.
 #[derive(Hash, Eq, PartialEq, Clone)]
 struct RouteCacheKey {
     a: NodeId,
@@ -68,55 +63,28 @@ struct RouterInner {
     route_cache: HashMap<RouteCacheKey, Vec<Route>>,
     /// Reverse index: cache keys whose routes traverse a given link. See [RouteCacheKey].
     link_to_cache_keys: HashMap<LinkId, HashSet<RouteCacheKey>>,
-    /// Reverse index: cache keys whose routes pass through a given node. See [RouteCacheKey].
-    node_to_cache_keys: HashMap<NodeId, HashSet<RouteCacheKey>>,
 }
 
 impl RouterInner {
-    /// Removes a set of cache keys and cleans up both reverse indices for each removed entry.
+    /// Removes a set of cache keys and cleans up `link_to_cache_keys` for each removed entry.
     ///
-    /// MUST be called before any topology mutation that removes links or nodes because it
-    /// resolves link endpoints via `topology.edges` to clean up `node_to_cache_keys`.
-    /// Duplicate keys in the iterator are safe — a missing `route_cache` entry is a no-op.
+    /// Must be called before any topology mutation that removes links, because it resolves
+    /// `LinkId` → endpoints via `topology.edges`.  Duplicate keys are safe — a missing
+    /// `route_cache` entry is a no-op.
     fn invalidate_keys(&mut self, keys: impl IntoIterator<Item = RouteCacheKey>) {
         for key in keys {
             let Some(routes) = self.route_cache.remove(&key) else {
                 continue;
             };
-            // Collect every link that appeared in any route for this key so we can remove
-            // the key from the per-link and per-node reverse-index buckets.
             let affected_links: HashSet<LinkId> = routes
                 .iter()
                 .flat_map(|r| r.links.iter().cloned())
                 .collect();
-
             for link_id in &affected_links {
                 if let Some(s) = self.link_to_cache_keys.get_mut(link_id) {
                     s.remove(&key);
                     if s.is_empty() {
                         self.link_to_cache_keys.remove(link_id);
-                    }
-                }
-                // Walk to the link's endpoint nodes to clean node_to_cache_keys.
-                // This is why we must be called before the topology mutation removes the link.
-                if let Some(link) = self.topology.edges.get(link_id) {
-                    for node_id in [&link.a, &link.b] {
-                        if let Some(s) = self.node_to_cache_keys.get_mut(node_id) {
-                            s.remove(&key);
-                            if s.is_empty() {
-                                self.node_to_cache_keys.remove(node_id);
-                            }
-                        }
-                    }
-                }
-            }
-            // Also clean up the endpoint registrations made for empty-result entries
-            // (those have no links, so the loop above doesn't cover them).
-            for node_id in [&key.a, &key.b] {
-                if let Some(s) = self.node_to_cache_keys.get_mut(node_id) {
-                    s.remove(&key);
-                    if s.is_empty() {
-                        self.node_to_cache_keys.remove(node_id);
                     }
                 }
             }
@@ -135,7 +103,6 @@ impl Router {
                 topology: Graph::default(),
                 route_cache: HashMap::new(),
                 link_to_cache_keys: HashMap::new(),
-                node_to_cache_keys: HashMap::new(),
             }),
         }
     }
@@ -159,19 +126,31 @@ impl Router {
         let mut inner = self.inner.lock().unwrap();
         let nid: NodeId = node_addr.into();
 
-        // Phase 1: evict entries that route *through* this node (intermediate-hop coverage).
-        // Collect first to avoid a simultaneous borrow of inner.node_to_cache_keys.
-        let keys: Vec<RouteCacheKey> = inner
-            .node_to_cache_keys
+        // Phase 1: evict entries whose routes traverse any of the node's incident links.
+        // Collect the union of link_to_cache_keys for each incident link first to avoid
+        // simultaneous borrows.
+        let incident_link_ids: Vec<LinkId> = inner
+            .topology
+            .nodes
             .get(&nid)
-            .map(|s| s.iter().cloned().collect())
+            .map(|n| n.edges.iter().cloned().collect())
             .unwrap_or_default();
+        let keys: Vec<RouteCacheKey> = incident_link_ids
+            .iter()
+            .flat_map(|lid| {
+                inner
+                    .link_to_cache_keys
+                    .get(lid)
+                    .into_iter()
+                    .flat_map(|s| s.iter().cloned())
+            })
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
         inner.invalidate_keys(keys);
-        inner.node_to_cache_keys.remove(&nid);
 
-        // Phase 2: scan for any remaining entries where the node is an explicit endpoint.
-        // These arise when compute_routes returned an empty Vec (no links to traverse, so
-        // phase 1's node-index walk wouldn't have found them).
+        // Phase 2: scan for entries where the node is an explicit endpoint.  These arise
+        // when compute_routes returned an empty Vec (no links → phase 1 finds nothing).
         let endpoint_keys: Vec<RouteCacheKey> = inner
             .route_cache
             .keys()
@@ -205,25 +184,11 @@ impl Router {
         let a: NodeId = zpr_addr_a.into();
         let b: NodeId = zpr_addr_b.into();
 
-        // A new link a-b can only create shorter or entirely new paths that pass through
-        // node a or node b.  Any cached entry whose routes don't touch a or b is unaffected,
-        // so we evict only the union of both nodes' reverse-index buckets.  This is exact,
-        // not merely conservative.  Collect first to release the shared borrow before
-        // calling invalidate_keys (which takes &mut inner).
-        let keys: HashSet<RouteCacheKey> = {
-            let from_a = inner
-                .node_to_cache_keys
-                .get(&a)
-                .cloned()
-                .unwrap_or_default();
-            let from_b = inner
-                .node_to_cache_keys
-                .get(&b)
-                .cloned()
-                .unwrap_or_default();
-            from_a.into_iter().chain(from_b).collect()
-        };
-        inner.invalidate_keys(keys);
+        // A new link can create routes for pairs whose cached routes never touched a or b
+        // (e.g. dormant x→a and b→y segments now form x→a→b→y).  Identifying all affected
+        // pairs would require a full graph traversal, so we flush the entire cache instead.
+        inner.route_cache.clear();
+        inner.link_to_cache_keys.clear();
 
         inner
             .topology
@@ -295,8 +260,7 @@ impl Router {
         }
         let routes = Self::compute_routes(&inner.topology, addr_a, addr_b, hint);
 
-        // Populate reverse indices so future topology mutations can do targeted eviction.
-        // key is cloned per-entry because route_cache.insert below takes ownership.
+        // Populate link_to_cache_keys so remove_link can do targeted eviction.
         for route in &routes {
             for link_id in &route.links {
                 inner
@@ -304,42 +268,7 @@ impl Router {
                     .entry(link_id.clone())
                     .or_default()
                     .insert(key.clone());
-                // Clone endpoints before dropping the topology borrow; otherwise
-                // Rust rejects the simultaneous immutable borrow of topology.edges
-                // and mutable borrow of node_to_cache_keys on the same `inner`.
-                let endpoints: Option<(NodeId, NodeId)> = inner
-                    .topology
-                    .edges
-                    .get(link_id)
-                    .map(|l| (l.a.clone(), l.b.clone()));
-                if let Some((na, nb)) = endpoints {
-                    inner
-                        .node_to_cache_keys
-                        .entry(na)
-                        .or_default()
-                        .insert(key.clone());
-                    inner
-                        .node_to_cache_keys
-                        .entry(nb)
-                        .or_default()
-                        .insert(key.clone());
-                }
             }
-        }
-        // An empty result (unreachable pair) has no links to walk, so register the key
-        // directly under both endpoint nodes.  This lets add_link bust the stale entry if
-        // it later creates a path between them.
-        if routes.is_empty() {
-            inner
-                .node_to_cache_keys
-                .entry(key.a.clone())
-                .or_default()
-                .insert(key.clone());
-            inner
-                .node_to_cache_keys
-                .entry(key.b.clone())
-                .or_default()
-                .insert(key.clone());
         }
 
         inner.route_cache.insert(key, routes.clone());
@@ -885,6 +814,33 @@ mod tests {
         // Adding a link between a and b must bust the stale empty entry.
         r.add_link(&a, &b, &LinkId("ab".into()), &[], 1).unwrap();
         assert_eq!(r.get_routes(&a, &b, Some(&hint)).len(), 1);
+    }
+
+    #[test]
+    fn test_add_link_bridge_invalidates_unrelated_cached_pair() {
+        // Regression: add_link(a,b) must evict a cached (x,y) entry even when the previously
+        // cached routes for (x,y) never traversed a or b, if adding a-b creates a new path
+        // x→a→b→y via pre-existing x-a and b-y links.
+        let x = ip("10.0.0.10");
+        let y = ip("10.0.0.20");
+        let a = ip("10.0.0.1");
+        let b = ip("10.0.0.2");
+        let r = Router::new();
+        r.add_node(&x).unwrap();
+        r.add_node(&y).unwrap();
+        r.add_node(&a).unwrap();
+        r.add_node(&b).unwrap();
+        // Direct x-y link and dormant legs x-a and b-y; no a-b yet.
+        r.add_link(&x, &y, &LinkId("xy".into()), &[], 10).unwrap();
+        r.add_link(&x, &a, &LinkId("xa".into()), &[], 1).unwrap();
+        r.add_link(&b, &y, &LinkId("by".into()), &[], 1).unwrap();
+        let hint = no_hint();
+        // Warm the cache: only the direct x-y route exists.
+        assert_eq!(r.get_routes(&x, &y, Some(&hint)).len(), 1);
+        // Adding the bridge a-b creates a second path x→a→b→y.
+        r.add_link(&a, &b, &LinkId("ab".into()), &[], 1).unwrap();
+        // Cache must be invalidated; both routes should now be returned.
+        assert_eq!(r.get_routes(&x, &y, Some(&hint)).len(), 2);
     }
 
     // --- Graph unit tests ---

--- a/vs/src/router.rs
+++ b/vs/src/router.rs
@@ -596,6 +596,57 @@ mod tests {
         assert_eq!(r.get_routes(&a, &b, Some(&hint)).len(), 0);
     }
 
+    #[test]
+    fn test_route_cache_invalidated_after_add_link() {
+        // Cache is warmed with an empty result, then add_link must bust it so the new route appears.
+        let a = ip("10.0.0.1");
+        let b = ip("10.0.0.2");
+        let r = Router::new();
+        r.add_node(&a).unwrap();
+        r.add_node(&b).unwrap();
+        let hint = no_hint();
+        assert_eq!(r.get_routes(&a, &b, Some(&hint)).len(), 0);
+        r.add_link(&a, &b, &LinkId("ab".into()), &[], 1).unwrap();
+        assert_eq!(r.get_routes(&a, &b, Some(&hint)).len(), 1);
+    }
+
+    #[test]
+    fn test_route_cache_invalidated_after_remove_node() {
+        // Cache is warmed with a route through an intermediate node; removing that node must bust the cache.
+        let a = ip("10.0.0.1");
+        let b = ip("10.0.0.2");
+        let c = ip("10.0.0.3");
+        let r = Router::new();
+        r.add_node(&a).unwrap();
+        r.add_node(&b).unwrap();
+        r.add_node(&c).unwrap();
+        r.add_link(&a, &b, &LinkId("ab".into()), &[], 1).unwrap();
+        r.add_link(&b, &c, &LinkId("bc".into()), &[], 1).unwrap();
+        let hint = no_hint();
+        assert_eq!(r.get_routes(&a, &c, Some(&hint)).len(), 1);
+        r.remove_node(&b);
+        assert_eq!(r.get_routes(&a, &c, Some(&hint)).len(), 0);
+    }
+
+    #[test]
+    fn test_route_cache_not_disturbed_by_add_node() {
+        // Adding an isolated node must not invalidate existing cached routes between other nodes.
+        let a = ip("10.0.0.1");
+        let b = ip("10.0.0.2");
+        let d = ip("10.0.0.4");
+        let r = Router::new();
+        r.add_node(&a).unwrap();
+        r.add_node(&b).unwrap();
+        r.add_link(&a, &b, &LinkId("ab".into()), &[], 1).unwrap();
+        let hint = no_hint();
+        assert_eq!(r.get_routes(&a, &b, Some(&hint)).len(), 1);
+        r.add_node(&d).unwrap();
+        // Route a->b still valid and served from cache.
+        assert_eq!(r.get_routes(&a, &b, Some(&hint)).len(), 1);
+        // New isolated node d has no routes to a.
+        assert_eq!(r.get_routes(&a, &d, Some(&hint)).len(), 0);
+    }
+
     // --- Graph unit tests ---
 
     fn nid(s: &str) -> NodeId {

--- a/vs/src/router.rs
+++ b/vs/src/router.rs
@@ -56,7 +56,6 @@ impl Router {
     pub fn add_node(&self, node_addr: &IpAddr) -> Result<(), TopologyError> {
         let mut inner = self.inner.lock().unwrap();
         inner.topology.add_node(node_addr)?;
-        inner.route_cache.clear();
         Ok(())
     }
 
@@ -226,7 +225,6 @@ impl Graph {
                 edges: HashSet::new(),
             },
         );
-        self.recompute();
         Ok(nid)
     }
 

--- a/vs/src/router.rs
+++ b/vs/src/router.rs
@@ -1,12 +1,20 @@
+//! Router keeps track of nodes and their connections. It does not know anything about adapters.
+//! So to route between two actors you first need to determine their docking nodes.  Then you
+//! can query this Router to see if there is a path.
+//!
+//! Must be kept in sync with the coming and going of nodes, and for each node the coming and
+//! going of links. (TODO)
+
 use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashMap, HashSet};
 use std::net::IpAddr;
 use std::sync::Mutex;
 
-use libeval::attribute::Attribute;
-use libeval::route::{AttrMatch, LinkId, NodeId, Route, RouteHint, RouteKind, TopologyQueryApi};
+use libeval::attribute::{AttrMatch, Attribute};
+use libeval::eval_route::{RouteHint, TopologyQueryApi};
+use libeval::route::{LinkId, NodeId, Route, RouteKind};
 
-use crate::error::ServiceError;
+use crate::error::TopologyError;
 
 /// This is a memoization key used for the [Router::get_routes] cache. It is the tuple of (addr_a, addr_b, hint)
 /// that identifies a particular query for routes between addr_a and addr_b with the given hint.
@@ -18,16 +26,22 @@ struct RouteCacheKey {
     hint: Option<RouteHint>,
 }
 
-pub struct Router {
+struct RouterInner {
     topology: Graph,
-    route_cache: Mutex<HashMap<RouteCacheKey, Vec<Route>>>,
+    route_cache: HashMap<RouteCacheKey, Vec<Route>>,
+}
+
+pub struct Router {
+    inner: Mutex<RouterInner>,
 }
 
 impl Router {
     pub fn new() -> Self {
         Self {
-            topology: Graph::default(),
-            route_cache: Mutex::new(HashMap::new()),
+            inner: Mutex::new(RouterInner {
+                topology: Graph::default(),
+                route_cache: HashMap::new(),
+            }),
         }
     }
 
@@ -38,46 +52,55 @@ impl Router {
     ///TODO: This does error if nodes exists... should we instead just merge it in?
     ///
     /// ## Errors
-    /// - If node already exists then this returns [ServiceError::TopologyNodeExists]
-    pub fn add_node(&mut self, node_addr: &IpAddr) -> Result<(), ServiceError> {
-        self.topology.add_node(node_addr)?;
-        self.route_cache.lock().unwrap().clear();
+    /// - If node already exists then this returns [TopologyError::NodeExists]
+    pub fn add_node(&self, node_addr: &IpAddr) -> Result<(), TopologyError> {
+        let mut inner = self.inner.lock().unwrap();
+        inner.topology.add_node(node_addr)?;
+        inner.route_cache.clear();
         Ok(())
     }
 
     /// Removes a node and all its incident links from the topology. If the node does not exist this is a no-op.
-    pub fn remove_node(&mut self, node_addr: &IpAddr) {
+    pub fn remove_node(&self, node_addr: &IpAddr) {
+        let mut inner = self.inner.lock().unwrap();
         let nid: NodeId = node_addr.into();
-        self.topology.remove_node(&nid);
-        self.route_cache.lock().unwrap().clear();
+        inner.topology.remove_node(&nid);
+        inner.route_cache.clear();
     }
 
     /// Adds a link between the two nodes identified by the given IP addresses.
     /// The two nodes must be distinct and must already exist in the topology.
     ///
     /// ## Errors
-    /// - If a or b do not exist or are the same then this returns [ServiceError::Topology]
-    /// - If link id already exists then this returns [ServiceError::TopologyEdgeExists]
+    /// - If attempt to create link from a node to itself then this returns [TopologyError::LinkToSelf]
+    /// - If a or b do not exist returns [TopologyError::NodeNotFound]
+    /// - If link id already exists then this returns [TopologyError::LinkExists]
+    ///
+    #[allow(dead_code)]
     pub fn add_link(
-        &mut self,
+        &self,
         zpr_addr_a: &IpAddr,
         zpr_addr_b: &IpAddr,
         id: &LinkId,
         attributes: &[Attribute],
         cost: u32,
-    ) -> Result<(), ServiceError> {
+    ) -> Result<(), TopologyError> {
+        let mut inner = self.inner.lock().unwrap();
         let a = zpr_addr_a.into();
         let b = zpr_addr_b.into();
-        self.topology
+        inner
+            .topology
             .add_link(a, b, id.clone(), attributes.to_vec(), cost)?;
-        self.route_cache.lock().unwrap().clear();
+        inner.route_cache.clear();
         Ok(())
     }
 
     /// Remove a link by its id. If the link does not exist this is a no-op.
-    pub fn remove_link(&mut self, id: &LinkId) {
-        self.topology.remove_link(id);
-        self.route_cache.lock().unwrap().clear();
+    #[allow(dead_code)]
+    pub fn remove_link(&self, id: &LinkId) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.topology.remove_link(id);
+        inner.route_cache.clear();
     }
 
     /// "Best" route is defined as the route with the lowest cost. If there is a tie, one is picked arbitrarily.
@@ -92,7 +115,8 @@ impl Router {
                 cost: 0,
             });
         }
-        let (links, cost) = self.topology.get_low_cost_path(&a, &b)?;
+        let inner = self.inner.lock().unwrap();
+        let (links, cost) = inner.topology.get_low_cost_path(&a, &b)?;
         Some(Route {
             kind: RouteKind::Multihop,
             links,
@@ -114,24 +138,22 @@ impl Router {
             b: addr_b.into(),
             hint: hint.cloned(),
         };
-        {
-            let cache = self.route_cache.lock().unwrap();
-            if let Some(routes) = cache.get(&key) {
-                return routes.clone();
-            }
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(routes) = inner.route_cache.get(&key) {
+            return routes.clone();
         }
-        let routes = self.compute_routes(addr_a, addr_b, hint);
-        self.route_cache.lock().unwrap().insert(key, routes.clone());
+        let routes = Self::compute_routes(&inner.topology, addr_a, addr_b, hint);
+        inner.route_cache.insert(key, routes.clone());
         routes
     }
 
-    /// For now the hint is ignored -- TODO implement ZPL for route policy and then build this out.
-    ///
     /// Unlike `get_best_route` this returns all the routes between addr_a and addr_b.
-    ///
     /// If the optional hint is provided it is used to reduce the set of returned routes. (not yet implemented)
+    ///
+    /// For now the hint is ignored.
+    /// TODO implement ZPL for route policy and then build this out.
     fn compute_routes(
-        &self,
+        topology: &Graph,
         addr_a: &IpAddr,
         addr_b: &IpAddr,
         _hint: Option<&RouteHint>,
@@ -145,7 +167,7 @@ impl Router {
                 cost: 0,
             }];
         }
-        self.topology
+        topology
             .get_all_paths(&a, &b)
             .into_iter()
             .map(|(links, cost)| Route {
@@ -169,6 +191,7 @@ struct Node {
     edges: HashSet<LinkId>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 struct Link {
     a: NodeId,
@@ -188,13 +211,13 @@ impl Graph {
     /// Add a node into the graph. Node is all alone unless a link is added that includes it.
     ///
     /// ## Errors
-    /// - If node already exists then this returns [ServiceError::TopologyNodeExists]
-    fn add_node(&mut self, node_id: impl Into<NodeId>) -> Result<NodeId, ServiceError> {
+    /// - If node already exists then this returns [TopologyError::NodeExists]
+    fn add_node(&mut self, node_id: impl Into<NodeId>) -> Result<NodeId, TopologyError> {
         let nid = node_id.into();
 
         // If node exists call that an error.
         if self.nodes.contains_key(&nid) {
-            return Err(ServiceError::TopologyNodeExists(nid.0));
+            return Err(TopologyError::NodeExists(nid.0));
         }
 
         self.nodes.insert(
@@ -210,8 +233,9 @@ impl Graph {
     /// Add a link between two nodes. The two nodes must be distinct.
     ///
     /// ## Errors
-    /// - If a or b do not exist or are the same then this returns [ServiceError::Topology]
-    /// - If link id already exists then this returns [ServiceError::TopologyLinkExists]
+    /// - If attempt to create link from a node to itself then this returns [TopologyError::LinkToSelf]
+    /// - If a or b do not exist returns [TopologyError::NodeNotFound]
+    /// - If link id already exists then this returns [TopologyError::LinkExists]
     fn add_link(
         &mut self,
         a: NodeId,
@@ -219,29 +243,29 @@ impl Graph {
         id: LinkId,
         attributes: Vec<Attribute>,
         cost: u32,
-    ) -> Result<(), ServiceError> {
+    ) -> Result<(), TopologyError> {
         if a == b {
-            return Err(ServiceError::Topology(
+            return Err(TopologyError::LinkToSelf(
                 "add_link: self-links are not allowed".into(),
             ));
         }
 
         if !self.nodes.contains_key(&a) {
-            return Err(ServiceError::Topology(format!(
+            return Err(TopologyError::NodeNotFound(format!(
                 "add_link: node {:?} does not exist",
                 a
             )));
         }
 
         if !self.nodes.contains_key(&b) {
-            return Err(ServiceError::Topology(format!(
+            return Err(TopologyError::NodeNotFound(format!(
                 "add_link: node {:?} does not exist",
                 b
             )));
         }
 
         if self.edges.contains_key(&id) {
-            return Err(ServiceError::TopologyLinkExists(id.0));
+            return Err(TopologyError::LinkExists(id.0));
         }
 
         self.edges.insert(
@@ -464,7 +488,7 @@ mod tests {
         let a = ip("10.0.0.1");
         let b = ip("10.0.0.2");
         let c = ip("10.0.0.3");
-        let mut r = Router::new();
+        let r = Router::new();
         r.add_node(&a).unwrap();
         r.add_node(&b).unwrap();
         r.add_node(&c).unwrap();
@@ -484,7 +508,7 @@ mod tests {
     #[test]
     fn test_direct_same_node() {
         let a = ip("10.0.0.1");
-        let mut r = Router::new();
+        let r = Router::new();
         r.add_node(&a).unwrap();
         let route = r.get_best_route(&a, &a).unwrap();
         assert!(route.is_direct());
@@ -496,7 +520,7 @@ mod tests {
     fn test_single_link() {
         let a = ip("10.0.0.1");
         let b = ip("10.0.0.2");
-        let mut r = Router::new();
+        let r = Router::new();
         r.add_node(&a).unwrap();
         r.add_node(&b).unwrap();
         r.add_link(&a, &b, &LinkId("ab".into()), &[], 5).unwrap();
@@ -508,7 +532,7 @@ mod tests {
 
     #[test]
     fn test_multihop() {
-        let (mut r, a, b, c) = make_router_abc();
+        let (r, a, b, c) = make_router_abc();
         r.add_link(&a, &b, &LinkId("ab".into()), &[], 1).unwrap();
         r.add_link(&b, &c, &LinkId("bc".into()), &[], 1).unwrap();
         let route = r.get_best_route(&a, &c).unwrap();
@@ -519,7 +543,7 @@ mod tests {
 
     #[test]
     fn test_prefers_lower_cost() {
-        let (mut r, a, b, c) = make_router_abc();
+        let (r, a, b, c) = make_router_abc();
         r.add_link(&a, &b, &LinkId("ab-direct".into()), &[], 10)
             .unwrap();
         r.add_link(&a, &c, &LinkId("ac".into()), &[], 3).unwrap();
@@ -533,7 +557,7 @@ mod tests {
     fn test_unreachable() {
         let a = ip("10.0.0.1");
         let b = ip("10.0.0.2");
-        let mut r = Router::new();
+        let r = Router::new();
         r.add_node(&a).unwrap();
         r.add_node(&b).unwrap();
         assert!(r.get_best_route(&a, &b).is_none());
@@ -542,7 +566,7 @@ mod tests {
     #[test]
     fn test_compute_routes_returns_all_paths() {
         // A-B, B-C, A-C: routes from A to C should include both A-B-C and A-C.
-        let (mut r, a, b, c) = make_router_abc();
+        let (r, a, b, c) = make_router_abc();
         r.add_link(&a, &b, &LinkId("ab".into()), &[], 1).unwrap();
         r.add_link(&b, &c, &LinkId("bc".into()), &[], 1).unwrap();
         r.add_link(&a, &c, &LinkId("ac".into()), &[], 5).unwrap();
@@ -564,7 +588,7 @@ mod tests {
     fn test_route_cache_invalidated_after_remove_link() {
         let a = ip("10.0.0.1");
         let b = ip("10.0.0.2");
-        let mut r = Router::new();
+        let r = Router::new();
         r.add_node(&a).unwrap();
         r.add_node(&b).unwrap();
         r.add_link(&a, &b, &LinkId("ab".into()), &[], 1).unwrap();

--- a/vs/src/router.rs
+++ b/vs/src/router.rs
@@ -1,33 +1,63 @@
-use std::collections::{HashMap, HashSet};
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, HashMap, HashSet};
 use std::net::IpAddr;
+use std::sync::Mutex;
 
 use libeval::attribute::Attribute;
 use libeval::route::{AttrMatch, LinkId, NodeId, Route, RouteHint, RouteKind, TopologyQueryApi};
 
 use crate::error::ServiceError;
 
+/// This is a memoization key used for the [Router::get_routes] cache. It is the tuple of (addr_a, addr_b, hint)
+/// that identifies a particular query for routes between addr_a and addr_b with the given hint.
+/// Repeated calls with the same parameters can return cached results.
+#[derive(Hash, Eq, PartialEq)]
+struct RouteCacheKey {
+    a: NodeId,
+    b: NodeId,
+    hint: Option<RouteHint>,
+}
+
 pub struct Router {
     topology: Graph,
+    route_cache: Mutex<HashMap<RouteCacheKey, Vec<Route>>>,
 }
 
 impl Router {
     pub fn new() -> Self {
         Self {
             topology: Graph::default(),
+            route_cache: Mutex::new(HashMap::new()),
         }
     }
 
-    // TODO: Should add node not error if it exists?
+    /// Adds a node to the Routers view of the network topology.
+    /// Nodes are identified by their IP address.
+    /// Nodes are all alone until links are added that include them.
+    ///
+    ///TODO: This does error if nodes exists... should we instead just merge it in?
+    ///
+    /// ## Errors
+    /// - If node already exists then this returns [ServiceError::TopologyNodeExists]
     pub fn add_node(&mut self, node_addr: &IpAddr) -> Result<(), ServiceError> {
         self.topology.add_node(node_addr)?;
+        self.route_cache.lock().unwrap().clear();
         Ok(())
     }
 
+    /// Removes a node and all its incident links from the topology. If the node does not exist this is a no-op.
     pub fn remove_node(&mut self, node_addr: &IpAddr) {
         let nid: NodeId = node_addr.into();
-        self.topology.remove_node(&nid).ok();
+        self.topology.remove_node(&nid);
+        self.route_cache.lock().unwrap().clear();
     }
 
+    /// Adds a link between the two nodes identified by the given IP addresses.
+    /// The two nodes must be distinct and must already exist in the topology.
+    ///
+    /// ## Errors
+    /// - If a or b do not exist or are the same then this returns [ServiceError::Topology]
+    /// - If link id already exists then this returns [ServiceError::TopologyEdgeExists]
     pub fn add_link(
         &mut self,
         zpr_addr_a: &IpAddr,
@@ -40,40 +70,95 @@ impl Router {
         let b = zpr_addr_b.into();
         self.topology
             .add_link(a, b, id.clone(), attributes.to_vec(), cost)?;
+        self.route_cache.lock().unwrap().clear();
         Ok(())
     }
 
+    /// Remove a link by its id. If the link does not exist this is a no-op.
     pub fn remove_link(&mut self, id: &LinkId) {
-        self.topology.remove_link(id).ok();
+        self.topology.remove_link(id);
+        self.route_cache.lock().unwrap().clear();
     }
 
-    /// For now this assumes there is only one node.
-    /// "Best" route is defined as the route with the lowest cost.  If there is a tie, one is picked arbitrarily.
-    /// These routes are cached and only upadted when topology changes. So this is a O(1) operation.
-    pub fn get_best_route(&self, _addr_a: &IpAddr, _addr_b: &IpAddr) -> Option<Route> {
-        return Some(Route {
-            kind: RouteKind::DirectSameNode {
-                node_id: NodeId("fake-node".to_string()),
-            },
-            links: vec![],
-            cost: 0,
-        });
+    /// "Best" route is defined as the route with the lowest cost. If there is a tie, one is picked arbitrarily.
+    /// These routes are cached and only updated when topology changes. So this is an O(1) operation.
+    pub fn get_best_route(&self, addr_a: &IpAddr, addr_b: &IpAddr) -> Option<Route> {
+        let a: NodeId = addr_a.into();
+        let b: NodeId = addr_b.into();
+        if a == b {
+            return Some(Route {
+                kind: RouteKind::DirectSameNode { node_id: a },
+                links: vec![],
+                cost: 0,
+            });
+        }
+        let (links, cost) = self.topology.get_low_cost_path(&a, &b)?;
+        Some(Route {
+            kind: RouteKind::Multihop,
+            links,
+            cost,
+        })
     }
 
     /// Returns list of routes between addr_a and addr_b that satisfy the hint.
     ///
-    /// Results here are cached. Cache is cleard when topology is updated.
+    /// Results here are cached. Cache is cleared when topology is updated.
     pub fn get_routes(
         &self,
         addr_a: &IpAddr,
         addr_b: &IpAddr,
         hint: Option<&RouteHint>,
     ) -> Vec<Route> {
-        vec![]
+        let key = RouteCacheKey {
+            a: addr_a.into(),
+            b: addr_b.into(),
+            hint: hint.cloned(),
+        };
+        {
+            let cache = self.route_cache.lock().unwrap();
+            if let Some(routes) = cache.get(&key) {
+                return routes.clone();
+            }
+        }
+        let routes = self.compute_routes(addr_a, addr_b, hint);
+        self.route_cache.lock().unwrap().insert(key, routes.clone());
+        routes
+    }
+
+    /// For now the hint is ignored -- TODO implement ZPL for route policy and then build this out.
+    ///
+    /// Unlike `get_best_route` this returns all the routes between addr_a and addr_b.
+    ///
+    /// If the optional hint is provided it is used to reduce the set of returned routes. (not yet implemented)
+    fn compute_routes(
+        &self,
+        addr_a: &IpAddr,
+        addr_b: &IpAddr,
+        _hint: Option<&RouteHint>,
+    ) -> Vec<Route> {
+        let a: NodeId = addr_a.into();
+        let b: NodeId = addr_b.into();
+        if a == b {
+            return vec![Route {
+                kind: RouteKind::DirectSameNode { node_id: a },
+                links: vec![],
+                cost: 0,
+            }];
+        }
+        self.topology
+            .get_all_paths(&a, &b)
+            .into_iter()
+            .map(|(links, cost)| Route {
+                kind: RouteKind::Multihop,
+                links,
+                cost,
+            })
+            .collect()
     }
 }
 
 impl TopologyQueryApi for Router {
+    /// TODO: We do not yet support policy on link attributes and [AttrMatch] is not yet defined. This alwayes returns false.
     fn link_has_attr(&self, _link_id: &LinkId, _attr: &AttrMatch) -> bool {
         false
     }
@@ -96,9 +181,14 @@ struct Link {
 struct Graph {
     nodes: HashMap<NodeId, Node>,
     edges: HashMap<LinkId, Link>,
+    best_routes: HashMap<(NodeId, NodeId), (Vec<LinkId>, u32)>,
 }
 
 impl Graph {
+    /// Add a node into the graph. Node is all alone unless a link is added that includes it.
+    ///
+    /// ## Errors
+    /// - If node already exists then this returns [ServiceError::TopologyNodeExists]
     fn add_node(&mut self, node_id: impl Into<NodeId>) -> Result<NodeId, ServiceError> {
         let nid = node_id.into();
 
@@ -113,9 +203,15 @@ impl Graph {
                 edges: HashSet::new(),
             },
         );
+        self.recompute();
         Ok(nid)
     }
 
+    /// Add a link between two nodes. The two nodes must be distinct.
+    ///
+    /// ## Errors
+    /// - If a or b do not exist or are the same then this returns [ServiceError::Topology]
+    /// - If link id already exists then this returns [ServiceError::TopologyLinkExists]
     fn add_link(
         &mut self,
         a: NodeId,
@@ -160,20 +256,27 @@ impl Graph {
 
         self.nodes.get_mut(&a).unwrap().edges.insert(id.clone());
         self.nodes.get_mut(&b).unwrap().edges.insert(id);
+        self.recompute();
 
         Ok(())
     }
 
+    /// Look up a link by id. Returns `None` if not found.
+    #[allow(dead_code)]
     fn link(&self, id: &LinkId) -> Option<&Link> {
         self.edges.get(id)
     }
 
+    /// Look up a link by id for mutation. Returns `None` if not found.
+    #[allow(dead_code)]
     fn link_mut(&mut self, id: &LinkId) -> Option<&mut Link> {
         self.edges.get_mut(id)
     }
 
+    /// Returns all nodes directly connected to `node_id` by a single link, or `None` if the node does not exist.
+    #[allow(dead_code)]
     fn neighbors(&self, node_id: &NodeId) -> Option<Vec<NodeId>> {
-        let node = self.nodes.get(&node_id)?;
+        let node = self.nodes.get(node_id)?;
         let mut out = Vec::new();
 
         for edge_id in &node.edges {
@@ -189,42 +292,542 @@ impl Graph {
         Some(out)
     }
 
-    /// Returns None if link not found. If link does exist then it is removed and returned.
-    fn remove_link(&mut self, link_id: &LinkId) -> Result<Option<Link>, ServiceError> {
-        let link = match self.edges.remove(link_id) {
-            Some(link) => link,
-            None => return Ok(None),
-        };
-
+    /// Remove a link from the edge map and from both endpoint nodes' edge sets without triggering a recompute.
+    /// Used internally so callers can batch multiple removals before calling `recompute` once.
+    fn remove_link_impl(&mut self, link_id: &LinkId) -> Option<Link> {
+        let link = self.edges.remove(link_id)?;
         if let Some(node) = self.nodes.get_mut(&link.a) {
             node.edges.remove(link_id);
         }
         if let Some(node) = self.nodes.get_mut(&link.b) {
             node.edges.remove(link_id);
         }
+        Some(link)
+    }
 
-        Ok(Some(link))
+    /// Returns None if link not found. If link does exist then it is removed and returned.
+    fn remove_link(&mut self, link_id: &LinkId) -> Option<Link> {
+        let result = self.remove_link_impl(link_id);
+        self.recompute();
+        result
     }
 
     /// Returns None if node not found. If node does exist then it is removed and returned.
-    fn remove_node(&mut self, node_id: &NodeId) -> Result<Option<Node>, ServiceError> {
-        let link_ids: Vec<LinkId> = match self.nodes.get(&node_id) {
+    fn remove_node(&mut self, node_id: &NodeId) -> Option<Node> {
+        let link_ids: Vec<LinkId> = match self.nodes.get(node_id) {
             Some(node) => node.edges.iter().cloned().collect(),
-            None => return Ok(None),
+            None => return None,
         };
 
         for link_id in &link_ids {
-            self.remove_link(link_id)?;
+            self.remove_link_impl(link_id);
         }
 
-        match self.nodes.remove(node_id) {
-            Some(node) => Ok(Some(node)),
-            None => Ok(None),
-        }
+        let result = self.nodes.remove(node_id);
+        self.recompute();
+        result
     }
 
     /// Get the lowest cost path from a to b. If there are multiple this should return one of them.
-    fn get_low_cost_path(&self, _a: &NodeId, _b: &NodeId) -> Option<Vec<LinkId>> {
-        None
+    fn get_low_cost_path(&self, a: &NodeId, b: &NodeId) -> Option<(Vec<LinkId>, u32)> {
+        self.best_routes.get(&(a.clone(), b.clone())).cloned()
+    }
+
+    /// Return every simple path from `start` to `end` (no repeated nodes).
+    fn get_all_paths(&self, start: &NodeId, end: &NodeId) -> Vec<(Vec<LinkId>, u32)> {
+        let mut results = Vec::new();
+        let mut visited = HashSet::new();
+        visited.insert(start.clone());
+        self.dfs_all_paths(start, end, &mut visited, &mut vec![], 0, &mut results);
+        results
+    }
+
+    /// Recursive DFS helper for `get_all_paths`. Extends `path` one link at a time,
+    /// records a result when `current == end`, and backtracks on return.
+    fn dfs_all_paths(
+        &self,
+        current: &NodeId,
+        end: &NodeId,
+        visited: &mut HashSet<NodeId>,
+        path: &mut Vec<LinkId>,
+        cost: u32,
+        results: &mut Vec<(Vec<LinkId>, u32)>,
+    ) {
+        if current == end {
+            results.push((path.clone(), cost));
+            return;
+        }
+        let Some(node) = self.nodes.get(current) else {
+            return;
+        };
+        for link_id in &node.edges {
+            let Some(link) = self.edges.get(link_id) else {
+                continue;
+            };
+            let neighbor = if &link.a == current { &link.b } else { &link.a };
+            if !visited.contains(neighbor) {
+                visited.insert(neighbor.clone());
+                path.push(link_id.clone());
+                self.dfs_all_paths(
+                    neighbor,
+                    end,
+                    visited,
+                    path,
+                    cost.saturating_add(link.cost),
+                    results,
+                );
+                path.pop();
+                visited.remove(neighbor);
+            }
+        }
+    }
+
+    /// Recompute the `best_routes` cache by running Dijkstra from every node.
+    /// Called after any topology change (add/remove node or link).
+    fn recompute(&mut self) {
+        self.best_routes.clear();
+        let starts: Vec<NodeId> = self.nodes.keys().cloned().collect();
+        for start in &starts {
+            for (dest, path_and_cost) in self.dijkstra_from(start) {
+                self.best_routes
+                    .insert((start.clone(), dest), path_and_cost);
+            }
+        }
+    }
+
+    /// Run Dijkstra from `start` and return, for each reachable destination, the
+    /// ordered sequence of link ids on the shortest path and its total cost.
+    fn dijkstra_from(&self, start: &NodeId) -> HashMap<NodeId, (Vec<LinkId>, u32)> {
+        let mut dist: HashMap<NodeId, u32> = HashMap::new();
+        let mut prev: HashMap<NodeId, LinkId> = HashMap::new();
+        let mut heap: BinaryHeap<Reverse<(u32, NodeId)>> = BinaryHeap::new();
+
+        dist.insert(start.clone(), 0);
+        heap.push(Reverse((0, start.clone())));
+
+        while let Some(Reverse((cost, node))) = heap.pop() {
+            if cost > *dist.get(&node).unwrap_or(&u32::MAX) {
+                continue;
+            }
+
+            let Some(node_data) = self.nodes.get(&node) else {
+                continue;
+            };
+            for link_id in &node_data.edges {
+                let Some(link) = self.edges.get(link_id) else {
+                    continue;
+                };
+                let neighbor = if link.a == node { &link.b } else { &link.a };
+                let next_cost = cost.saturating_add(link.cost);
+                if next_cost < *dist.get(neighbor).unwrap_or(&u32::MAX) {
+                    dist.insert(neighbor.clone(), next_cost);
+                    prev.insert(neighbor.clone(), link_id.clone());
+                    heap.push(Reverse((next_cost, neighbor.clone())));
+                }
+            }
+        }
+
+        let mut result = HashMap::new();
+        for dest in dist.keys() {
+            if dest == start {
+                continue;
+            }
+            let mut path = vec![];
+            let mut cur = dest.clone();
+            while let Some(link_id) = prev.get(&cur) {
+                let link = self.edges.get(link_id).unwrap();
+                path.push(link_id.clone());
+                cur = if link.a == cur {
+                    link.b.clone()
+                } else {
+                    link.a.clone()
+                };
+            }
+            if &cur == start {
+                path.reverse();
+                result.insert(dest.clone(), (path, dist[dest]));
+            }
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    fn make_router_abc() -> (Router, IpAddr, IpAddr, IpAddr) {
+        let a = ip("10.0.0.1");
+        let b = ip("10.0.0.2");
+        let c = ip("10.0.0.3");
+        let mut r = Router::new();
+        r.add_node(&a).unwrap();
+        r.add_node(&b).unwrap();
+        r.add_node(&c).unwrap();
+        (r, a, b, c)
+    }
+
+    fn no_hint() -> RouteHint {
+        RouteHint {
+            direct_only: false,
+            require_linked_path: false,
+            any_link_has: vec![],
+            no_link_has: vec![],
+            all_links_have: vec![],
+        }
+    }
+
+    #[test]
+    fn test_direct_same_node() {
+        let a = ip("10.0.0.1");
+        let mut r = Router::new();
+        r.add_node(&a).unwrap();
+        let route = r.get_best_route(&a, &a).unwrap();
+        assert!(route.is_direct());
+        assert_eq!(route.cost, 0);
+        assert!(route.links.is_empty());
+    }
+
+    #[test]
+    fn test_single_link() {
+        let a = ip("10.0.0.1");
+        let b = ip("10.0.0.2");
+        let mut r = Router::new();
+        r.add_node(&a).unwrap();
+        r.add_node(&b).unwrap();
+        r.add_link(&a, &b, &LinkId("ab".into()), &[], 5).unwrap();
+        let route = r.get_best_route(&a, &b).unwrap();
+        assert!(!route.is_direct());
+        assert_eq!(route.cost, 5);
+        assert_eq!(route.links, vec![LinkId("ab".into())]);
+    }
+
+    #[test]
+    fn test_multihop() {
+        let (mut r, a, b, c) = make_router_abc();
+        r.add_link(&a, &b, &LinkId("ab".into()), &[], 1).unwrap();
+        r.add_link(&b, &c, &LinkId("bc".into()), &[], 1).unwrap();
+        let route = r.get_best_route(&a, &c).unwrap();
+        assert!(!route.is_direct());
+        assert_eq!(route.cost, 2);
+        assert_eq!(route.links, vec![LinkId("ab".into()), LinkId("bc".into())]);
+    }
+
+    #[test]
+    fn test_prefers_lower_cost() {
+        let (mut r, a, b, c) = make_router_abc();
+        r.add_link(&a, &b, &LinkId("ab-direct".into()), &[], 10)
+            .unwrap();
+        r.add_link(&a, &c, &LinkId("ac".into()), &[], 3).unwrap();
+        r.add_link(&c, &b, &LinkId("cb".into()), &[], 3).unwrap();
+        let route = r.get_best_route(&a, &b).unwrap();
+        assert_eq!(route.cost, 6);
+        assert_eq!(route.links, vec![LinkId("ac".into()), LinkId("cb".into())]);
+    }
+
+    #[test]
+    fn test_unreachable() {
+        let a = ip("10.0.0.1");
+        let b = ip("10.0.0.2");
+        let mut r = Router::new();
+        r.add_node(&a).unwrap();
+        r.add_node(&b).unwrap();
+        assert!(r.get_best_route(&a, &b).is_none());
+    }
+
+    #[test]
+    fn test_compute_routes_returns_all_paths() {
+        // A-B, B-C, A-C: routes from A to C should include both A-B-C and A-C.
+        let (mut r, a, b, c) = make_router_abc();
+        r.add_link(&a, &b, &LinkId("ab".into()), &[], 1).unwrap();
+        r.add_link(&b, &c, &LinkId("bc".into()), &[], 1).unwrap();
+        r.add_link(&a, &c, &LinkId("ac".into()), &[], 5).unwrap();
+        let hint = no_hint();
+        let routes = r.get_routes(&a, &c, Some(&hint));
+        assert_eq!(routes.len(), 2);
+        let mut link_sets: Vec<Vec<LinkId>> = routes.into_iter().map(|r| r.links).collect();
+        link_sets.sort_by_key(|v| v.iter().map(|l| l.0.clone()).collect::<Vec<_>>());
+        assert_eq!(
+            link_sets,
+            vec![
+                vec![LinkId("ab".into()), LinkId("bc".into())],
+                vec![LinkId("ac".into())],
+            ]
+        );
+    }
+
+    #[test]
+    fn test_route_cache_invalidated_after_remove_link() {
+        let a = ip("10.0.0.1");
+        let b = ip("10.0.0.2");
+        let mut r = Router::new();
+        r.add_node(&a).unwrap();
+        r.add_node(&b).unwrap();
+        r.add_link(&a, &b, &LinkId("ab".into()), &[], 1).unwrap();
+        let hint = no_hint();
+        assert_eq!(r.get_routes(&a, &b, Some(&hint)).len(), 1);
+        r.remove_link(&LinkId("ab".into()));
+        assert_eq!(r.get_routes(&a, &b, Some(&hint)).len(), 0);
+    }
+
+    // --- Graph unit tests ---
+
+    fn nid(s: &str) -> NodeId {
+        NodeId(s.into())
+    }
+
+    fn lid(s: &str) -> LinkId {
+        LinkId(s.into())
+    }
+
+    fn make_graph_abc() -> Graph {
+        let mut g = Graph::default();
+        g.add_node("a").unwrap();
+        g.add_node("b").unwrap();
+        g.add_node("c").unwrap();
+        g
+    }
+
+    #[test]
+    fn test_graph_add_node_success() {
+        // Adding a new node returns its NodeId and stores the node.
+        let mut g = Graph::default();
+        let nid = g.add_node("a").unwrap();
+        assert_eq!(nid, NodeId("a".into()));
+        assert!(g.nodes.contains_key(&nid));
+    }
+
+    #[test]
+    fn test_graph_add_node_duplicate_errors() {
+        // Adding a node whose ID already exists returns an error.
+        let mut g = Graph::default();
+        g.add_node("a").unwrap();
+        assert!(g.add_node("a").is_err());
+    }
+
+    #[test]
+    fn test_graph_add_link_inserts_into_both_nodes() {
+        // A new link is stored in the edges map and in both endpoint nodes' edge sets.
+        let mut g = make_graph_abc();
+        g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 1)
+            .unwrap();
+        assert!(g.edges.contains_key(&lid("ab")));
+        assert!(g.nodes[&nid("a")].edges.contains(&lid("ab")));
+        assert!(g.nodes[&nid("b")].edges.contains(&lid("ab")));
+    }
+
+    #[test]
+    fn test_graph_add_link_self_loop_errors() {
+        // A link whose two endpoints are the same node is rejected.
+        let mut g = Graph::default();
+        g.add_node("a").unwrap();
+        assert!(
+            g.add_link(nid("a"), nid("a"), lid("aa"), vec![], 1)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_graph_add_link_missing_node_a_errors() {
+        // A link referencing a non-existent source node is rejected.
+        let mut g = Graph::default();
+        g.add_node("b").unwrap();
+        assert!(
+            g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 1)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_graph_add_link_missing_node_b_errors() {
+        // A link referencing a non-existent destination node is rejected.
+        let mut g = Graph::default();
+        g.add_node("a").unwrap();
+        assert!(
+            g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 1)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_graph_add_link_duplicate_id_errors() {
+        // Inserting two links with the same ID is rejected.
+        let mut g = make_graph_abc();
+        g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 1)
+            .unwrap();
+        assert!(
+            g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 2)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_graph_remove_link_cleans_up() {
+        // Removing a link returns it and clears it from both nodes' edge sets.
+        let mut g = make_graph_abc();
+        g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 1)
+            .unwrap();
+        let removed = g.remove_link(&lid("ab"));
+        assert!(removed.is_some());
+        assert!(!g.edges.contains_key(&lid("ab")));
+        assert!(!g.nodes[&nid("a")].edges.contains(&lid("ab")));
+        assert!(!g.nodes[&nid("b")].edges.contains(&lid("ab")));
+    }
+
+    #[test]
+    fn test_graph_remove_link_not_found_returns_none() {
+        // Removing a link that does not exist succeeds with Ok(None).
+        let mut g = Graph::default();
+        assert!(g.remove_link(&lid("nope")).is_none());
+    }
+
+    #[test]
+    fn test_graph_remove_node_removes_incident_links() {
+        // Removing a node removes it along with all its incident links and clears peer edge sets.
+        let mut g = make_graph_abc();
+        g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 1)
+            .unwrap();
+        g.add_link(nid("a"), nid("c"), lid("ac"), vec![], 1)
+            .unwrap();
+        g.remove_node(&nid("a"));
+        assert!(!g.nodes.contains_key(&nid("a")));
+        assert!(!g.edges.contains_key(&lid("ab")));
+        assert!(!g.edges.contains_key(&lid("ac")));
+        assert!(g.nodes[&nid("b")].edges.is_empty());
+        assert!(g.nodes[&nid("c")].edges.is_empty());
+    }
+
+    #[test]
+    fn test_graph_remove_node_not_found_returns_none() {
+        // Removing a node that does not exist succeeds with Ok(None).
+        let mut g = Graph::default();
+        assert!(g.remove_node(&nid("x")).is_none());
+    }
+
+    #[test]
+    fn test_graph_neighbors_returns_connected_nodes() {
+        // neighbors() returns all nodes directly connected by a link.
+        let mut g = make_graph_abc();
+        g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 1)
+            .unwrap();
+        g.add_link(nid("a"), nid("c"), lid("ac"), vec![], 1)
+            .unwrap();
+        let mut nbrs = g.neighbors(&nid("a")).unwrap();
+        nbrs.sort();
+        assert_eq!(nbrs, vec![nid("b"), nid("c")]);
+    }
+
+    #[test]
+    fn test_graph_neighbors_unknown_node_returns_none() {
+        // neighbors() returns None when the node does not exist.
+        let g = Graph::default();
+        assert!(g.neighbors(&nid("x")).is_none());
+    }
+
+    #[test]
+    fn test_graph_no_path_returns_none() {
+        // get_low_cost_path returns None when no links connect the two nodes.
+        let mut g = Graph::default();
+        g.add_node("a").unwrap();
+        g.add_node("b").unwrap();
+        assert!(g.get_low_cost_path(&nid("a"), &nid("b")).is_none());
+    }
+
+    #[test]
+    fn test_graph_single_link_path() {
+        // A direct one-link path is found with the correct cost and link sequence.
+        let mut g = Graph::default();
+        g.add_node("a").unwrap();
+        g.add_node("b").unwrap();
+        g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 7)
+            .unwrap();
+        let (path, cost) = g.get_low_cost_path(&nid("a"), &nid("b")).unwrap();
+        assert_eq!(cost, 7);
+        assert_eq!(path, vec![lid("ab")]);
+    }
+
+    #[test]
+    fn test_graph_path_is_symmetric() {
+        // The cost of a→b and b→a are equal (graph is undirected).
+        let mut g = Graph::default();
+        g.add_node("a").unwrap();
+        g.add_node("b").unwrap();
+        g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 4)
+            .unwrap();
+        let (_, fwd) = g.get_low_cost_path(&nid("a"), &nid("b")).unwrap();
+        let (_, rev) = g.get_low_cost_path(&nid("b"), &nid("a")).unwrap();
+        assert_eq!(fwd, rev);
+    }
+
+    #[test]
+    fn test_graph_multihop_path() {
+        // A two-hop path through an intermediate node is returned in traversal order.
+        let mut g = make_graph_abc();
+        g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 1)
+            .unwrap();
+        g.add_link(nid("b"), nid("c"), lid("bc"), vec![], 1)
+            .unwrap();
+        let (path, cost) = g.get_low_cost_path(&nid("a"), &nid("c")).unwrap();
+        assert_eq!(cost, 2);
+        assert_eq!(path, vec![lid("ab"), lid("bc")]);
+    }
+
+    #[test]
+    fn test_graph_prefers_lower_cost_path() {
+        // Dijkstra chooses the cheaper multi-hop route over a costlier direct link.
+        let mut g = make_graph_abc();
+        g.add_link(nid("a"), nid("b"), lid("ab-direct"), vec![], 10)
+            .unwrap();
+        g.add_link(nid("a"), nid("c"), lid("ac"), vec![], 3)
+            .unwrap();
+        g.add_link(nid("c"), nid("b"), lid("cb"), vec![], 3)
+            .unwrap();
+        let (path, cost) = g.get_low_cost_path(&nid("a"), &nid("b")).unwrap();
+        assert_eq!(cost, 6);
+        assert_eq!(path, vec![lid("ac"), lid("cb")]);
+    }
+
+    #[test]
+    fn test_graph_remove_link_invalidates_route() {
+        // After the only link between two nodes is removed, no path remains.
+        let mut g = Graph::default();
+        g.add_node("a").unwrap();
+        g.add_node("b").unwrap();
+        g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 1)
+            .unwrap();
+        assert!(g.get_low_cost_path(&nid("a"), &nid("b")).is_some());
+        g.remove_link(&lid("ab"));
+        assert!(g.get_low_cost_path(&nid("a"), &nid("b")).is_none());
+    }
+
+    #[test]
+    fn test_graph_remove_intermediate_node_invalidates_route() {
+        // Removing the only intermediate node on a path leaves the endpoints unreachable.
+        let mut g = make_graph_abc();
+        g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 1)
+            .unwrap();
+        g.add_link(nid("b"), nid("c"), lid("bc"), vec![], 1)
+            .unwrap();
+        assert!(g.get_low_cost_path(&nid("a"), &nid("c")).is_some());
+        g.remove_node(&nid("b"));
+        assert!(g.get_low_cost_path(&nid("a"), &nid("c")).is_none());
+    }
+
+    #[test]
+    fn test_graph_link_accessor() {
+        // link() returns the stored link with correct endpoints and cost.
+        let mut g = Graph::default();
+        g.add_node("a").unwrap();
+        g.add_node("b").unwrap();
+        g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 9)
+            .unwrap();
+        let l = g.link(&lid("ab")).unwrap();
+        assert_eq!(l.a, nid("a"));
+        assert_eq!(l.b, nid("b"));
+        assert_eq!(l.cost, 9);
     }
 }

--- a/vs/src/router.rs
+++ b/vs/src/router.rs
@@ -1,0 +1,230 @@
+use std::collections::{HashMap, HashSet};
+use std::net::IpAddr;
+
+use libeval::attribute::Attribute;
+use libeval::route::{AttrMatch, LinkId, NodeId, Route, RouteHint, RouteKind, TopologyQueryApi};
+
+use crate::error::ServiceError;
+
+pub struct Router {
+    topology: Graph,
+}
+
+impl Router {
+    pub fn new() -> Self {
+        Self {
+            topology: Graph::default(),
+        }
+    }
+
+    // TODO: Should add node not error if it exists?
+    pub fn add_node(&mut self, node_addr: &IpAddr) -> Result<(), ServiceError> {
+        self.topology.add_node(node_addr)?;
+        Ok(())
+    }
+
+    pub fn remove_node(&mut self, node_addr: &IpAddr) {
+        let nid: NodeId = node_addr.into();
+        self.topology.remove_node(&nid).ok();
+    }
+
+    pub fn add_link(
+        &mut self,
+        zpr_addr_a: &IpAddr,
+        zpr_addr_b: &IpAddr,
+        id: &LinkId,
+        attributes: &[Attribute],
+        cost: u32,
+    ) -> Result<(), ServiceError> {
+        let a = zpr_addr_a.into();
+        let b = zpr_addr_b.into();
+        self.topology
+            .add_link(a, b, id.clone(), attributes.to_vec(), cost)?;
+        Ok(())
+    }
+
+    pub fn remove_link(&mut self, id: &LinkId) {
+        self.topology.remove_link(id).ok();
+    }
+
+    /// For now this assumes there is only one node.
+    /// "Best" route is defined as the route with the lowest cost.  If there is a tie, one is picked arbitrarily.
+    /// These routes are cached and only upadted when topology changes. So this is a O(1) operation.
+    pub fn get_best_route(&self, _addr_a: &IpAddr, _addr_b: &IpAddr) -> Option<Route> {
+        return Some(Route {
+            kind: RouteKind::DirectSameNode {
+                node_id: NodeId("fake-node".to_string()),
+            },
+            links: vec![],
+            cost: 0,
+        });
+    }
+
+    /// Returns list of routes between addr_a and addr_b that satisfy the hint.
+    ///
+    /// Results here are cached. Cache is cleard when topology is updated.
+    pub fn get_routes(
+        &self,
+        addr_a: &IpAddr,
+        addr_b: &IpAddr,
+        hint: Option<&RouteHint>,
+    ) -> Vec<Route> {
+        vec![]
+    }
+}
+
+impl TopologyQueryApi for Router {
+    fn link_has_attr(&self, _link_id: &LinkId, _attr: &AttrMatch) -> bool {
+        false
+    }
+}
+
+#[derive(Debug)]
+struct Node {
+    edges: HashSet<LinkId>,
+}
+
+#[derive(Debug)]
+struct Link {
+    a: NodeId,
+    b: NodeId,
+    attributes: Vec<Attribute>,
+    cost: u32,
+}
+
+#[derive(Debug, Default)]
+struct Graph {
+    nodes: HashMap<NodeId, Node>,
+    edges: HashMap<LinkId, Link>,
+}
+
+impl Graph {
+    fn add_node(&mut self, node_id: impl Into<NodeId>) -> Result<NodeId, ServiceError> {
+        let nid = node_id.into();
+
+        // If node exists call that an error.
+        if self.nodes.contains_key(&nid) {
+            return Err(ServiceError::TopologyNodeExists(nid.0));
+        }
+
+        self.nodes.insert(
+            nid.clone(),
+            Node {
+                edges: HashSet::new(),
+            },
+        );
+        Ok(nid)
+    }
+
+    fn add_link(
+        &mut self,
+        a: NodeId,
+        b: NodeId,
+        id: LinkId,
+        attributes: Vec<Attribute>,
+        cost: u32,
+    ) -> Result<(), ServiceError> {
+        if a == b {
+            return Err(ServiceError::Topology(
+                "add_link: self-links are not allowed".into(),
+            ));
+        }
+
+        if !self.nodes.contains_key(&a) {
+            return Err(ServiceError::Topology(format!(
+                "add_link: node {:?} does not exist",
+                a
+            )));
+        }
+
+        if !self.nodes.contains_key(&b) {
+            return Err(ServiceError::Topology(format!(
+                "add_link: node {:?} does not exist",
+                b
+            )));
+        }
+
+        if self.edges.contains_key(&id) {
+            return Err(ServiceError::TopologyLinkExists(id.0));
+        }
+
+        self.edges.insert(
+            id.clone(),
+            Link {
+                a: a.clone(),
+                b: b.clone(),
+                attributes,
+                cost,
+            },
+        );
+
+        self.nodes.get_mut(&a).unwrap().edges.insert(id.clone());
+        self.nodes.get_mut(&b).unwrap().edges.insert(id);
+
+        Ok(())
+    }
+
+    fn link(&self, id: &LinkId) -> Option<&Link> {
+        self.edges.get(id)
+    }
+
+    fn link_mut(&mut self, id: &LinkId) -> Option<&mut Link> {
+        self.edges.get_mut(id)
+    }
+
+    fn neighbors(&self, node_id: &NodeId) -> Option<Vec<NodeId>> {
+        let node = self.nodes.get(&node_id)?;
+        let mut out = Vec::new();
+
+        for edge_id in &node.edges {
+            let edge = self.edges.get(edge_id)?;
+            let other = if &edge.a == node_id {
+                edge.b.clone()
+            } else {
+                edge.a.clone()
+            };
+            out.push(other);
+        }
+
+        Some(out)
+    }
+
+    /// Returns None if link not found. If link does exist then it is removed and returned.
+    fn remove_link(&mut self, link_id: &LinkId) -> Result<Option<Link>, ServiceError> {
+        let link = match self.edges.remove(link_id) {
+            Some(link) => link,
+            None => return Ok(None),
+        };
+
+        if let Some(node) = self.nodes.get_mut(&link.a) {
+            node.edges.remove(link_id);
+        }
+        if let Some(node) = self.nodes.get_mut(&link.b) {
+            node.edges.remove(link_id);
+        }
+
+        Ok(Some(link))
+    }
+
+    /// Returns None if node not found. If node does exist then it is removed and returned.
+    fn remove_node(&mut self, node_id: &NodeId) -> Result<Option<Node>, ServiceError> {
+        let link_ids: Vec<LinkId> = match self.nodes.get(&node_id) {
+            Some(node) => node.edges.iter().cloned().collect(),
+            None => return Ok(None),
+        };
+
+        for link_id in &link_ids {
+            self.remove_link(link_id)?;
+        }
+
+        match self.nodes.remove(node_id) {
+            Some(node) => Ok(Some(node)),
+            None => Ok(None),
+        }
+    }
+
+    /// Get the lowest cost path from a to b. If there are multiple this should return one of them.
+    fn get_low_cost_path(&self, _a: &NodeId, _b: &NodeId) -> Option<Vec<LinkId>> {
+        None
+    }
+}

--- a/vs/src/router.rs
+++ b/vs/src/router.rs
@@ -16,10 +16,47 @@ use libeval::route::{LinkId, NodeId, Route, RouteKind};
 
 use crate::error::TopologyError;
 
-/// This is a memoization key used for the [Router::get_routes] cache. It is the tuple of (addr_a, addr_b, hint)
-/// that identifies a particular query for routes between addr_a and addr_b with the given hint.
-/// Repeated calls with the same parameters can return cached results.
-#[derive(Hash, Eq, PartialEq)]
+/// Memoization key for [Router::get_routes].
+///
+/// ## Route cache strategy
+///
+/// `get_routes` runs a DFS over the full topology to enumerate all simple paths between two
+/// nodes, which is expensive on large or dense graphs.  Results are stored in
+/// `RouterInner::route_cache` keyed by `(src, dst, hint)`.
+///
+/// ### Targeted invalidation
+///
+/// Instead of flushing the entire cache on every topology change, `RouterInner` maintains two
+/// reverse indices:
+///
+/// - **`link_to_cache_keys`** — maps each `LinkId` → set of cache keys whose routes traverse
+///   that link.  `remove_link` uses this to evict only the entries that actually use the
+///   removed link.
+///
+/// - **`node_to_cache_keys`** — maps each `NodeId` → set of cache keys whose routes pass
+///   through that node (as src, dst, or intermediate hop).  `add_link(a, b)` uses this to
+///   evict only entries touching node a or b — a new link a-b cannot improve any path that
+///   doesn't already go through a or b, so this is exact, not merely conservative.
+///   `remove_node` also uses it to find all entries that route through the removed node.
+///
+/// Both indices are populated in `get_routes` at cache-insert time and cleaned up atomically
+/// by `RouterInner::invalidate_keys` whenever entries are evicted.
+///
+/// ### Ordering constraint
+///
+/// `invalidate_keys` walks `topology.edges` to resolve a `LinkId` → `(node_a, node_b)` for
+/// node-index cleanup.  It must therefore be called **before** the topology mutation that
+/// removes the link/node, otherwise those entries are gone and the node-index leaks stale
+/// `HashSet` entries.
+///
+/// ### Empty-result entries
+///
+/// When `compute_routes` returns an empty `Vec` (nodes exist but are currently unreachable),
+/// the empty result is still cached so we don't keep re-running DFS.  Because there are no
+/// link IDs to walk, the insertion code registers the key directly under
+/// `node_to_cache_keys[src]` and `node_to_cache_keys[dst]`.  This ensures that a subsequent
+/// `add_link` touching either endpoint will correctly evict the stale "unreachable" entry.
+#[derive(Hash, Eq, PartialEq, Clone)]
 struct RouteCacheKey {
     a: NodeId,
     b: NodeId,
@@ -29,6 +66,62 @@ struct RouteCacheKey {
 struct RouterInner {
     topology: Graph,
     route_cache: HashMap<RouteCacheKey, Vec<Route>>,
+    /// Reverse index: cache keys whose routes traverse a given link. See [RouteCacheKey].
+    link_to_cache_keys: HashMap<LinkId, HashSet<RouteCacheKey>>,
+    /// Reverse index: cache keys whose routes pass through a given node. See [RouteCacheKey].
+    node_to_cache_keys: HashMap<NodeId, HashSet<RouteCacheKey>>,
+}
+
+impl RouterInner {
+    /// Removes a set of cache keys and cleans up both reverse indices for each removed entry.
+    ///
+    /// MUST be called before any topology mutation that removes links or nodes because it
+    /// resolves link endpoints via `topology.edges` to clean up `node_to_cache_keys`.
+    /// Duplicate keys in the iterator are safe — a missing `route_cache` entry is a no-op.
+    fn invalidate_keys(&mut self, keys: impl IntoIterator<Item = RouteCacheKey>) {
+        for key in keys {
+            let Some(routes) = self.route_cache.remove(&key) else {
+                continue;
+            };
+            // Collect every link that appeared in any route for this key so we can remove
+            // the key from the per-link and per-node reverse-index buckets.
+            let affected_links: HashSet<LinkId> = routes
+                .iter()
+                .flat_map(|r| r.links.iter().cloned())
+                .collect();
+
+            for link_id in &affected_links {
+                if let Some(s) = self.link_to_cache_keys.get_mut(link_id) {
+                    s.remove(&key);
+                    if s.is_empty() {
+                        self.link_to_cache_keys.remove(link_id);
+                    }
+                }
+                // Walk to the link's endpoint nodes to clean node_to_cache_keys.
+                // This is why we must be called before the topology mutation removes the link.
+                if let Some(link) = self.topology.edges.get(link_id) {
+                    for node_id in [&link.a, &link.b] {
+                        if let Some(s) = self.node_to_cache_keys.get_mut(node_id) {
+                            s.remove(&key);
+                            if s.is_empty() {
+                                self.node_to_cache_keys.remove(node_id);
+                            }
+                        }
+                    }
+                }
+            }
+            // Also clean up the endpoint registrations made for empty-result entries
+            // (those have no links, so the loop above doesn't cover them).
+            for node_id in [&key.a, &key.b] {
+                if let Some(s) = self.node_to_cache_keys.get_mut(node_id) {
+                    s.remove(&key);
+                    if s.is_empty() {
+                        self.node_to_cache_keys.remove(node_id);
+                    }
+                }
+            }
+        }
+    }
 }
 
 pub struct Router {
@@ -41,6 +134,8 @@ impl Router {
             inner: Mutex::new(RouterInner {
                 topology: Graph::default(),
                 route_cache: HashMap::new(),
+                link_to_cache_keys: HashMap::new(),
+                node_to_cache_keys: HashMap::new(),
             }),
         }
     }
@@ -59,12 +154,34 @@ impl Router {
         Ok(())
     }
 
-    /// Removes a node and all its incident links from the topology. If the node does not exist this is a no-op.
+    /// Removes a node and all its incident links from the topology.
     pub fn remove_node(&self, node_addr: &IpAddr) {
         let mut inner = self.inner.lock().unwrap();
         let nid: NodeId = node_addr.into();
+
+        // Phase 1: evict entries that route *through* this node (intermediate-hop coverage).
+        // Collect first to avoid a simultaneous borrow of inner.node_to_cache_keys.
+        let keys: Vec<RouteCacheKey> = inner
+            .node_to_cache_keys
+            .get(&nid)
+            .map(|s| s.iter().cloned().collect())
+            .unwrap_or_default();
+        inner.invalidate_keys(keys);
+        inner.node_to_cache_keys.remove(&nid);
+
+        // Phase 2: scan for any remaining entries where the node is an explicit endpoint.
+        // These arise when compute_routes returned an empty Vec (no links to traverse, so
+        // phase 1's node-index walk wouldn't have found them).
+        let endpoint_keys: Vec<RouteCacheKey> = inner
+            .route_cache
+            .keys()
+            .filter(|k| k.a == nid || k.b == nid)
+            .cloned()
+            .collect();
+        inner.invalidate_keys(endpoint_keys);
+
+        // Topology mutation comes last — invalidate_keys needs topology.edges intact.
         inner.topology.remove_node(&nid);
-        inner.route_cache.clear();
     }
 
     /// Adds a link between the two nodes identified by the given IP addresses.
@@ -85,12 +202,32 @@ impl Router {
         cost: u32,
     ) -> Result<(), TopologyError> {
         let mut inner = self.inner.lock().unwrap();
-        let a = zpr_addr_a.into();
-        let b = zpr_addr_b.into();
+        let a: NodeId = zpr_addr_a.into();
+        let b: NodeId = zpr_addr_b.into();
+
+        // A new link a-b can only create shorter or entirely new paths that pass through
+        // node a or node b.  Any cached entry whose routes don't touch a or b is unaffected,
+        // so we evict only the union of both nodes' reverse-index buckets.  This is exact,
+        // not merely conservative.  Collect first to release the shared borrow before
+        // calling invalidate_keys (which takes &mut inner).
+        let keys: HashSet<RouteCacheKey> = {
+            let from_a = inner
+                .node_to_cache_keys
+                .get(&a)
+                .cloned()
+                .unwrap_or_default();
+            let from_b = inner
+                .node_to_cache_keys
+                .get(&b)
+                .cloned()
+                .unwrap_or_default();
+            from_a.into_iter().chain(from_b).collect()
+        };
+        inner.invalidate_keys(keys);
+
         inner
             .topology
             .add_link(a, b, id.clone(), attributes.to_vec(), cost)?;
-        inner.route_cache.clear();
         Ok(())
     }
 
@@ -98,12 +235,26 @@ impl Router {
     #[allow(dead_code)]
     pub fn remove_link(&self, id: &LinkId) {
         let mut inner = self.inner.lock().unwrap();
+
+        // Only evict entries that actually traverse this specific link — routes on
+        // completely disjoint parts of the topology are unaffected.
+        // Collect before calling invalidate_keys to release the shared borrow.
+        let keys: Vec<RouteCacheKey> = inner
+            .link_to_cache_keys
+            .get(id)
+            .map(|s| s.iter().cloned().collect())
+            .unwrap_or_default();
+
+        // Invalidation must precede topology.remove_link so that topology.edges still
+        // contains the link's endpoint info needed for node-index cleanup.
+        inner.invalidate_keys(keys);
+        inner.link_to_cache_keys.remove(id);
+
         inner.topology.remove_link(id);
-        inner.route_cache.clear();
     }
 
     /// "Best" route is defined as the route with the lowest cost. If there is a tie, one is picked arbitrarily.
-    /// These routes are cached and only updated when topology changes. So this is an O(1) operation.
+    /// These routes are cached and only updated when topology changes.
     pub fn get_best_route(&self, addr_a: &IpAddr, addr_b: &IpAddr) -> Option<Route> {
         let a: NodeId = addr_a.into();
         let b: NodeId = addr_b.into();
@@ -125,7 +276,8 @@ impl Router {
 
     /// Returns list of routes between addr_a and addr_b that satisfy the hint.
     ///
-    /// Results here are cached. Cache is cleared when topology is updated.
+    /// Results are cached; only the affected subset of the cache is invalidated when the
+    /// topology changes.  See [RouteCacheKey] for the full caching strategy.
     pub fn get_routes(
         &self,
         addr_a: &IpAddr,
@@ -142,6 +294,54 @@ impl Router {
             return routes.clone();
         }
         let routes = Self::compute_routes(&inner.topology, addr_a, addr_b, hint);
+
+        // Populate reverse indices so future topology mutations can do targeted eviction.
+        // key is cloned per-entry because route_cache.insert below takes ownership.
+        for route in &routes {
+            for link_id in &route.links {
+                inner
+                    .link_to_cache_keys
+                    .entry(link_id.clone())
+                    .or_default()
+                    .insert(key.clone());
+                // Clone endpoints before dropping the topology borrow; otherwise
+                // Rust rejects the simultaneous immutable borrow of topology.edges
+                // and mutable borrow of node_to_cache_keys on the same `inner`.
+                let endpoints: Option<(NodeId, NodeId)> = inner
+                    .topology
+                    .edges
+                    .get(link_id)
+                    .map(|l| (l.a.clone(), l.b.clone()));
+                if let Some((na, nb)) = endpoints {
+                    inner
+                        .node_to_cache_keys
+                        .entry(na)
+                        .or_default()
+                        .insert(key.clone());
+                    inner
+                        .node_to_cache_keys
+                        .entry(nb)
+                        .or_default()
+                        .insert(key.clone());
+                }
+            }
+        }
+        // An empty result (unreachable pair) has no links to walk, so register the key
+        // directly under both endpoint nodes.  This lets add_link bust the stale entry if
+        // it later creates a path between them.
+        if routes.is_empty() {
+            inner
+                .node_to_cache_keys
+                .entry(key.a.clone())
+                .or_default()
+                .insert(key.clone());
+            inner
+                .node_to_cache_keys
+                .entry(key.b.clone())
+                .or_default()
+                .insert(key.clone());
+        }
+
         inner.route_cache.insert(key, routes.clone());
         routes
     }
@@ -645,6 +845,46 @@ mod tests {
         assert_eq!(r.get_routes(&a, &b, Some(&hint)).len(), 1);
         // New isolated node d has no routes to a.
         assert_eq!(r.get_routes(&a, &d, Some(&hint)).len(), 0);
+    }
+
+    #[test]
+    fn test_targeted_invalidation_preserves_unrelated_entries() {
+        // Removing link a-b must not evict the cached route for the disjoint pair c-d.
+        let a = ip("10.0.0.1");
+        let b = ip("10.0.0.2");
+        let c = ip("10.0.0.3");
+        let d = ip("10.0.0.4");
+        let r = Router::new();
+        r.add_node(&a).unwrap();
+        r.add_node(&b).unwrap();
+        r.add_node(&c).unwrap();
+        r.add_node(&d).unwrap();
+        r.add_link(&a, &b, &LinkId("ab".into()), &[], 1).unwrap();
+        r.add_link(&c, &d, &LinkId("cd".into()), &[], 1).unwrap();
+        let hint = no_hint();
+        // Warm both cache entries.
+        assert_eq!(r.get_routes(&a, &b, Some(&hint)).len(), 1);
+        assert_eq!(r.get_routes(&c, &d, Some(&hint)).len(), 1);
+        // Removing link ab should evict (a,b) but leave (c,d) intact.
+        r.remove_link(&LinkId("ab".into()));
+        assert_eq!(r.get_routes(&a, &b, Some(&hint)).len(), 0);
+        assert_eq!(r.get_routes(&c, &d, Some(&hint)).len(), 1);
+    }
+
+    #[test]
+    fn test_empty_result_invalidated_by_add_link() {
+        // A cached "unreachable" empty result must be evicted when add_link creates a path.
+        let a = ip("10.0.0.1");
+        let b = ip("10.0.0.2");
+        let r = Router::new();
+        r.add_node(&a).unwrap();
+        r.add_node(&b).unwrap();
+        let hint = no_hint();
+        // Warm cache with empty result (no path exists yet).
+        assert_eq!(r.get_routes(&a, &b, Some(&hint)).len(), 0);
+        // Adding a link between a and b must bust the stale empty entry.
+        r.add_link(&a, &b, &LinkId("ab".into()), &[], 1).unwrap();
+        assert_eq!(r.get_routes(&a, &b, Some(&hint)).len(), 1);
     }
 
     // --- Graph unit tests ---

--- a/vs/src/router.rs
+++ b/vs/src/router.rs
@@ -520,15 +520,10 @@ impl Graph {
 
     /// Returns None if node not found. If node does exist then it is removed and returned.
     fn remove_node(&mut self, node_id: &NodeId) -> Option<Node> {
-        let link_ids: Vec<LinkId> = match self.nodes.get(node_id) {
-            Some(node) => node.edges.iter().cloned().collect(),
-            None => return None,
-        };
-
+        let link_ids: Vec<LinkId> = self.nodes.get(node_id)?.edges.iter().cloned().collect();
         for link_id in &link_ids {
             self.remove_link_impl(link_id);
         }
-
         let result = self.nodes.remove(node_id);
         self.recompute();
         result

--- a/vs/src/router.rs
+++ b/vs/src/router.rs
@@ -691,10 +691,9 @@ impl Graph {
                     link.a.clone()
                 };
             }
-            if &cur == start {
-                path.reverse();
-                result.insert(dest.clone(), (path, dist[dest].min(u32::MAX as u64) as u32));
-            }
+            debug_assert_eq!(&cur, start, "prev chain must terminate at start");
+            path.reverse();
+            result.insert(dest.clone(), (path, dist[dest].min(u32::MAX as u64) as u32));
         }
         result
     }

--- a/vs/src/router.rs
+++ b/vs/src/router.rs
@@ -8,7 +8,7 @@
 use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashMap, HashSet};
 use std::net::IpAddr;
-use std::sync::Mutex;
+use std::sync::RwLock;
 
 use libeval::attribute::{AttrMatch, Attribute};
 use libeval::eval_route::{RouteHint, TopologyQueryApi};
@@ -23,6 +23,22 @@ use crate::error::TopologyError;
 /// `get_routes` runs a DFS over the full topology to enumerate all simple paths between two
 /// nodes, which is expensive on large or dense graphs.  Results are stored in
 /// `RouterInner::route_cache` keyed by `(src, dst, hint)`.
+///
+/// ### Concurrency model
+///
+/// `RouterInner` is protected by a `RwLock`.  Cache hits and DFS computation on cache misses
+/// both proceed under a **read** lock, so concurrent route lookups run in parallel.  Only the
+/// brief final step of inserting a computed result into the cache requires a **write** lock.
+///
+/// Because the DFS runs under a read lock, a topology mutation (write lock) may land between
+/// the DFS and the write-lock acquisition.  `RouterInner::topo_generation` is incremented on every
+/// topology change; `get_routes` compares the topo_generation it read against the topo_generation it sees
+/// when it acquires the write lock.  A mismatch means the computed routes may be stale: the
+/// call re-computes from the current topology under the write lock and skips caching to keep
+/// the critical section short.  The caller always receives correct routes.
+///
+/// Note that we are assuming that the co-occurance of full DFS and node changes is infrequent.
+/// If this turns out not to be the case we can look to something like an `ArcSwap<RwLock<>>`.
 ///
 /// ### Targeted invalidation
 ///
@@ -40,11 +56,22 @@ use crate::error::TopologyError;
 /// Targeted invalidation on link *removal* is exact: any affected route must traverse the
 /// removed link, so `link_to_cache_keys` identifies the precise affected set.
 ///
-/// Link *addition* is different.  A new link a-b can create routes for pairs (x, y) whose
-/// previously cached routes never touched a or b at all (e.g. x→a and b→y existed but
-/// a-b did not, so the only cached route was direct x→y).  Determining which pairs could
-/// gain new routes would require a full graph traversal — no cheaper exact answer exists.
-/// `add_link` therefore flushes the entire route cache.
+/// Link *addition* cannot use the same index.  A new link a→b may render stale a cached
+/// entry for (x, y) whose existing routes never touched a or b
+/// (e.g. x→a and b→y existed, a→b did not, so the only cached route was x→y direct;
+/// that entry is now incomplete).  `link_to_cache_keys` won't find it because the entry
+/// doesn't traverse the new link.
+///
+/// A tighter bound exists — the *topological horizon*: only pairs (x, y) where x can
+/// reach {a, b} and {a, b} can reach y are potentially affected; pairs in disconnected
+/// subgraphs are safe.  Computing that reachable set requires a BFS from a and b,
+/// O(V + E).  For shortest-path caches a further *cost horizon* applies: only pairs
+/// where d(x,a) + cost(a,b) + d(b,y) < d(x,y) are actually affected (the incremental
+/// SSSP problem; see Ramalingam & Reps 1996).  Because this cache covers all simple
+/// paths — not just shortest paths — the cost horizon does not directly apply here.
+///
+/// For now `add_link` flushes the entire route cache; targeted invalidation can be
+/// added later if profiling shows link addition is a hot path.
 ///
 /// ### Ordering constraint
 ///
@@ -63,6 +90,8 @@ struct RouterInner {
     route_cache: HashMap<RouteCacheKey, Vec<Route>>,
     /// Reverse index: cache keys whose routes traverse a given link. See [RouteCacheKey].
     link_to_cache_keys: HashMap<LinkId, HashSet<RouteCacheKey>>,
+    /// Incremented on every topology mutation; lets `get_routes` detect stale DFS results.
+    topo_generation: u64,
 }
 
 impl RouterInner {
@@ -93,16 +122,17 @@ impl RouterInner {
 }
 
 pub struct Router {
-    inner: Mutex<RouterInner>,
+    inner: RwLock<RouterInner>,
 }
 
 impl Router {
     pub fn new() -> Self {
         Self {
-            inner: Mutex::new(RouterInner {
+            inner: RwLock::new(RouterInner {
                 topology: Graph::default(),
                 route_cache: HashMap::new(),
                 link_to_cache_keys: HashMap::new(),
+                topo_generation: 0,
             }),
         }
     }
@@ -116,14 +146,15 @@ impl Router {
     /// ## Errors
     /// - If node already exists then this returns [TopologyError::NodeExists]
     pub fn add_node(&self, node_addr: &IpAddr) -> Result<(), TopologyError> {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.write().unwrap();
         inner.topology.add_node(node_addr)?;
+        inner.topo_generation += 1;
         Ok(())
     }
 
     /// Removes a node and all its incident links from the topology.
     pub fn remove_node(&self, node_addr: &IpAddr) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.write().unwrap();
         let nid: NodeId = node_addr.into();
 
         // Phase 1: evict entries whose routes traverse any of the node's incident links.
@@ -161,6 +192,7 @@ impl Router {
 
         // Topology mutation comes last — invalidate_keys needs topology.edges intact.
         inner.topology.remove_node(&nid);
+        inner.topo_generation += 1;
     }
 
     /// Adds a link between the two nodes identified by the given IP addresses.
@@ -180,7 +212,7 @@ impl Router {
         attributes: &[Attribute],
         cost: u32,
     ) -> Result<(), TopologyError> {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.write().unwrap();
         let a: NodeId = zpr_addr_a.into();
         let b: NodeId = zpr_addr_b.into();
 
@@ -193,13 +225,14 @@ impl Router {
         inner
             .topology
             .add_link(a, b, id.clone(), attributes.to_vec(), cost)?;
+        inner.topo_generation += 1;
         Ok(())
     }
 
     /// Remove a link by its id. If the link does not exist this is a no-op.
     #[allow(dead_code)]
     pub fn remove_link(&self, id: &LinkId) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.write().unwrap();
 
         // Only evict entries that actually traverse this specific link — routes on
         // completely disjoint parts of the topology are unaffected.
@@ -216,6 +249,7 @@ impl Router {
         inner.link_to_cache_keys.remove(id);
 
         inner.topology.remove_link(id);
+        inner.topo_generation += 1;
     }
 
     /// "Best" route is defined as the route with the lowest cost. If there is a tie, one is picked arbitrarily.
@@ -230,7 +264,7 @@ impl Router {
                 cost: 0,
             });
         }
-        let inner = self.inner.lock().unwrap();
+        let inner = self.inner.read().unwrap();
         let (links, cost) = inner.topology.get_low_cost_path(&a, &b)?;
         Some(Route {
             kind: RouteKind::Multihop,
@@ -254,14 +288,34 @@ impl Router {
             b: addr_b.into(),
             hint: hint.cloned(),
         };
-        let mut inner = self.inner.lock().unwrap();
+
+        // Fast path: cache hit under read lock.
+        // Cache miss: compute DFS under read lock so concurrent callers run in parallel.
+        let (topo_gen, computed) = {
+            let inner = self.inner.read().unwrap();
+            if let Some(routes) = inner.route_cache.get(&key) {
+                return routes.clone();
+            }
+            let topo_gen = inner.topo_generation;
+            (
+                topo_gen,
+                Self::compute_routes(&inner.topology, addr_a, addr_b, hint),
+            )
+        };
+
+        // Commit under write lock.  If the topology changed while we were computing
+        // (detected via topo_generation mismatch), re-compute from the current topology
+        // and skip caching to keep the write critical section short.
+        let mut inner = self.inner.write().unwrap();
+        if inner.topo_generation != topo_gen {
+            return Self::compute_routes(&inner.topology, addr_a, addr_b, hint);
+        }
+        // Another thread may have won the race and already populated this key.
         if let Some(routes) = inner.route_cache.get(&key) {
             return routes.clone();
         }
-        let routes = Self::compute_routes(&inner.topology, addr_a, addr_b, hint);
-
         // Populate link_to_cache_keys so remove_link can do targeted eviction.
-        for route in &routes {
+        for route in &computed {
             for link_id in &route.links {
                 inner
                     .link_to_cache_keys
@@ -270,9 +324,8 @@ impl Router {
                     .insert(key.clone());
             }
         }
-
-        inner.route_cache.insert(key, routes.clone());
-        routes
+        inner.route_cache.insert(key, computed.clone());
+        computed
     }
 
     /// Unlike `get_best_route` this returns all the routes between addr_a and addr_b.
@@ -365,12 +418,14 @@ impl Graph {
     /// - If link id already exists then this returns [TopologyError::LinkExists]
     fn add_link(
         &mut self,
-        a: NodeId,
-        b: NodeId,
+        a: impl Into<NodeId>,
+        b: impl Into<NodeId>,
         id: LinkId,
         attributes: Vec<Attribute>,
         cost: u32,
     ) -> Result<(), TopologyError> {
+        let a = a.into();
+        let b = b.into();
         if a == b {
             return Err(TopologyError::LinkToSelf(
                 "add_link: self-links are not allowed".into(),
@@ -882,8 +937,7 @@ mod tests {
     fn test_graph_add_link_inserts_into_both_nodes() {
         // A new link is stored in the edges map and in both endpoint nodes' edge sets.
         let mut g = make_graph_abc();
-        g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 1)
-            .unwrap();
+        g.add_link("a", "b", lid("ab"), vec![], 1).unwrap();
         assert!(g.edges.contains_key(&lid("ab")));
         assert!(g.nodes[&nid("a")].edges.contains(&lid("ab")));
         assert!(g.nodes[&nid("b")].edges.contains(&lid("ab")));
@@ -894,10 +948,7 @@ mod tests {
         // A link whose two endpoints are the same node is rejected.
         let mut g = Graph::default();
         g.add_node("a").unwrap();
-        assert!(
-            g.add_link(nid("a"), nid("a"), lid("aa"), vec![], 1)
-                .is_err()
-        );
+        assert!(g.add_link("a", "a", lid("aa"), vec![], 1).is_err());
     }
 
     #[test]
@@ -905,10 +956,7 @@ mod tests {
         // A link referencing a non-existent source node is rejected.
         let mut g = Graph::default();
         g.add_node("b").unwrap();
-        assert!(
-            g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 1)
-                .is_err()
-        );
+        assert!(g.add_link("a", "b", lid("ab"), vec![], 1).is_err());
     }
 
     #[test]
@@ -916,30 +964,22 @@ mod tests {
         // A link referencing a non-existent destination node is rejected.
         let mut g = Graph::default();
         g.add_node("a").unwrap();
-        assert!(
-            g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 1)
-                .is_err()
-        );
+        assert!(g.add_link("a", "b", lid("ab"), vec![], 1).is_err());
     }
 
     #[test]
     fn test_graph_add_link_duplicate_id_errors() {
         // Inserting two links with the same ID is rejected.
         let mut g = make_graph_abc();
-        g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 1)
-            .unwrap();
-        assert!(
-            g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 2)
-                .is_err()
-        );
+        g.add_link("a", "b", lid("ab"), vec![], 1).unwrap();
+        assert!(g.add_link("a", "b", lid("ab"), vec![], 2).is_err());
     }
 
     #[test]
     fn test_graph_remove_link_cleans_up() {
         // Removing a link returns it and clears it from both nodes' edge sets.
         let mut g = make_graph_abc();
-        g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 1)
-            .unwrap();
+        g.add_link("a", "b", lid("ab"), vec![], 1).unwrap();
         let removed = g.remove_link(&lid("ab"));
         assert!(removed.is_some());
         assert!(!g.edges.contains_key(&lid("ab")));
@@ -958,10 +998,8 @@ mod tests {
     fn test_graph_remove_node_removes_incident_links() {
         // Removing a node removes it along with all its incident links and clears peer edge sets.
         let mut g = make_graph_abc();
-        g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 1)
-            .unwrap();
-        g.add_link(nid("a"), nid("c"), lid("ac"), vec![], 1)
-            .unwrap();
+        g.add_link("a", "b", lid("ab"), vec![], 1).unwrap();
+        g.add_link("a", "c", lid("ac"), vec![], 1).unwrap();
         g.remove_node(&nid("a"));
         assert!(!g.nodes.contains_key(&nid("a")));
         assert!(!g.edges.contains_key(&lid("ab")));
@@ -981,10 +1019,8 @@ mod tests {
     fn test_graph_neighbors_returns_connected_nodes() {
         // neighbors() returns all nodes directly connected by a link.
         let mut g = make_graph_abc();
-        g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 1)
-            .unwrap();
-        g.add_link(nid("a"), nid("c"), lid("ac"), vec![], 1)
-            .unwrap();
+        g.add_link("a", "b", lid("ab"), vec![], 1).unwrap();
+        g.add_link("a", "c", lid("ac"), vec![], 1).unwrap();
         let mut nbrs = g.neighbors(&nid("a")).unwrap();
         nbrs.sort();
         assert_eq!(nbrs, vec![nid("b"), nid("c")]);
@@ -1012,8 +1048,7 @@ mod tests {
         let mut g = Graph::default();
         g.add_node("a").unwrap();
         g.add_node("b").unwrap();
-        g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 7)
-            .unwrap();
+        g.add_link("a", "b", lid("ab"), vec![], 7).unwrap();
         let (path, cost) = g.get_low_cost_path(&nid("a"), &nid("b")).unwrap();
         assert_eq!(cost, 7);
         assert_eq!(path, vec![lid("ab")]);
@@ -1025,8 +1060,7 @@ mod tests {
         let mut g = Graph::default();
         g.add_node("a").unwrap();
         g.add_node("b").unwrap();
-        g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 4)
-            .unwrap();
+        g.add_link("a", "b", lid("ab"), vec![], 4).unwrap();
         let (_, fwd) = g.get_low_cost_path(&nid("a"), &nid("b")).unwrap();
         let (_, rev) = g.get_low_cost_path(&nid("b"), &nid("a")).unwrap();
         assert_eq!(fwd, rev);
@@ -1036,10 +1070,8 @@ mod tests {
     fn test_graph_multihop_path() {
         // A two-hop path through an intermediate node is returned in traversal order.
         let mut g = make_graph_abc();
-        g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 1)
-            .unwrap();
-        g.add_link(nid("b"), nid("c"), lid("bc"), vec![], 1)
-            .unwrap();
+        g.add_link("a", "b", lid("ab"), vec![], 1).unwrap();
+        g.add_link("b", "c", lid("bc"), vec![], 1).unwrap();
         let (path, cost) = g.get_low_cost_path(&nid("a"), &nid("c")).unwrap();
         assert_eq!(cost, 2);
         assert_eq!(path, vec![lid("ab"), lid("bc")]);
@@ -1049,12 +1081,9 @@ mod tests {
     fn test_graph_prefers_lower_cost_path() {
         // Dijkstra chooses the cheaper multi-hop route over a costlier direct link.
         let mut g = make_graph_abc();
-        g.add_link(nid("a"), nid("b"), lid("ab-direct"), vec![], 10)
-            .unwrap();
-        g.add_link(nid("a"), nid("c"), lid("ac"), vec![], 3)
-            .unwrap();
-        g.add_link(nid("c"), nid("b"), lid("cb"), vec![], 3)
-            .unwrap();
+        g.add_link("a", "b", lid("ab-direct"), vec![], 10).unwrap();
+        g.add_link("a", "c", lid("ac"), vec![], 3).unwrap();
+        g.add_link("c", "b", lid("cb"), vec![], 3).unwrap();
         let (path, cost) = g.get_low_cost_path(&nid("a"), &nid("b")).unwrap();
         assert_eq!(cost, 6);
         assert_eq!(path, vec![lid("ac"), lid("cb")]);
@@ -1066,8 +1095,7 @@ mod tests {
         let mut g = Graph::default();
         g.add_node("a").unwrap();
         g.add_node("b").unwrap();
-        g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 1)
-            .unwrap();
+        g.add_link("a", "b", lid("ab"), vec![], 1).unwrap();
         assert!(g.get_low_cost_path(&nid("a"), &nid("b")).is_some());
         g.remove_link(&lid("ab"));
         assert!(g.get_low_cost_path(&nid("a"), &nid("b")).is_none());
@@ -1077,10 +1105,8 @@ mod tests {
     fn test_graph_remove_intermediate_node_invalidates_route() {
         // Removing the only intermediate node on a path leaves the endpoints unreachable.
         let mut g = make_graph_abc();
-        g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 1)
-            .unwrap();
-        g.add_link(nid("b"), nid("c"), lid("bc"), vec![], 1)
-            .unwrap();
+        g.add_link("a", "b", lid("ab"), vec![], 1).unwrap();
+        g.add_link("b", "c", lid("bc"), vec![], 1).unwrap();
         assert!(g.get_low_cost_path(&nid("a"), &nid("c")).is_some());
         g.remove_node(&nid("b"));
         assert!(g.get_low_cost_path(&nid("a"), &nid("c")).is_none());
@@ -1092,8 +1118,7 @@ mod tests {
         let mut g = Graph::default();
         g.add_node("a").unwrap();
         g.add_node("b").unwrap();
-        g.add_link(nid("a"), nid("b"), lid("ab"), vec![], 9)
-            .unwrap();
+        g.add_link("a", "b", lid("ab"), vec![], 9).unwrap();
         let l = g.link(&lid("ab")).unwrap();
         assert_eq!(l.a, nid("a"));
         assert_eq!(l.b, nid("b"));

--- a/vs/src/router.rs
+++ b/vs/src/router.rs
@@ -535,52 +535,99 @@ impl Graph {
     }
 
     /// Return every simple path from `start` to `end` (no repeated nodes).
+    /// Uses an explicit heap-allocated stack to avoid recursion depth limits.
     fn get_all_paths(&self, start: &NodeId, end: &NodeId) -> Vec<(Vec<LinkId>, u32)> {
-        let mut results = Vec::new();
-        let mut visited = HashSet::new();
-        visited.insert(start.clone());
-        self.dfs_all_paths(start, end, &mut visited, &mut vec![], 0, &mut results);
-        results
-    }
-
-    /// Recursive DFS helper for `get_all_paths`. Extends `path` one link at a time,
-    /// records a result when `current == end`, and backtracks on return.
-    fn dfs_all_paths(
-        &self,
-        current: &NodeId,
-        end: &NodeId,
-        visited: &mut HashSet<NodeId>,
-        path: &mut Vec<LinkId>,
-        cost: u32,
-        results: &mut Vec<(Vec<LinkId>, u32)>,
-    ) {
-        if current == end {
-            results.push((path.clone(), cost));
-            return;
+        struct Frame {
+            current: NodeId,
+            /// Remaining edges to try; treated as a stack (pop from end).
+            remaining: Vec<LinkId>,
+            /// Link used to reach this node — popped from `path` on backtrack.
+            entered_via: Option<LinkId>,
+            /// Neighbor added to `visited` on entry — removed on backtrack.
+            entered_neighbor: Option<NodeId>,
+            cost: u32,
         }
-        let Some(node) = self.nodes.get(current) else {
-            return;
+
+        if start == end {
+            return vec![(vec![], 0)];
+        }
+        let Some(start_node) = self.nodes.get(start) else {
+            return vec![];
         };
-        for link_id in &node.edges {
-            let Some(link) = self.edges.get(link_id) else {
+
+        let mut results = Vec::new();
+        let mut visited: HashSet<NodeId> = HashSet::new();
+        visited.insert(start.clone());
+        let mut path: Vec<LinkId> = Vec::new();
+        let mut stack = vec![Frame {
+            current: start.clone(),
+            remaining: start_node.edges.iter().cloned().collect(),
+            entered_via: None,
+            entered_neighbor: None,
+            cost: 0,
+        }];
+
+        loop {
+            // Phase 1: backtrack if this frame's edges are exhausted.
+            let exhausted = match stack.last() {
+                None => break,
+                Some(f) => f.remaining.is_empty(),
+            };
+            if exhausted {
+                let f = stack.pop().unwrap();
+                if f.entered_via.is_some() {
+                    path.pop();
+                }
+                if let Some(nb) = f.entered_neighbor {
+                    visited.remove(&nb);
+                }
+                continue;
+            }
+
+            // Phase 2: take the next edge (borrow ends before any stack.push below).
+            let (link_id, cost, current) = {
+                let f = stack.last_mut().unwrap();
+                (f.remaining.pop().unwrap(), f.cost, f.current.clone())
+            };
+
+            let Some(link) = self.edges.get(&link_id) else {
                 continue;
             };
-            let neighbor = if &link.a == current { &link.b } else { &link.a };
-            if !visited.contains(neighbor) {
+            let neighbor = if &link.a == &current {
+                &link.b
+            } else {
+                &link.a
+            };
+
+            if visited.contains(neighbor) {
+                continue;
+            }
+
+            let new_cost = cost.saturating_add(link.cost);
+
+            if neighbor == end {
+                let mut full_path = path.clone();
+                full_path.push(link_id);
+                results.push((full_path, new_cost));
+                continue;
+            }
+
+            // Descend: mark neighbor visited, extend path, push a new frame.
+            let neighbor = neighbor.clone();
+            if let Some(nb_node) = self.nodes.get(&neighbor) {
                 visited.insert(neighbor.clone());
                 path.push(link_id.clone());
-                self.dfs_all_paths(
-                    neighbor,
-                    end,
-                    visited,
-                    path,
-                    cost.saturating_add(link.cost),
-                    results,
-                );
-                path.pop();
-                visited.remove(neighbor);
+                stack.push(Frame {
+                    current: neighbor.clone(),
+                    remaining: nb_node.edges.iter().cloned().collect(),
+                    entered_via: Some(link_id),
+                    entered_neighbor: Some(neighbor),
+                    cost: new_cost,
+                });
             }
         }
+
+        results
     }
 
     /// Recompute the `best_routes` cache by running Dijkstra from every node.
@@ -599,15 +646,15 @@ impl Graph {
     /// Run Dijkstra from `start` and return, for each reachable destination, the
     /// ordered sequence of link ids on the shortest path and its total cost.
     fn dijkstra_from(&self, start: &NodeId) -> HashMap<NodeId, (Vec<LinkId>, u32)> {
-        let mut dist: HashMap<NodeId, u32> = HashMap::new();
+        let mut dist: HashMap<NodeId, u64> = HashMap::new();
         let mut prev: HashMap<NodeId, LinkId> = HashMap::new();
-        let mut heap: BinaryHeap<Reverse<(u32, NodeId)>> = BinaryHeap::new();
+        let mut heap: BinaryHeap<Reverse<(u64, NodeId)>> = BinaryHeap::new();
 
         dist.insert(start.clone(), 0);
         heap.push(Reverse((0, start.clone())));
 
         while let Some(Reverse((cost, node))) = heap.pop() {
-            if cost > *dist.get(&node).unwrap_or(&u32::MAX) {
+            if cost > *dist.get(&node).unwrap_or(&u64::MAX) {
                 continue;
             }
 
@@ -619,8 +666,8 @@ impl Graph {
                     continue;
                 };
                 let neighbor = if link.a == node { &link.b } else { &link.a };
-                let next_cost = cost.saturating_add(link.cost);
-                if next_cost < *dist.get(neighbor).unwrap_or(&u32::MAX) {
+                let next_cost = cost + link.cost as u64;
+                if next_cost < *dist.get(neighbor).unwrap_or(&u64::MAX) {
                     dist.insert(neighbor.clone(), next_cost);
                     prev.insert(neighbor.clone(), link_id.clone());
                     heap.push(Reverse((next_cost, neighbor.clone())));
@@ -646,7 +693,7 @@ impl Graph {
             }
             if &cur == start {
                 path.reverse();
-                result.insert(dest.clone(), (path, dist[dest]));
+                result.insert(dest.clone(), (path, dist[dest].min(u32::MAX as u64) as u32));
             }
         }
         result
@@ -728,6 +775,34 @@ mod tests {
         let route = r.get_best_route(&a, &b).unwrap();
         assert_eq!(route.cost, 6);
         assert_eq!(route.links, vec![LinkId("ac".into()), LinkId("cb".into())]);
+    }
+
+    #[test]
+    fn test_high_cost_multihop_is_reachable() {
+        // Verifies the u64 fix: with saturating_add the old code would compute
+        // u32::MAX + 1 == u32::MAX and fail the < guard, silently dropping node b.
+        let (r, a, b, c) = make_router_abc();
+        r.add_link(&a, &c, &LinkId("ac".into()), &[], u32::MAX)
+            .unwrap();
+        r.add_link(&c, &b, &LinkId("cb".into()), &[], 1).unwrap();
+        let route = r.get_best_route(&a, &b).unwrap();
+        assert_eq!(route.links, vec![LinkId("ac".into()), LinkId("cb".into())]);
+    }
+
+    #[test]
+    fn test_high_cost_prefers_cheaper_over_saturating_path() {
+        // A direct link costing u32::MAX-1 must beat a 2-hop path whose u64
+        // accumulated cost exceeds u32::MAX (old u32 arithmetic would saturate
+        // both to u32::MAX and pick arbitrarily).
+        let (r, a, b, c) = make_router_abc();
+        let half = u32::MAX / 2 + 1;
+        r.add_link(&a, &b, &LinkId("ab".into()), &[], u32::MAX - 1)
+            .unwrap();
+        r.add_link(&a, &c, &LinkId("ac".into()), &[], half).unwrap();
+        r.add_link(&c, &b, &LinkId("cb".into()), &[], half).unwrap();
+        let route = r.get_best_route(&a, &b).unwrap();
+        assert_eq!(route.links, vec![LinkId("ab".into())]);
+        assert_eq!(route.cost, u32::MAX - 1);
     }
 
     #[test]
@@ -1118,5 +1193,71 @@ mod tests {
         assert_eq!(l.a, nid("a"));
         assert_eq!(l.b, nid("b"));
         assert_eq!(l.cost, 9);
+    }
+
+    // --- get_all_paths cycle tests ---
+
+    fn sorted_paths(mut paths: Vec<(Vec<LinkId>, u32)>) -> Vec<Vec<LinkId>> {
+        // Sort by the sequence of link-ID strings so assertions are deterministic.
+        paths.sort_by_key(|(links, _)| links.iter().map(|l| l.0.clone()).collect::<Vec<_>>());
+        paths.into_iter().map(|(l, _)| l).collect()
+    }
+
+    #[test]
+    fn test_graph_get_all_paths_triangle() {
+        // Triangle a-b, b-c, a-c: node c is reachable from a via a direct link
+        // and via b, so get_all_paths must return exactly two paths.
+        let mut g = make_graph_abc();
+        g.add_link("a", "b", lid("ab"), vec![], 1).unwrap();
+        g.add_link("b", "c", lid("bc"), vec![], 1).unwrap();
+        g.add_link("a", "c", lid("ac"), vec![], 5).unwrap();
+        let paths = sorted_paths(g.get_all_paths(&nid("a"), &nid("c")));
+        assert_eq!(paths.len(), 2);
+        assert!(paths.contains(&vec![lid("ab"), lid("bc")]));
+        assert!(paths.contains(&vec![lid("ac")]));
+    }
+
+    #[test]
+    fn test_graph_get_all_paths_diamond() {
+        // Diamond a-b, a-c, b-d, c-d: node d is reachable from a via two
+        // vertex-disjoint paths.  The DFS must not revisit nodes and must
+        // enumerate both routes exactly once each.
+        let mut g = Graph::default();
+        g.add_node("a").unwrap();
+        g.add_node("b").unwrap();
+        g.add_node("c").unwrap();
+        g.add_node("d").unwrap();
+        g.add_link("a", "b", lid("ab"), vec![], 1).unwrap();
+        g.add_link("a", "c", lid("ac"), vec![], 1).unwrap();
+        g.add_link("b", "d", lid("bd"), vec![], 1).unwrap();
+        g.add_link("c", "d", lid("cd"), vec![], 1).unwrap();
+        let paths = sorted_paths(g.get_all_paths(&nid("a"), &nid("d")));
+        assert_eq!(paths.len(), 2);
+        assert!(paths.contains(&vec![lid("ab"), lid("bd")]));
+        assert!(paths.contains(&vec![lid("ac"), lid("cd")]));
+    }
+
+    #[test]
+    fn test_graph_get_all_paths_4node_ring_with_chord() {
+        // 4-node ring a-b-c-d-a plus a direct chord a-c.
+        // Paths from a to c: the chord (a-c), the clockwise hop via b (a-b-c),
+        // and the counter-clockwise hop via d (a-d-c).
+        // This verifies that the iterative DFS correctly backtracks through cycles
+        // without revisiting any node.
+        let mut g = Graph::default();
+        g.add_node("a").unwrap();
+        g.add_node("b").unwrap();
+        g.add_node("c").unwrap();
+        g.add_node("d").unwrap();
+        g.add_link("a", "b", lid("ab"), vec![], 1).unwrap();
+        g.add_link("b", "c", lid("bc"), vec![], 1).unwrap();
+        g.add_link("c", "d", lid("cd"), vec![], 1).unwrap();
+        g.add_link("d", "a", lid("da"), vec![], 1).unwrap();
+        g.add_link("a", "c", lid("ac"), vec![], 3).unwrap();
+        let paths = sorted_paths(g.get_all_paths(&nid("a"), &nid("c")));
+        assert_eq!(paths.len(), 3);
+        assert!(paths.contains(&vec![lid("ab"), lid("bc")]));
+        assert!(paths.contains(&vec![lid("ac")]));
+        assert!(paths.contains(&vec![lid("da"), lid("cd")]));
     }
 }

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -130,7 +130,7 @@ impl VisaMgr {
         )
         .await
         {
-            Ok(VisaDecision::Allow(visa)) => Ok(visa),
+            Ok(VisaDecision::Allow(visa, _route)) => Ok(visa), // TODO: do something with the route
             Ok(VisaDecision::Deny(dcode)) => Err(ServiceError::VisaDenied(dcode.to_string())),
             Err(e) => Err(e),
         }

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -464,6 +464,23 @@ async fn resolve_actors_or_deny(
             source_actor = Some(anon_actor);
         } else {
             // Response side: auth service → unauthenticated adapter.
+            // Verify the source is an auth service before allowing traffic to the AAA address.
+            match asm
+                .actor_mgr
+                .has_auth_services(asm.clone(), candidate_addr)
+                .await
+            {
+                Ok(true) => (),
+                Ok(false) => {
+                    warn!(target: VREQ, "visa denied: non-authentication service at {candidate_addr} attempting to contact AAA address {anon_addr}");
+                    return Err(VisaDecision::Deny(DenyCode::DestNotFound));
+                }
+                Err(e) => {
+                    debug!(target: VREQ, "visa denied: error checking authentication services for actor at {candidate_addr}: {}", e);
+                    return Err(VisaDecision::Deny(DenyCode::DestNotFound));
+                }
+            };
+
             // The AAA address must already be in the table (registered on the request side).
             // This replaces the subnet check: the table records which node owns this address.
             match asm.actor_mgr.get_docking_node_for_aaa(anon_addr) {

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -35,7 +35,7 @@ use libeval::route::Route;
 
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 use zpr::vsapi_types::{DenyCode, PacketDesc, Visa};
 
 use crate::assembly::Assembly;
@@ -500,7 +500,7 @@ mod tests {
     #[tokio::test]
     async fn request_visa_wait_response_denies_when_policy_has_no_match() {
         let (vreq_tx, vreq_rx) = mpsc::channel(8);
-        let mut asm_inner = new_assembly_for_tests(Some(vreq_tx)).await;
+        let asm_inner = new_assembly_for_tests(Some(vreq_tx)).await;
         let src_zpr: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
         let dst_zpr: IpAddr = "fd5a:5052:3000::2".parse().unwrap();
         asm_inner.router.add_node(&src_zpr).unwrap();

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -222,34 +222,34 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
         return Ok(VisaDecision::Deny(DenyCode::DestNotFound));
     };
 
-    // Find the docking nodes for each actor.
+    // Find the docking nodes for each actor. For AAA actors (unauthenticated adapters
+    // fabricated during anonymous auth), the docking node is looked up from the AAA table
+    // registered on the request side, rather than from the connection table.
     let node_addr_a = match asm.actor_mgr.get_docking_node_for_actor(&source_actor) {
         Some(node_addr) => node_addr,
-        None => {
-            if actor_is_phantom(&source_actor) {
-                job.requesting_node.clone()
-            } else {
+        None => match asm.actor_mgr.get_docking_node_for_aaa(source_zpr_addr) {
+            Some(node_addr) => node_addr,
+            None => {
                 warn!(target: VREQ,
                     "visa request from {:?} denied: source actor {:?} is not docked to any node",
                     job.requesting_node, source_actor
                 );
                 return Ok(VisaDecision::Deny(DenyCode::SourceNotFound));
             }
-        }
+        },
     };
     let node_addr_b = match asm.actor_mgr.get_docking_node_for_actor(&dest_actor) {
         Some(node_addr) => node_addr,
-        None => {
-            if actor_is_phantom(&dest_actor) {
-                job.requesting_node.clone()
-            } else {
+        None => match asm.actor_mgr.get_docking_node_for_aaa(dest_zpr_addr) {
+            Some(node_addr) => node_addr,
+            None => {
                 warn!(target: VREQ,
                     "visa request from {:?} denied: dest actor {:?} is not docked to any node",
                     job.requesting_node, dest_actor
                 );
                 return Ok(VisaDecision::Deny(DenyCode::DestNotFound));
             }
-        }
+        },
     };
 
     let Some(default_route) = asm.router.get_best_route(&node_addr_a, &node_addr_b) else {
@@ -329,13 +329,31 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
     }
 }
 
-/// Return TRUE if the actor is tagged as as phantom actor (ie, created for authentication only).
-fn actor_is_phantom(actor: &Actor) -> bool {
-    if let Some(phantom_attr) = actor.get_attribute(key::ZPR_PHANTOM) {
-        phantom_attr.get_value_as_string() == "true"
-    } else {
-        false
-    }
+/// Fabricate an AAA actor for an anonymous endpoint at the given address.
+fn fabricate_aaa_actor(anon_addr: &IpAddr, expiration: SystemTime) -> Actor {
+    let mut anon_actor = Actor::new();
+    let _ = anon_actor.add_attribute(
+        Attribute::builder(key::ZPR_ADDR)
+            .expires(expiration)
+            .value(anon_addr.to_string()),
+    );
+    let _ = anon_actor.add_attribute(
+        Attribute::builder(key::AUTHORITY)
+            .expires(expiration)
+            .value("vs_hack_anon_to_auth"),
+    );
+    let _ = anon_actor.add_attribute(
+        Attribute::builder(key::ROLE)
+            .expires(expiration)
+            .value(ROLE_ADAPTER),
+    );
+    let _ = anon_actor.add_attribute(
+        Attribute::builder(key::CN)
+            .expires(expiration)
+            .value(format!("hack.{}.zpr", anon_addr)),
+    );
+    let _ = anon_actor.add_identity_key(0, key::CN);
+    anon_actor
 }
 
 /// Given that we have an ALLOW decision, pass the hist list in here and we will pick the first
@@ -405,78 +423,61 @@ async fn resolve_actors_or_deny(
             (job.packet_desc.source_addr(), job.packet_desc.dest_addr())
         };
 
-        // The anonymous actor must be using an AAA address (from its node).
-        let node_aaa_net = net_mgr::aaa_network_for_node(&job.requesting_node);
-        if !node_aaa_net.contains(anon_addr) {
-            if missing_source {
+        let expiration = SystemTime::now() + config::DEFAULT_ANON_AUTH_EXPIRATION;
+
+        if missing_source {
+            // Request side: assume this is an unauthenticated adapter → auth service.
+            // Validate that the source is in the requesting node's AAA subnet and that the
+            // destination is a registered auth service, then record the docking node.
+            let node_aaa_net = net_mgr::aaa_network_for_node(&job.requesting_node);
+            if !node_aaa_net.contains(anon_addr) {
                 debug!(target: VREQ,
                     "visa denied: unknown source {anon_addr} is not in the AAA network for node {:?}",
                     job.requesting_node
                 );
                 return Err(VisaDecision::Deny(DenyCode::SourceNotFound));
-            } else {
-                debug!(target: VREQ,
-                    "visa denied: unknown destination {anon_addr} is not in the AAA network for node {:?}",
-                    job.requesting_node
-                );
-                return Err(VisaDecision::Deny(DenyCode::DestNotFound));
             }
-        }
 
-        // The candidate actor must be an installed authentication service.
-        match asm
-            .actor_mgr
-            .has_auth_services(asm.clone(), candidate_addr)
-            .await
-        {
-            Ok(true) => (),
-            Ok(false) => {
-                warn!(target: VREQ, "visa denied: actor using AAA addr attempting to contact non-authentication service at {candidate_addr}");
-                return Err(VisaDecision::Deny(DenyCode::DestNotFound));
-            }
-            Err(e) => {
-                debug!(target: VREQ, "visa denied: error checking authentication services for actor at {candidate_addr}: {}", e);
-                return Err(VisaDecision::Deny(DenyCode::DestNotFound));
-            }
-        };
+            match asm
+                .actor_mgr
+                .has_auth_services(asm.clone(), candidate_addr)
+                .await
+            {
+                Ok(true) => (),
+                Ok(false) => {
+                    warn!(target: VREQ, "visa denied: actor using AAA addr attempting to contact non-authentication service at {candidate_addr}");
+                    return Err(VisaDecision::Deny(DenyCode::DestNotFound));
+                }
+                Err(e) => {
+                    debug!(target: VREQ, "visa denied: error checking authentication services for actor at {candidate_addr}: {}", e);
+                    return Err(VisaDecision::Deny(DenyCode::DestNotFound));
+                }
+            };
 
-        // We have confirmed that an actor is trying to access a valid authentication service using a valid AAA address.
-        // To proceed, we fabricate a phantom actor for this request.  This phantom acts as the anonymous actor for
-        // purposes of granting a visa.
-        let expiration = SystemTime::now() + config::DEFAULT_ANON_AUTH_EXPIRATION;
-        let mut anon_actor = Actor::new();
-        let _ = anon_actor.add_attribute(
-            Attribute::builder(key::ZPR_PHANTOM)
-                .expires(expiration)
-                .value("true"),
-        );
-        let _ = anon_actor.add_attribute(
-            Attribute::builder(key::ZPR_ADDR)
-                .expires(expiration)
-                .value(anon_addr.to_string()),
-        );
-        let _ = anon_actor.add_attribute(
-            Attribute::builder(key::AUTHORITY)
-                .expires(expiration)
-                .value("vs_hack_anon_to_auth"),
-        );
-        let _ = anon_actor.add_attribute(
-            Attribute::builder(key::ROLE)
-                .expires(expiration)
-                .value(ROLE_ADAPTER),
-        );
-        let _ = anon_actor.add_attribute(
-            Attribute::builder(key::CN)
-                .expires(expiration)
-                .value(format!("hack.{}.zpr", anon_addr)),
-        );
-        let _ = anon_actor.add_identity_key(0, key::CN);
+            // Record the docking node so the response side can resolve it correctly,
+            // even when the response arrives via a different requesting node.
+            asm.actor_mgr
+                .register_aaa(*anon_addr, job.requesting_node, expiration);
 
-        if missing_source {
-            debug!(target: VREQ, "fabricated phantom actor for anonymous AAA request: {:?} -> {candidate_addr}", anon_actor);
+            let anon_actor = fabricate_aaa_actor(anon_addr, expiration);
+            debug!(target: VREQ, "fabricated AAA actor for anonymous request: {:?} -> {candidate_addr}", anon_actor);
             source_actor = Some(anon_actor);
         } else {
-            debug!(target: VREQ, "fabricated phantom actor for anonymous AAA response: {candidate_addr} -> {:?}", anon_actor);
+            // Response side: auth service → unauthenticated adapter.
+            // The AAA address must already be in the table (registered on the request side).
+            // This replaces the subnet check: the table records which node owns this address.
+            match asm.actor_mgr.get_docking_node_for_aaa(anon_addr) {
+                Some(_) => {}
+                None => {
+                    warn!(target: VREQ,
+                        "visa denied: AAA address {anon_addr} not found in AAA table (expired or never registered)"
+                    );
+                    return Err(VisaDecision::Deny(DenyCode::DestNotFound));
+                }
+            }
+
+            let anon_actor = fabricate_aaa_actor(anon_addr, expiration);
+            debug!(target: VREQ, "fabricated AAA actor for anonymous response: {candidate_addr} -> {:?}", anon_actor);
             dest_actor = Some(anon_actor);
         }
     }
@@ -536,15 +537,13 @@ mod tests {
 
     use crate::assembly::Assembly;
     use crate::assembly::tests::new_assembly_for_tests;
-    use crate::test_helpers::{
-        make_actor_defexp, make_actor_with_services_defexp, make_node_actor_defexp,
-    };
+    use crate::test_helpers::{make_actor_with_services_defexp, make_node_actor_defexp};
     use bytes::Bytes;
-    use libeval::attribute::{ROLE_ADAPTER, key};
+    use libeval::attribute::ROLE_ADAPTER;
     use libeval::eval_result::Direction;
     use libeval::policy::Policy;
     use libeval::route::{LinkId, RouteKind};
-    use std::time::Duration;
+    use std::time::{Duration, SystemTime};
     use zpr::policy_types::{JoinPolicy, PFlags, Scope, Service, ServiceType};
     use zpr::write_to::WriteTo;
 
@@ -714,10 +713,10 @@ mod tests {
     }
 
     // Missing source in the AAA subnet, destination is a registered auth service:
-    // fabricate a phantom actor for the anonymous source and allow the resolution.
+    // fabricate an AAA actor for the anonymous source and register it in the AAA table.
     #[tokio::test]
-    async fn resolve_actors_or_deny_missing_source_in_aaa_net_with_auth_service_fabricates_phantom()
-    {
+    async fn resolve_actors_or_deny_missing_source_in_aaa_net_with_auth_service_fabricates_aaa_actor()
+     {
         let asm_inner = new_assembly_for_tests(None).await;
 
         let dest_zpr = "fd5a:5052:3000::2";
@@ -740,15 +739,22 @@ mod tests {
         let (job, _rx) = VisaRequestJob::new(requesting_node, pkt);
 
         let dst = make_node_actor_defexp(dest_zpr, "dst", "10.0.0.2:1002");
-        let (phantom_src, resolved_dst) = resolve_actors_or_deny(&asm, &job, None, Some(dst))
+        let (aaa_src_actor, resolved_dst) = resolve_actors_or_deny(&asm, &job, None, Some(dst))
             .await
             .ok()
             .expect("expected Ok");
 
         let expected_aaa: IpAddr = aaa_src.parse().unwrap();
         let expected_dst: IpAddr = dest_zpr.parse().unwrap();
-        assert_eq!(phantom_src.get_zpr_addr(), Some(&expected_aaa));
+        assert_eq!(aaa_src_actor.get_zpr_addr(), Some(&expected_aaa));
         assert_eq!(resolved_dst.get_zpr_addr(), Some(&expected_dst));
+
+        // Confirm the AAA table was populated by the request-side registration.
+        assert_eq!(
+            asm.actor_mgr.get_docking_node_for_aaa(&expected_aaa),
+            Some(requesting_node),
+            "aaa_table must record the requesting node as docking node"
+        );
     }
 
     // Missing destination whose address is a plain ZPR address (not in the node's AAA subnet) is denied.
@@ -769,10 +775,10 @@ mod tests {
         ));
     }
 
-    // Missing destination in the AAA subnet, source is a registered auth service:
-    // fabricate a phantom actor for the anonymous destination and allow the resolution.
+    // Missing destination with the AAA address pre-registered in the table (simulating a prior
+    // forward request): fabricate an AAA actor for the anonymous destination.
     #[tokio::test]
-    async fn resolve_actors_or_deny_missing_dest_in_aaa_net_with_auth_service_fabricates_phantom() {
+    async fn resolve_actors_or_deny_missing_dest_in_aaa_table_fabricates_aaa_actor() {
         let asm_inner = new_assembly_for_tests(None).await;
 
         let src_zpr = "fd5a:5052:3000::1";
@@ -791,45 +797,37 @@ mod tests {
         let asm = Arc::new(asm_inner);
         let requesting_node: IpAddr = "fd5a:5052:3000::ff".parse().unwrap();
         let aaa_dst = "fd5a:5052:0:aaa:0:ff00::1";
+        let aaa_dst_addr: IpAddr = aaa_dst.parse().unwrap();
+
+        // Pre-register as the request side would have done.
+        asm.actor_mgr.register_aaa(
+            aaa_dst_addr,
+            requesting_node,
+            SystemTime::now() + Duration::from_secs(300),
+        );
+
         let pkt = PacketDesc::new_tcp(src_zpr, aaa_dst, 12345, 80).unwrap();
         let (job, _rx) = VisaRequestJob::new(requesting_node, pkt);
 
         let src = make_node_actor_defexp(src_zpr, "src", "10.0.0.1:1001");
-        let (resolved_src, phantom_dst) = resolve_actors_or_deny(&asm, &job, Some(src), None)
+        let (resolved_src, aaa_dst_actor) = resolve_actors_or_deny(&asm, &job, Some(src), None)
             .await
             .ok()
             .expect("expected Ok");
 
         let expected_src: IpAddr = src_zpr.parse().unwrap();
-        let expected_aaa: IpAddr = aaa_dst.parse().unwrap();
         assert_eq!(resolved_src.get_zpr_addr(), Some(&expected_src));
-        assert_eq!(phantom_dst.get_zpr_addr(), Some(&expected_aaa));
+        assert_eq!(aaa_dst_actor.get_zpr_addr(), Some(&aaa_dst_addr));
     }
 
-    // --- actor_is_phantom tests ---
+    // --- AAA actor full pipeline tests ---
 
-    // An actor tagged with ZPR_PHANTOM="true" is recognized as a phantom.
-    #[test]
-    fn actor_is_phantom_returns_true_for_tagged_actor() {
-        let actor = make_actor_defexp(&[(key::ZPR_PHANTOM, "true")]);
-        assert!(actor_is_phantom(&actor));
-    }
-
-    // A normal node actor with no ZPR_PHANTOM attribute is not a phantom.
-    #[test]
-    fn actor_is_phantom_returns_false_for_untagged_actor() {
-        let actor = make_node_actor_defexp("fd5a:5052:3000::1", "some-node", "10.0.0.1:1001");
-        assert!(!actor_is_phantom(&actor));
-    }
-
-    // --- Phantom actor full pipeline tests ---
-
-    // Shared setup for phantom pipeline tests:
-    //   node A (fd5a:5052:3000::1) = requesting node and phantom docking node
+    // Shared setup for AAA pipeline tests:
+    //   node A (fd5a:5052:3000::1) = requesting node and AAA actor docking node
     //   node B (fd5a:5052:3000::2) = auth service docking node
     //   auth adapter (fd5a:5052:3000::30) docked to node B, service "svc:auth"
     //   AAA subnet for node A: fd5a:5052:0:aaa:0:100::/88
-    async fn build_phantom_test_asm(with_link: bool) -> Arc<Assembly> {
+    async fn build_aaa_test_asm(with_link: bool) -> Arc<Assembly> {
         let asm = new_assembly_for_tests(None).await;
 
         let node_a_addr: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
@@ -872,11 +870,11 @@ mod tests {
         Arc::new(asm)
     }
 
-    // A phantom source actor passes the docking-node check and reaches policy evaluation.
-    // Without the patch this returns Deny(SourceNotFound); with it, Deny(NoMatch).
+    // An AAA source actor passes the docking-node check and reaches policy evaluation.
+    // Deny(NoMatch) confirms the actor was resolved and routing succeeded.
     #[tokio::test]
-    async fn process_visa_request_phantom_source_reaches_policy_eval() {
-        let asm = build_phantom_test_asm(true).await;
+    async fn process_visa_request_aaa_source_reaches_policy_eval() {
+        let asm = build_aaa_test_asm(true).await;
         let requesting_node: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
         // node_id for ::1 = 0x000001; segments[5] = 0x0001<<8 = 0x0100 → subnet fd5a:5052:0:aaa:0:100::/88
         let pkt = PacketDesc::new_tcp(
@@ -891,11 +889,11 @@ mod tests {
         assert!(matches!(result, VisaDecision::Deny(DenyCode::NoMatch)));
     }
 
-    // A phantom source with no route between the phantom docking node and the auth service
-    // docking node is denied NoReason (not SourceNotFound), proving the docking check passed.
+    // An AAA source with no route between the docking node and the auth service docking node
+    // is denied NoReason (not SourceNotFound), confirming the docking check passed.
     #[tokio::test]
-    async fn process_visa_request_phantom_source_no_route_denied() {
-        let asm = build_phantom_test_asm(false).await;
+    async fn process_visa_request_aaa_source_no_route_denied() {
+        let asm = build_aaa_test_asm(false).await;
         let requesting_node: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
         let pkt = PacketDesc::new_tcp(
             "fd5a:5052:0:aaa:0:100::1",
@@ -909,12 +907,22 @@ mod tests {
         assert!(matches!(result, VisaDecision::Deny(DenyCode::NoReason)));
     }
 
-    // A phantom destination actor passes the docking-node check and reaches policy evaluation.
-    // Without the patch this returns Deny(DestNotFound); with it, Deny(NoMatch).
+    // An AAA destination actor with the AAA table pre-populated reaches policy evaluation.
+    // Deny(NoMatch) confirms the actor was resolved and routing succeeded.
     #[tokio::test]
-    async fn process_visa_request_phantom_dest_reaches_policy_eval() {
-        let asm = build_phantom_test_asm(true).await;
-        let requesting_node: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
+    async fn process_visa_request_aaa_dest_reaches_policy_eval() {
+        let asm = build_aaa_test_asm(true).await;
+        let node_a_addr: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
+        let aaa_addr: IpAddr = "fd5a:5052:0:aaa:0:100::1".parse().unwrap();
+
+        // Pre-register as the request side would have done.
+        asm.actor_mgr.register_aaa(
+            aaa_addr,
+            node_a_addr,
+            SystemTime::now() + Duration::from_secs(300),
+        );
+
+        let requesting_node = node_a_addr;
         let pkt = PacketDesc::new_tcp(
             "fd5a:5052:3000::30",
             "fd5a:5052:0:aaa:0:100::1",
@@ -925,5 +933,55 @@ mod tests {
         let (job, _rx) = VisaRequestJob::new(requesting_node, pkt);
         let result = process_visa_request(asm, &job).await.unwrap();
         assert!(matches!(result, VisaDecision::Deny(DenyCode::NoMatch)));
+    }
+
+    // Multi-node test: node A is the AAA docking node, node B hosts the auth service.
+    // A forward request (requesting_node=A) registers the AAA address.
+    // A return visa (requesting_node=B) must resolve the AAA dest to node A via the table.
+    #[tokio::test]
+    async fn process_visa_request_aaa_dest_multi_node_resolves_to_correct_docking_node() {
+        let asm = build_aaa_test_asm(true).await;
+
+        let node_a_addr: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
+        let node_b_addr: IpAddr = "fd5a:5052:3000::2".parse().unwrap();
+        let aaa_addr: IpAddr = "fd5a:5052:0:aaa:0:100::1".parse().unwrap();
+
+        // Step 1: forward request from node A registers the AAA address in the table.
+        let fwd_pkt = PacketDesc::new_tcp(
+            "fd5a:5052:0:aaa:0:100::1",
+            "fd5a:5052:3000::30",
+            12345,
+            4000,
+        )
+        .unwrap();
+        let (fwd_job, _rx) = VisaRequestJob::new(node_a_addr, fwd_pkt);
+        let _ = process_visa_request(asm.clone(), &fwd_job).await.unwrap();
+
+        // Confirm the AAA table now maps the address to node A.
+        assert_eq!(
+            asm.actor_mgr.get_docking_node_for_aaa(&aaa_addr),
+            Some(node_a_addr),
+            "aaa_table must map aaa_addr to node A after forward request"
+        );
+
+        // Step 2: return visa arrives via node B (the auth service's node).
+        // Without the fix, requesting_node=B would cause the subnet check to fail.
+        // With the fix, the table lookup finds node A as the correct docking node.
+        let ret_pkt = PacketDesc::new_tcp(
+            "fd5a:5052:3000::30",
+            "fd5a:5052:0:aaa:0:100::1",
+            4000,
+            12345,
+        )
+        .unwrap();
+        let (ret_job, _rx) = VisaRequestJob::new(node_b_addr, ret_pkt);
+        let result = process_visa_request(asm, &ret_job).await.unwrap();
+
+        // Deny(NoMatch) means routing resolved correctly; the request reached policy eval.
+        // Deny(DestNotFound) would mean the table lookup failed (the old bug).
+        assert!(
+            matches!(result, VisaDecision::Deny(DenyCode::NoMatch)),
+            "expected NoMatch (policy eval reached)"
+        );
     }
 }

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -515,9 +515,47 @@ mod tests {
     use super::*;
 
     use crate::assembly::tests::new_assembly_for_tests;
-    use crate::test_helpers::make_node_actor_defexp;
-    use libeval::route::LinkId;
+    use crate::test_helpers::{make_actor_with_services_defexp, make_node_actor_defexp};
+    use bytes::Bytes;
+    use libeval::attribute::ROLE_ADAPTER;
+    use libeval::eval_result::Direction;
+    use libeval::policy::Policy;
+    use libeval::route::{LinkId, RouteKind};
     use std::time::Duration;
+    use zpr::policy_types::{JoinPolicy, PFlags, Scope, Service, ServiceType};
+    use zpr::write_to::WriteTo;
+
+    /// Builds a Policy that declares one Authentication service with the given id.
+    fn make_policy_with_auth_service(service_id: &str) -> Policy {
+        let mut msg = capnp::message::Builder::new_default();
+        {
+            let mut policy_bldr = msg.init_root::<zpr::policy::v1::policy::Builder>();
+            policy_bldr.set_created("2024-01-01T00:00:00Z");
+            policy_bldr.set_version(2);
+            policy_bldr.set_metadata("");
+
+            let mut jp_list = policy_bldr.reborrow().init_join_policies(1);
+            let mut jp_bldr = jp_list.reborrow().get(0);
+            let jp = JoinPolicy {
+                conditions: Vec::new(),
+                flags: PFlags::default(),
+                provides: Some(vec![Service {
+                    id: service_id.to_string(),
+                    endpoints: vec![Scope {
+                        protocol: 0,
+                        flag: None,
+                        port: Some(4000),
+                        port_range: None,
+                    }],
+                    kind: ServiceType::Authentication,
+                }]),
+            };
+            jp.write_to(&mut jp_bldr);
+        }
+        let mut bytes = Vec::new();
+        capnp::serialize::write_message(&mut bytes, &msg).unwrap();
+        Policy::new_from_policy_bytes(Bytes::copy_from_slice(&bytes)).unwrap()
+    }
 
     // This test just runs a request through the pipeline. There is no real policy here
     // so it will fail.  But it should be a visa-deny not some other error.
@@ -555,5 +593,193 @@ mod tests {
         assert!(matches!(result, VisaDecision::Deny(DenyCode::NoMatch)));
 
         arena.abort();
+    }
+
+    // Verifies that visa_from_allow issues a visa and returns Allow when given a valid hit and route.
+    #[tokio::test]
+    async fn visa_from_allow_issues_visa_on_allow() {
+        let asm = new_assembly_for_tests(None).await;
+        let requesting_node: IpAddr = "fd5a:5052:3000::ff".parse().unwrap();
+        let pkt_data =
+            PacketDesc::new_tcp("fd5a:5052:3000::1", "fd5a:5052:3000::2", 12345, 80).unwrap();
+        let (job, _rx) = VisaRequestJob::new(requesting_node, pkt_data);
+
+        let hits = vec![Hit::new_no_signal(0, Direction::Forward)];
+        let policy = Policy::new_empty();
+        let route = Route {
+            kind: RouteKind::Multihop,
+            links: vec![],
+            cost: 0,
+        };
+
+        let result = visa_from_allow(&asm, &job, &hits, &policy, route).await;
+        assert!(matches!(result, Ok(VisaDecision::Allow(_, _))));
+    }
+
+    // When both actors are None the request cannot proceed: deny the source immediately.
+    #[tokio::test]
+    async fn resolve_actors_or_deny_both_missing_denies_source() {
+        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let requesting_node: IpAddr = "fd5a:5052:3000::ff".parse().unwrap();
+        let pkt = PacketDesc::new_tcp("fd5a:5052:3000::1", "fd5a:5052:3000::2", 12345, 80).unwrap();
+        let (job, _rx) = VisaRequestJob::new(requesting_node, pkt);
+
+        let result = resolve_actors_or_deny(&asm, &job, None, None).await;
+        assert!(matches!(
+            result,
+            Err(VisaDecision::Deny(DenyCode::SourceNotFound))
+        ));
+    }
+
+    // When both actors are known they pass through unchanged.
+    #[tokio::test]
+    async fn resolve_actors_or_deny_both_present_passes_through() {
+        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let requesting_node: IpAddr = "fd5a:5052:3000::ff".parse().unwrap();
+        let pkt = PacketDesc::new_tcp("fd5a:5052:3000::1", "fd5a:5052:3000::2", 12345, 80).unwrap();
+        let (job, _rx) = VisaRequestJob::new(requesting_node, pkt);
+
+        let src = make_node_actor_defexp("fd5a:5052:3000::1", "src", "10.0.0.1:1001");
+        let dst = make_node_actor_defexp("fd5a:5052:3000::2", "dst", "10.0.0.2:1002");
+        let src_addr: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
+        let dst_addr: IpAddr = "fd5a:5052:3000::2".parse().unwrap();
+
+        let (ra, rb) = resolve_actors_or_deny(&asm, &job, Some(src), Some(dst))
+            .await
+            .ok()
+            .expect("expected Ok");
+        assert_eq!(ra.get_zpr_addr(), Some(&src_addr));
+        assert_eq!(rb.get_zpr_addr(), Some(&dst_addr));
+    }
+
+    // Missing source whose address is a plain ZPR address (not in the node's AAA subnet) is denied.
+    #[tokio::test]
+    async fn resolve_actors_or_deny_missing_source_not_in_aaa_network_denies_source() {
+        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let requesting_node: IpAddr = "fd5a:5052:3000::ff".parse().unwrap();
+        // source addr is a normal ZPR address, outside any node AAA subnet
+        let pkt =
+            PacketDesc::new_tcp("fd5a:5052:3000::99", "fd5a:5052:3000::2", 12345, 80).unwrap();
+        let (job, _rx) = VisaRequestJob::new(requesting_node, pkt);
+
+        let dst = make_node_actor_defexp("fd5a:5052:3000::2", "dst", "10.0.0.2:1002");
+        let result = resolve_actors_or_deny(&asm, &job, None, Some(dst)).await;
+        assert!(matches!(
+            result,
+            Err(VisaDecision::Deny(DenyCode::SourceNotFound))
+        ));
+    }
+
+    // Missing source in the AAA subnet but the destination has no auth service registered:
+    // deny because it would be a non-authenticated actor talking to a non-auth endpoint.
+    #[tokio::test]
+    async fn resolve_actors_or_deny_missing_source_in_aaa_net_dest_not_auth_service_denies() {
+        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let requesting_node: IpAddr = "fd5a:5052:3000::ff".parse().unwrap();
+        // AAA subnet for node ::ff is fd5a:5052:0:aaa:0:ff00::/88; pick an address inside it.
+        let aaa_src = "fd5a:5052:0:aaa:0:ff00::1";
+        let pkt = PacketDesc::new_tcp(aaa_src, "fd5a:5052:3000::2", 12345, 80).unwrap();
+        let (job, _rx) = VisaRequestJob::new(requesting_node, pkt);
+
+        // No actor with auth services in the DB at the dest addr.
+        let dst = make_node_actor_defexp("fd5a:5052:3000::2", "dst", "10.0.0.2:1002");
+        let result = resolve_actors_or_deny(&asm, &job, None, Some(dst)).await;
+        assert!(matches!(
+            result,
+            Err(VisaDecision::Deny(DenyCode::DestNotFound))
+        ));
+    }
+
+    // Missing source in the AAA subnet, destination is a registered auth service:
+    // fabricate a phantom actor for the anonymous source and allow the resolution.
+    #[tokio::test]
+    async fn resolve_actors_or_deny_missing_source_in_aaa_net_with_auth_service_fabricates_phantom()
+    {
+        let asm_inner = new_assembly_for_tests(None).await;
+
+        let dest_zpr = "fd5a:5052:3000::2";
+        let auth_actor =
+            make_actor_with_services_defexp(ROLE_ADAPTER, dest_zpr, &["svc:auth"], "auth-svc");
+        asm_inner
+            .actor_mgr
+            .hack_add_adapter_no_node(&auth_actor)
+            .await
+            .unwrap();
+        asm_inner
+            .policy_mgr
+            .update_policy(make_policy_with_auth_service("svc:auth"))
+            .unwrap();
+
+        let asm = Arc::new(asm_inner);
+        let requesting_node: IpAddr = "fd5a:5052:3000::ff".parse().unwrap();
+        let aaa_src = "fd5a:5052:0:aaa:0:ff00::1";
+        let pkt = PacketDesc::new_tcp(aaa_src, dest_zpr, 12345, 80).unwrap();
+        let (job, _rx) = VisaRequestJob::new(requesting_node, pkt);
+
+        let dst = make_node_actor_defexp(dest_zpr, "dst", "10.0.0.2:1002");
+        let (phantom_src, resolved_dst) = resolve_actors_or_deny(&asm, &job, None, Some(dst))
+            .await
+            .ok()
+            .expect("expected Ok");
+
+        let expected_aaa: IpAddr = aaa_src.parse().unwrap();
+        let expected_dst: IpAddr = dest_zpr.parse().unwrap();
+        assert_eq!(phantom_src.get_zpr_addr(), Some(&expected_aaa));
+        assert_eq!(resolved_dst.get_zpr_addr(), Some(&expected_dst));
+    }
+
+    // Missing destination whose address is a plain ZPR address (not in the node's AAA subnet) is denied.
+    #[tokio::test]
+    async fn resolve_actors_or_deny_missing_dest_not_in_aaa_network_denies_dest() {
+        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let requesting_node: IpAddr = "fd5a:5052:3000::ff".parse().unwrap();
+        // dest addr is a normal ZPR address, outside any node AAA subnet
+        let pkt =
+            PacketDesc::new_tcp("fd5a:5052:3000::1", "fd5a:5052:3000::99", 12345, 80).unwrap();
+        let (job, _rx) = VisaRequestJob::new(requesting_node, pkt);
+
+        let src = make_node_actor_defexp("fd5a:5052:3000::1", "src", "10.0.0.1:1001");
+        let result = resolve_actors_or_deny(&asm, &job, Some(src), None).await;
+        assert!(matches!(
+            result,
+            Err(VisaDecision::Deny(DenyCode::DestNotFound))
+        ));
+    }
+
+    // Missing destination in the AAA subnet, source is a registered auth service:
+    // fabricate a phantom actor for the anonymous destination and allow the resolution.
+    #[tokio::test]
+    async fn resolve_actors_or_deny_missing_dest_in_aaa_net_with_auth_service_fabricates_phantom() {
+        let asm_inner = new_assembly_for_tests(None).await;
+
+        let src_zpr = "fd5a:5052:3000::1";
+        let auth_actor =
+            make_actor_with_services_defexp(ROLE_ADAPTER, src_zpr, &["svc:auth"], "auth-svc");
+        asm_inner
+            .actor_mgr
+            .hack_add_adapter_no_node(&auth_actor)
+            .await
+            .unwrap();
+        asm_inner
+            .policy_mgr
+            .update_policy(make_policy_with_auth_service("svc:auth"))
+            .unwrap();
+
+        let asm = Arc::new(asm_inner);
+        let requesting_node: IpAddr = "fd5a:5052:3000::ff".parse().unwrap();
+        let aaa_dst = "fd5a:5052:0:aaa:0:ff00::1";
+        let pkt = PacketDesc::new_tcp(src_zpr, aaa_dst, 12345, 80).unwrap();
+        let (job, _rx) = VisaRequestJob::new(requesting_node, pkt);
+
+        let src = make_node_actor_defexp(src_zpr, "src", "10.0.0.1:1001");
+        let (resolved_src, phantom_dst) = resolve_actors_or_deny(&asm, &job, Some(src), None)
+            .await
+            .ok()
+            .expect("expected Ok");
+
+        let expected_src: IpAddr = src_zpr.parse().unwrap();
+        let expected_aaa: IpAddr = aaa_dst.parse().unwrap();
+        assert_eq!(resolved_src.get_zpr_addr(), Some(&expected_src));
+        assert_eq!(phantom_dst.get_zpr_addr(), Some(&expected_aaa));
     }
 }

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -1,15 +1,17 @@
 //! Visa request worker work on matching packets to policy in order to create visas.
 //! The beating heart of the visa service.
 //!
-//! Each worker gets a single visa request and tried to run it throught the policy.
+//! Each worker gets a single visa request and tries to run it through the policy.
 //! There are several outcomes:
 //! - One or both actors may be missing (disconnected)
+//! - There may not be a route between the actors, so request fails.
 //! - One or both actors may need to be refreshed from attribute services.
 //! - One or both actors may have expired authentication.
 //! - A visa may already exist and policy has not changed, in which case we can use existing visa.
 //! - The visa may be denied by policy.
+//! - The visa may be allowed, but not over any available route, so that is a deny.
 //! - If at the end of all this a visa is permitted, then
-//! - If poicy has not been updated in the meawhile, we issue a visa, else we fail it and hope caller tries again.
+//! - If policy has not been updated in the meanwhile, we issue a visa, else we fail it and hope caller tries again.
 //!
 //! Once a visa is issued we need to pick the path and figure out which nodes need to be informed.
 //! There may be path constraints that make the visa invalid.
@@ -193,101 +195,12 @@ async fn process_visa_request_job(asm: Arc<Assembly>, job: VisaRequestJob) {
 
 /// Run visa request.
 async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaRequestResult {
-    let (mut source_actor, mut dest_actor) = get_actors(&asm, job).await?;
-
-    if source_actor.is_none() && dest_actor.is_none() {
-        return Ok(VisaDecision::Deny(DenyCode::SourceNotFound));
-    }
-
-    if source_actor.is_none() || dest_actor.is_none() {
-        // This might be an actor trying to talk to an authentication service.
-        //
-        // To check this we confirm that one actor is using an AAA network address
-        // from its node, and the other is an installed authentication service.
-        //
-
-        let missing_source = source_actor.is_none();
-
-        // "candidate" => the possible auth service, "anon_addr" => possible actor using AAA addr.
-        let (candidate_addr, anon_addr) = if missing_source {
-            (job.packet_desc.dest_addr(), job.packet_desc.source_addr())
-        } else {
-            (job.packet_desc.source_addr(), job.packet_desc.dest_addr())
+    let (source_actor, dest_actor) = get_actors(&asm, job).await?;
+    let (source_actor, dest_actor) =
+        match resolve_actors_or_deny(&asm, job, source_actor, dest_actor).await {
+            Ok(actors) => actors,
+            Err(decision) => return Ok(decision),
         };
-
-        // The anonymous actor must be using an AAA address (from its node).
-        let node_aaa_net = net_mgr::aaa_network_for_node(&job.requesting_node);
-        if !node_aaa_net.contains(anon_addr) {
-            if missing_source {
-                debug!(target: VREQ,
-                    "visa denied: unknown source {anon_addr} is not in the AAA network for node {:?}",
-                    job.requesting_node
-                );
-                return Ok(VisaDecision::Deny(DenyCode::SourceNotFound));
-            } else {
-                debug!(target: VREQ,
-                    "visa denied: unknown destination {anon_addr} is not in the AAA network for node {:?}",
-                    job.requesting_node
-                );
-                return Ok(VisaDecision::Deny(DenyCode::DestNotFound));
-            }
-        }
-
-        // The candidate actor must be an installed authentication service.
-        match asm
-            .actor_mgr
-            .has_auth_services(asm.clone(), candidate_addr)
-            .await
-        {
-            Ok(true) => (),
-            Ok(false) => {
-                warn!(target: VREQ, "visa denied: actor using AAA addr attempting to contact non-authentication service at {candidate_addr}");
-                return Ok(VisaDecision::Deny(DenyCode::DestNotFound));
-            }
-            Err(e) => {
-                debug!(target: VREQ, "visa denied: error checking authentication services for actor at {candidate_addr}: {}", e);
-                return Ok(VisaDecision::Deny(DenyCode::DestNotFound));
-            }
-        };
-
-        // We have confirmed that an actor is trying to access a valid authentication service using a valid AAA address.
-        // To proceed, we fabricate a phantom actor for this request.  This phantom acts as the anonymous actor for
-        // purposes of granting a visa.
-        let expiration = SystemTime::now() + config::DEFAULT_ANON_AUTH_EXPIRATION;
-        let mut anon_actor = Actor::new();
-        let _ = anon_actor.add_attribute(
-            Attribute::builder(key::ZPR_ADDR)
-                .expires(expiration)
-                .value(anon_addr.to_string()),
-        );
-        let _ = anon_actor.add_attribute(
-            Attribute::builder(key::AUTHORITY)
-                .expires(expiration)
-                .value("vs_hack_anon_to_auth"),
-        );
-        let _ = anon_actor.add_attribute(
-            Attribute::builder(key::ROLE)
-                .expires(expiration)
-                .value(ROLE_ADAPTER),
-        );
-        let _ = anon_actor.add_attribute(
-            Attribute::builder(key::CN)
-                .expires(expiration)
-                .value(format!("hack.{}.zpr", anon_addr)),
-        );
-        let _ = anon_actor.add_identity_key(0, key::CN);
-
-        if missing_source {
-            debug!(target: VREQ, "fabricated phantom actor for anonymous AAA request: {:?} -> {candidate_addr}", anon_actor);
-            source_actor = Some(anon_actor);
-        } else {
-            debug!(target: VREQ, "fabricated phantom actor for anonymous AAA response: {candidate_addr} -> {:?}", anon_actor);
-            dest_actor = Some(anon_actor);
-        }
-    }
-
-    let source_actor = source_actor.unwrap();
-    let dest_actor = dest_actor.unwrap();
 
     let policy = asm.policy_mgr.get_current();
     let ctx = EvalContext::new(policy.clone());
@@ -355,6 +268,111 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
             Ok(VisaDecision::Deny(DenyCode::NoMatch))
         }
     }
+}
+
+/// Resolves a pair of optional actors into concrete actors, handling the case where one is
+/// missing because it is an unauthenticated actor reaching an auth service via an AAA address.
+///
+/// Returns `Ok((source, dest))` when both actors are resolved, or `Err(decision)` for an
+/// early deny that should be returned directly to the caller.
+async fn resolve_actors_or_deny(
+    asm: &Arc<Assembly>,
+    job: &VisaRequestJob,
+    mut source_actor: Option<Actor>,
+    mut dest_actor: Option<Actor>,
+) -> Result<(Actor, Actor), VisaDecision> {
+    if source_actor.is_none() && dest_actor.is_none() {
+        return Err(VisaDecision::Deny(DenyCode::SourceNotFound));
+    }
+
+    if source_actor.is_none() || dest_actor.is_none() {
+        // This might be an actor trying to talk to an authentication service.
+        //
+        // To check this we confirm that one actor is using an AAA network address
+        // from its node, and the other is an installed authentication service.
+        //
+
+        let missing_source = source_actor.is_none();
+
+        // "candidate" => the possible auth service, "anon_addr" => possible actor using AAA addr.
+        let (candidate_addr, anon_addr) = if missing_source {
+            (job.packet_desc.dest_addr(), job.packet_desc.source_addr())
+        } else {
+            (job.packet_desc.source_addr(), job.packet_desc.dest_addr())
+        };
+
+        // The anonymous actor must be using an AAA address (from its node).
+        let node_aaa_net = net_mgr::aaa_network_for_node(&job.requesting_node);
+        if !node_aaa_net.contains(anon_addr) {
+            if missing_source {
+                debug!(target: VREQ,
+                    "visa denied: unknown source {anon_addr} is not in the AAA network for node {:?}",
+                    job.requesting_node
+                );
+                return Err(VisaDecision::Deny(DenyCode::SourceNotFound));
+            } else {
+                debug!(target: VREQ,
+                    "visa denied: unknown destination {anon_addr} is not in the AAA network for node {:?}",
+                    job.requesting_node
+                );
+                return Err(VisaDecision::Deny(DenyCode::DestNotFound));
+            }
+        }
+
+        // The candidate actor must be an installed authentication service.
+        match asm
+            .actor_mgr
+            .has_auth_services(asm.clone(), candidate_addr)
+            .await
+        {
+            Ok(true) => (),
+            Ok(false) => {
+                warn!(target: VREQ, "visa denied: actor using AAA addr attempting to contact non-authentication service at {candidate_addr}");
+                return Err(VisaDecision::Deny(DenyCode::DestNotFound));
+            }
+            Err(e) => {
+                debug!(target: VREQ, "visa denied: error checking authentication services for actor at {candidate_addr}: {}", e);
+                return Err(VisaDecision::Deny(DenyCode::DestNotFound));
+            }
+        };
+
+        // We have confirmed that an actor is trying to access a valid authentication service using a valid AAA address.
+        // To proceed, we fabricate a phantom actor for this request.  This phantom acts as the anonymous actor for
+        // purposes of granting a visa.
+        let expiration = SystemTime::now() + config::DEFAULT_ANON_AUTH_EXPIRATION;
+        let mut anon_actor = Actor::new();
+        let _ = anon_actor.add_attribute(
+            Attribute::builder(key::ZPR_ADDR)
+                .expires(expiration)
+                .value(anon_addr.to_string()),
+        );
+        let _ = anon_actor.add_attribute(
+            Attribute::builder(key::AUTHORITY)
+                .expires(expiration)
+                .value("vs_hack_anon_to_auth"),
+        );
+        let _ = anon_actor.add_attribute(
+            Attribute::builder(key::ROLE)
+                .expires(expiration)
+                .value(ROLE_ADAPTER),
+        );
+        let _ = anon_actor.add_attribute(
+            Attribute::builder(key::CN)
+                .expires(expiration)
+                .value(format!("hack.{}.zpr", anon_addr)),
+        );
+        let _ = anon_actor.add_identity_key(0, key::CN);
+
+        if missing_source {
+            debug!(target: VREQ, "fabricated phantom actor for anonymous AAA request: {:?} -> {candidate_addr}", anon_actor);
+            source_actor = Some(anon_actor);
+        } else {
+            debug!(target: VREQ, "fabricated phantom actor for anonymous AAA response: {candidate_addr} -> {:?}", anon_actor);
+            dest_actor = Some(anon_actor);
+        }
+    }
+
+    Ok((source_actor.unwrap(), dest_actor.unwrap()))
 }
 
 // Lookup source and destination actors in the DB based on ZPR address.

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -222,27 +222,33 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
         return Ok(VisaDecision::Deny(DenyCode::DestNotFound));
     };
 
-    // A visa request has a requesting node. So that is a route starting point. We then need
-    // to find the node attached to the destination actor.  The actors may themselves be nodes.
-
+    // Find the docking nodes for each actor.
     let node_addr_a = match asm.actor_mgr.get_docking_node_for_actor(&source_actor) {
         Some(node_addr) => node_addr,
         None => {
-            warn!(target: VREQ,
-                "visa request from {:?} denied: source actor {:?} is not docked to any node",
-                job.requesting_node, source_actor
-            );
-            return Ok(VisaDecision::Deny(DenyCode::SourceNotFound));
+            if actor_is_phantom(&source_actor) {
+                job.requesting_node.clone()
+            } else {
+                warn!(target: VREQ,
+                    "visa request from {:?} denied: source actor {:?} is not docked to any node",
+                    job.requesting_node, source_actor
+                );
+                return Ok(VisaDecision::Deny(DenyCode::SourceNotFound));
+            }
         }
     };
     let node_addr_b = match asm.actor_mgr.get_docking_node_for_actor(&dest_actor) {
         Some(node_addr) => node_addr,
         None => {
-            warn!(target: VREQ,
-                "visa request from {:?} denied: dest actor {:?} is not docked to any node",
-                job.requesting_node, dest_actor
-            );
-            return Ok(VisaDecision::Deny(DenyCode::DestNotFound));
+            if actor_is_phantom(&dest_actor) {
+                job.requesting_node.clone()
+            } else {
+                warn!(target: VREQ,
+                    "visa request from {:?} denied: dest actor {:?} is not docked to any node",
+                    job.requesting_node, dest_actor
+                );
+                return Ok(VisaDecision::Deny(DenyCode::DestNotFound));
+            }
         }
     };
 
@@ -320,6 +326,15 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
                 }
             }
         }
+    }
+}
+
+/// Return TRUE if the actor is tagged as as phantom actor (ie, created for authentication only).
+fn actor_is_phantom(actor: &Actor) -> bool {
+    if let Some(phantom_attr) = actor.get_attribute(key::ZPR_PHANTOM) {
+        phantom_attr.get_value_as_string() == "true"
+    } else {
+        false
     }
 }
 
@@ -431,6 +446,11 @@ async fn resolve_actors_or_deny(
         let expiration = SystemTime::now() + config::DEFAULT_ANON_AUTH_EXPIRATION;
         let mut anon_actor = Actor::new();
         let _ = anon_actor.add_attribute(
+            Attribute::builder(key::ZPR_PHANTOM)
+                .expires(expiration)
+                .value("true"),
+        );
+        let _ = anon_actor.add_attribute(
             Attribute::builder(key::ZPR_ADDR)
                 .expires(expiration)
                 .value(anon_addr.to_string()),
@@ -514,10 +534,13 @@ async fn get_actors(
 mod tests {
     use super::*;
 
+    use crate::assembly::Assembly;
     use crate::assembly::tests::new_assembly_for_tests;
-    use crate::test_helpers::{make_actor_with_services_defexp, make_node_actor_defexp};
+    use crate::test_helpers::{
+        make_actor_defexp, make_actor_with_services_defexp, make_node_actor_defexp,
+    };
     use bytes::Bytes;
-    use libeval::attribute::ROLE_ADAPTER;
+    use libeval::attribute::{ROLE_ADAPTER, key};
     use libeval::eval_result::Direction;
     use libeval::policy::Policy;
     use libeval::route::{LinkId, RouteKind};
@@ -781,5 +804,126 @@ mod tests {
         let expected_aaa: IpAddr = aaa_dst.parse().unwrap();
         assert_eq!(resolved_src.get_zpr_addr(), Some(&expected_src));
         assert_eq!(phantom_dst.get_zpr_addr(), Some(&expected_aaa));
+    }
+
+    // --- actor_is_phantom tests ---
+
+    // An actor tagged with ZPR_PHANTOM="true" is recognized as a phantom.
+    #[test]
+    fn actor_is_phantom_returns_true_for_tagged_actor() {
+        let actor = make_actor_defexp(&[(key::ZPR_PHANTOM, "true")]);
+        assert!(actor_is_phantom(&actor));
+    }
+
+    // A normal node actor with no ZPR_PHANTOM attribute is not a phantom.
+    #[test]
+    fn actor_is_phantom_returns_false_for_untagged_actor() {
+        let actor = make_node_actor_defexp("fd5a:5052:3000::1", "some-node", "10.0.0.1:1001");
+        assert!(!actor_is_phantom(&actor));
+    }
+
+    // --- Phantom actor full pipeline tests ---
+
+    // Shared setup for phantom pipeline tests:
+    //   node A (fd5a:5052:3000::1) = requesting node and phantom docking node
+    //   node B (fd5a:5052:3000::2) = auth service docking node
+    //   auth adapter (fd5a:5052:3000::30) docked to node B, service "svc:auth"
+    //   AAA subnet for node A: fd5a:5052:0:aaa:0:100::/88
+    async fn build_phantom_test_asm(with_link: bool) -> Arc<Assembly> {
+        let asm = new_assembly_for_tests(None).await;
+
+        let node_a_addr: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
+        let node_b_addr: IpAddr = "fd5a:5052:3000::2".parse().unwrap();
+
+        let node_a = make_node_actor_defexp("fd5a:5052:3000::1", "node-a", "10.0.0.1:1001");
+        let node_b = make_node_actor_defexp("fd5a:5052:3000::2", "node-b", "10.0.0.2:1002");
+        asm.actor_mgr.add_node(&node_a, false).await.unwrap();
+        asm.actor_mgr.add_node(&node_b, false).await.unwrap();
+        asm.router.add_node(&node_a_addr).unwrap();
+        asm.router.add_node(&node_b_addr).unwrap();
+
+        if with_link {
+            asm.router
+                .add_link(
+                    &node_a_addr,
+                    &node_b_addr,
+                    &LinkId("link-ab".into()),
+                    &[],
+                    1,
+                )
+                .unwrap();
+        }
+
+        let auth_adapter = make_actor_with_services_defexp(
+            ROLE_ADAPTER,
+            "fd5a:5052:3000::30",
+            &["svc:auth"],
+            "auth-svc",
+        );
+        asm.actor_mgr
+            .add_adapter_via_node(&auth_adapter, &node_b_addr)
+            .await
+            .unwrap();
+
+        asm.policy_mgr
+            .update_policy(make_policy_with_auth_service("svc:auth"))
+            .unwrap();
+
+        Arc::new(asm)
+    }
+
+    // A phantom source actor passes the docking-node check and reaches policy evaluation.
+    // Without the patch this returns Deny(SourceNotFound); with it, Deny(NoMatch).
+    #[tokio::test]
+    async fn process_visa_request_phantom_source_reaches_policy_eval() {
+        let asm = build_phantom_test_asm(true).await;
+        let requesting_node: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
+        // node_id for ::1 = 0x000001; segments[5] = 0x0001<<8 = 0x0100 → subnet fd5a:5052:0:aaa:0:100::/88
+        let pkt = PacketDesc::new_tcp(
+            "fd5a:5052:0:aaa:0:100::1",
+            "fd5a:5052:3000::30",
+            12345,
+            4000,
+        )
+        .unwrap();
+        let (job, _rx) = VisaRequestJob::new(requesting_node, pkt);
+        let result = process_visa_request(asm, &job).await.unwrap();
+        assert!(matches!(result, VisaDecision::Deny(DenyCode::NoMatch)));
+    }
+
+    // A phantom source with no route between the phantom docking node and the auth service
+    // docking node is denied NoReason (not SourceNotFound), proving the docking check passed.
+    #[tokio::test]
+    async fn process_visa_request_phantom_source_no_route_denied() {
+        let asm = build_phantom_test_asm(false).await;
+        let requesting_node: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
+        let pkt = PacketDesc::new_tcp(
+            "fd5a:5052:0:aaa:0:100::1",
+            "fd5a:5052:3000::30",
+            12345,
+            4000,
+        )
+        .unwrap();
+        let (job, _rx) = VisaRequestJob::new(requesting_node, pkt);
+        let result = process_visa_request(asm, &job).await.unwrap();
+        assert!(matches!(result, VisaDecision::Deny(DenyCode::NoReason)));
+    }
+
+    // A phantom destination actor passes the docking-node check and reaches policy evaluation.
+    // Without the patch this returns Deny(DestNotFound); with it, Deny(NoMatch).
+    #[tokio::test]
+    async fn process_visa_request_phantom_dest_reaches_policy_eval() {
+        let asm = build_phantom_test_asm(true).await;
+        let requesting_node: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
+        let pkt = PacketDesc::new_tcp(
+            "fd5a:5052:3000::30",
+            "fd5a:5052:0:aaa:0:100::1",
+            4000,
+            12345,
+        )
+        .unwrap();
+        let (job, _rx) = VisaRequestJob::new(requesting_node, pkt);
+        let result = process_visa_request(asm, &job).await.unwrap();
+        assert!(matches!(result, VisaDecision::Deny(DenyCode::NoMatch)));
     }
 }

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -463,26 +463,11 @@ async fn resolve_actors_or_deny(
             debug!(target: VREQ, "fabricated AAA actor for anonymous request: {:?} -> {candidate_addr}", anon_actor);
             source_actor = Some(anon_actor);
         } else {
-            // Response side: auth service → unauthenticated adapter.
-            // Verify the source is an auth service before allowing traffic to the AAA address.
-            match asm
-                .actor_mgr
-                .has_auth_services(asm.clone(), candidate_addr)
-                .await
-            {
-                Ok(true) => (),
-                Ok(false) => {
-                    warn!(target: VREQ, "visa denied: non-authentication service at {candidate_addr} attempting to contact AAA address {anon_addr}");
-                    return Err(VisaDecision::Deny(DenyCode::DestNotFound));
-                }
-                Err(e) => {
-                    debug!(target: VREQ, "visa denied: error checking authentication services for actor at {candidate_addr}: {}", e);
-                    return Err(VisaDecision::Deny(DenyCode::DestNotFound));
-                }
-            };
-
+            // Response side: assume "auth service" → unauthenticated adapter.
+            // On this side we don't bother checking to see if source is an auth-service.
+            // The policy eval will flag that.
+            //
             // The AAA address must already be in the table (registered on the request side).
-            // This replaces the subnet check: the table records which node owns this address.
             match asm.actor_mgr.get_docking_node_for_aaa(anon_addr) {
                 Some(_) => {}
                 None => {

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -25,10 +25,14 @@ use std::time::{Duration, SystemTime};
 
 use futures::StreamExt;
 use futures::future::FutureExt;
+
 use libeval::actor::Actor;
 use libeval::attribute::{Attribute, ROLE_ADAPTER, key};
 use libeval::eval::EvalContext;
-use libeval::eval_result::{FinalDeny, PartialEvalResult};
+use libeval::eval_result::{FinalDeny, FinalEvalResult, Hit, PartialEvalResult};
+use libeval::policy::Policy;
+use libeval::route::Route;
+
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, error, info, warn};
@@ -41,7 +45,7 @@ use crate::logging::targets::VREQ;
 use crate::{config, net_mgr};
 
 pub enum VisaDecision {
-    Allow(Visa),
+    Allow(Visa, Route),
     Deny(DenyCode),
 }
 
@@ -119,7 +123,7 @@ pub async fn request_visa_wait_response(
     match tokio::time::timeout_at(deadline, response_rx).await {
         // Increment the appropriate counters before returning.
         Ok(Ok(vr_result)) => match vr_result {
-            Ok(VisaDecision::Allow(_)) => {
+            Ok(VisaDecision::Allow(_, _)) => {
                 asm.counters.incr(CounterType::VisaRequestsApproved);
                 asm.counters
                     .incr_node(CounterType::VisaRequestsApproved, requesting_node);
@@ -202,6 +206,30 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
             Err(decision) => return Ok(decision),
         };
 
+    // Both actors must have addresses. Extract them here or return a fail.
+    let Some(source_zpr_addr) = source_actor.get_zpr_addr() else {
+        debug!(target: VREQ,
+            "visa request from {:?} denied: source actor {:?} has no ZPR address",
+            job.requesting_node, source_actor
+        );
+        return Ok(VisaDecision::Deny(DenyCode::SourceNotFound));
+    };
+    let Some(dest_zpr_addr) = dest_actor.get_zpr_addr() else {
+        debug!(target: VREQ,
+            "visa request from {:?} denied: dest actor {:?} has no ZPR address",
+            job.requesting_node, dest_actor
+        );
+        return Ok(VisaDecision::Deny(DenyCode::DestNotFound));
+    };
+
+    let Some(default_route) = asm.router.get_best_route(&source_zpr_addr, &dest_zpr_addr) else {
+        info!(target: VREQ,
+            "visa request from {:?} denied: no route between {:?} and {:?}",
+            job.requesting_node, source_zpr_addr, dest_zpr_addr
+        );
+        return Ok(VisaDecision::Deny(DenyCode::NoReason)); // TODO: Update to the NoRoute code when available in vsapi
+    };
+
     let policy = asm.policy_mgr.get_current();
     let ctx = EvalContext::new(policy.clone());
     let decision = match ctx.eval_request(&source_actor, &dest_actor, &job.packet_desc) {
@@ -214,7 +242,9 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
             return Err(e.into());
         }
     };
-    drop(ctx);
+
+    // TODO: drop eval context?
+    // Do I need eval context in the residual evaluator? I do unless we copied relevant policy out of it.
 
     match decision {
         PartialEvalResult::Deny(FinalDeny::NoMatch(message)) => {
@@ -225,33 +255,7 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
             Ok(VisaDecision::Deny(DenyCode::NoMatch))
         }
         PartialEvalResult::AllowWithoutRoute(hits) => {
-            debug_assert!(!hits.is_empty(), "allow decision with no hits"); // should never happen.
-            let policy_version = policy.get_version().unwrap_or(0);
-            // TODO: For now we pick the first hit.
-            let zpl = policy
-                .get_cpol_source(hits[0].match_idx)
-                .unwrap_or("")
-                .to_string();
-            match asm
-                .visa_mgr
-                .create_visa(
-                    &job.requesting_node,
-                    &job.packet_desc,
-                    &hits[0],
-                    zpl,
-                    policy_version,
-                )
-                .await
-            {
-                Ok(visa) => Ok(VisaDecision::Allow(visa)),
-                Err(e) => {
-                    debug!(target: VREQ,
-                        "visa_mgr error creating visa for request from {:?}: {}",
-                        job.requesting_node, e
-                    );
-                    Err(e)
-                }
-            }
+            visa_from_allow(&asm, job, &hits, &policy, default_route).await
         }
         PartialEvalResult::Deny(FinalDeny::Deny(_hits)) => {
             info!(target: VREQ,
@@ -260,14 +264,75 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
             );
             Ok(VisaDecision::Deny(DenyCode::Denied))
         }
-        PartialEvalResult::NeedsRoute(_) => {
-            error!(target: VREQ,
-                "visa request from {:?} could not be evaluated due to route constraints (not implemented)",
-                job.requesting_node
-            );
-            Ok(VisaDecision::Deny(DenyCode::NoMatch))
+        PartialEvalResult::NeedsRoute(residual_evaluator) => {
+            let hint = residual_evaluator.hint();
+            let routes = asm.router.get_routes(source_zpr_addr, dest_zpr_addr, hint);
+
+            match residual_evaluator.eval_routes(&routes, &asm.router) {
+                // TODO: Note that when we get a match using routes, the route it returned in the hit.
+                Ok(FinalEvalResult::Allow(hits)) => {
+                    visa_from_allow(&asm, job, &hits, &policy, default_route).await
+                }
+                Ok(FinalEvalResult::Deny(_hits)) => {
+                    info!(target: VREQ,
+                        "visa request from {:?} denied by policy with routes",
+                        job.requesting_node
+                    );
+                    Ok(VisaDecision::Deny(DenyCode::Denied))
+                }
+                Ok(FinalEvalResult::NoMatch(message)) => {
+                    info!(target: VREQ,
+                        "visa request from {:?} denied (no match using route): {}",
+                        job.requesting_node, message
+                    );
+                    Ok(VisaDecision::Deny(DenyCode::NoMatch))
+                }
+                Err(e) => {
+                    debug!(target: VREQ,
+                        "error evaluating route for visa request from {:?}: {}",
+                        job.requesting_node, e
+                    );
+                    return Err(e.into());
+                }
+            }
         }
     }
+}
+
+/// Given that we have an ALLOW decision, pass the hist list in here and we will pick the first
+/// hit and create a visa based on it.
+async fn visa_from_allow(
+    asm: &Assembly,
+    job: &VisaRequestJob,
+    hits: &[Hit],
+    policy: &Policy,
+    default_route: Route,
+) -> Result<VisaDecision, ServiceError> {
+    debug_assert!(!hits.is_empty(), "allow decision with no hits"); // should never happen.
+    let policy_version = policy.get_version().unwrap_or(0);
+    // TODO: For now we pick the first hit.
+    let zpl = policy
+        .get_cpol_source(hits[0].match_idx)
+        .unwrap_or("")
+        .to_string();
+
+    let allowed_route: Route = match hits[0].route.as_ref() {
+        Some(route) => route.clone(),
+        None => default_route,
+    };
+
+    let visa = asm
+        .visa_mgr
+        .create_visa(
+            &job.requesting_node,
+            &job.packet_desc,
+            &hits[0],
+            zpl,
+            policy_version,
+        )
+        .await?;
+
+    Ok(VisaDecision::Allow(visa, allowed_route))
 }
 
 /// Resolves a pair of optional actors into concrete actors, handling the case where one is

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -492,6 +492,7 @@ mod tests {
 
     use crate::assembly::tests::new_assembly_for_tests;
     use crate::test_helpers::make_node_actor_defexp;
+    use libeval::route::LinkId;
     use std::time::Duration;
 
     // This test just runs a request through the pipeline. There is no real policy here
@@ -499,7 +500,16 @@ mod tests {
     #[tokio::test]
     async fn request_visa_wait_response_denies_when_policy_has_no_match() {
         let (vreq_tx, vreq_rx) = mpsc::channel(8);
-        let asm = Arc::new(new_assembly_for_tests(Some(vreq_tx)).await);
+        let mut asm_inner = new_assembly_for_tests(Some(vreq_tx)).await;
+        let src_zpr: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
+        let dst_zpr: IpAddr = "fd5a:5052:3000::2".parse().unwrap();
+        asm_inner.router.add_node(&src_zpr).unwrap();
+        asm_inner.router.add_node(&dst_zpr).unwrap();
+        asm_inner
+            .router
+            .add_link(&src_zpr, &dst_zpr, &LinkId("test-link".into()), &[], 1)
+            .unwrap();
+        let asm = Arc::new(asm_inner);
 
         let source_actor =
             make_node_actor_defexp("fd5a:5052:3000::1", "source-node", "10.0.0.1:10001");

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -222,10 +222,42 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
         return Ok(VisaDecision::Deny(DenyCode::DestNotFound));
     };
 
-    let Some(default_route) = asm.router.get_best_route(&source_zpr_addr, &dest_zpr_addr) else {
+    // A visa request has a requesting node. So that is a route starting point. We then need
+    // to find the node attached to the destination actor.  The actors may themselves be nodes.
+
+    let node_addr_a = if source_actor.is_node() {
+        source_zpr_addr.clone()
+    } else {
+        match asm.actor_mgr.get_docking_node_for_actor(&source_actor) {
+            Some(node_addr) => node_addr,
+            None => {
+                warn!(target: VREQ,
+                    "visa request from {:?} denied: source actor {:?} is not docked to any node",
+                    job.requesting_node, source_actor
+                );
+                return Ok(VisaDecision::Deny(DenyCode::SourceNotFound));
+            }
+        }
+    };
+    let node_addr_b = if dest_actor.is_node() {
+        dest_zpr_addr.clone()
+    } else {
+        match asm.actor_mgr.get_docking_node_for_actor(&dest_actor) {
+            Some(node_addr) => node_addr,
+            None => {
+                warn!(target: VREQ,
+                    "visa request from {:?} denied: dest actor {:?} is not docked to any node",
+                    job.requesting_node, dest_actor
+                );
+                return Ok(VisaDecision::Deny(DenyCode::DestNotFound));
+            }
+        }
+    };
+
+    let Some(default_route) = asm.router.get_best_route(&node_addr_a, &node_addr_b) else {
         info!(target: VREQ,
             "visa request from {:?} denied: no route between {:?} and {:?}",
-            job.requesting_node, source_zpr_addr, dest_zpr_addr
+            job.requesting_node, node_addr_a, node_addr_b
         );
         return Ok(VisaDecision::Deny(DenyCode::NoReason)); // TODO: Update to the NoRoute code when available in vsapi
     };

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -225,32 +225,24 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
     // A visa request has a requesting node. So that is a route starting point. We then need
     // to find the node attached to the destination actor.  The actors may themselves be nodes.
 
-    let node_addr_a = if source_actor.is_node() {
-        source_zpr_addr.clone()
-    } else {
-        match asm.actor_mgr.get_docking_node_for_actor(&source_actor) {
-            Some(node_addr) => node_addr,
-            None => {
-                warn!(target: VREQ,
-                    "visa request from {:?} denied: source actor {:?} is not docked to any node",
-                    job.requesting_node, source_actor
-                );
-                return Ok(VisaDecision::Deny(DenyCode::SourceNotFound));
-            }
+    let node_addr_a = match asm.actor_mgr.get_docking_node_for_actor(&source_actor) {
+        Some(node_addr) => node_addr,
+        None => {
+            warn!(target: VREQ,
+                "visa request from {:?} denied: source actor {:?} is not docked to any node",
+                job.requesting_node, source_actor
+            );
+            return Ok(VisaDecision::Deny(DenyCode::SourceNotFound));
         }
     };
-    let node_addr_b = if dest_actor.is_node() {
-        dest_zpr_addr.clone()
-    } else {
-        match asm.actor_mgr.get_docking_node_for_actor(&dest_actor) {
-            Some(node_addr) => node_addr,
-            None => {
-                warn!(target: VREQ,
-                    "visa request from {:?} denied: dest actor {:?} is not docked to any node",
-                    job.requesting_node, dest_actor
-                );
-                return Ok(VisaDecision::Deny(DenyCode::DestNotFound));
-            }
+    let node_addr_b = match asm.actor_mgr.get_docking_node_for_actor(&dest_actor) {
+        Some(node_addr) => node_addr,
+        None => {
+            warn!(target: VREQ,
+                "visa request from {:?} denied: dest actor {:?} is not docked to any node",
+                job.requesting_node, dest_actor
+            );
+            return Ok(VisaDecision::Deny(DenyCode::DestNotFound));
         }
     };
 

--- a/vs/src/vsapi_worker.rs
+++ b/vs/src/vsapi_worker.rs
@@ -53,13 +53,13 @@ impl AuthenticateUndo {
         self.added_node_to_router = Some(addr.clone());
     }
 
-    fn undo(self, asm: &Assembly) {
+    async fn undo(self, asm: &Assembly) {
         if let Some(addr) = self.added_node_to_router {
-            let _ = asm.router.remove_node(&addr);
+            asm.router.remove_node(&addr);
         }
         if let Some(addr) = self.actor_mgr_add_node {
-            // Will also remove the vs-docking mapping.
-            let _ = asm.actor_mgr.remove_node(&addr);
+            let _ = asm.actor_mgr.remove_node(&addr).await;
+            let _ = asm.actor_mgr.remove_actor_by_zpr_addr(&addr).await;
         }
         if let Some(addr) = self.taken_zpr_addr {
             let _ = asm.net_mgr.release_zpr_addr(addr);
@@ -585,7 +585,7 @@ impl vsapi::v_s_gate::Server for VSGateImpl {
             Some(addr) => addr.clone(),
             None => {
                 error!(target: API, "auth subsystem failed to set a ZPR address on an authenticated node");
-                undo.undo(&self.asm);
+                undo.undo(&self.asm).await;
                 return self.ok_with_authenticate_error(
                     results,
                     vsapi::ErrorCode::Internal,
@@ -601,7 +601,7 @@ impl vsapi::v_s_gate::Server for VSGateImpl {
             Some(cn) => cn.to_owned(),
             None => {
                 error!(target: API, "auth subsystem failed to set a CN on an authenticated node");
-                undo.undo(&self.asm);
+                undo.undo(&self.asm).await;
                 return self.ok_with_authenticate_error(
                     results,
                     vsapi::ErrorCode::Internal,
@@ -636,7 +636,7 @@ impl vsapi::v_s_gate::Server for VSGateImpl {
         if !self.reconnect {
             if let Err(e) = self.asm.visa_mgr.clear_node_state(&node_zpr_addr).await {
                 error!(target: API, "failed to clear node state for {:?}: {}", &node_cn, e);
-                undo.undo(&self.asm);
+                undo.undo(&self.asm).await;
                 return self.ok_with_authenticate_error(
                     results,
                     vsapi::ErrorCode::Internal,
@@ -654,7 +654,7 @@ impl vsapi::v_s_gate::Server for VSGateImpl {
             .await
         {
             error!(target: API, "failed to add authenticated node {:?} to actor db: {}", &node_cn, e);
-            undo.undo(&self.asm);
+            undo.undo(&self.asm).await;
             return self.ok_with_authenticate_error(
                 results,
                 vsapi::ErrorCode::Internal,
@@ -686,7 +686,7 @@ impl vsapi::v_s_gate::Server for VSGateImpl {
                             .await
                         {
                             error!(target: API, "failed to set VS docking node to {:?}: {}", &node_cn, e);
-                            undo.undo(&self.asm);
+                            undo.undo(&self.asm).await;
                             return self.ok_with_authenticate_error(
                                 results,
                                 vsapi::ErrorCode::Internal,
@@ -710,7 +710,7 @@ impl vsapi::v_s_gate::Server for VSGateImpl {
                     // Failed to add the node to the router. We won't be able to route visas through this node.
                     // Best to just abort this connect.
                     error!(target: API, "router: failed to add node {} to router after removing existing: {}", node_zpr_addr, e);
-                    undo.undo(&self.asm);
+                    undo.undo(&self.asm).await;
                     return self.ok_with_authenticate_error(
                         results,
                         vsapi::ErrorCode::Internal,
@@ -728,7 +728,7 @@ impl vsapi::v_s_gate::Server for VSGateImpl {
         let evt = VsEvent::ActorJoins(node_zpr_addr);
         if let Err(e) = self.asm.event_mgr.record_event(evt).await {
             error!(target: API, "failed to record actor joins event for node {:?}: {}", &node_cn, e);
-            undo.undo(&self.asm);
+            undo.undo(&self.asm).await;
             return self.ok_with_authenticate_error(
                 results,
                 vsapi::ErrorCode::Internal,
@@ -1265,5 +1265,108 @@ mod tests {
         assert_eq!(result[0].name, "param0");
         assert_eq!(result[1].name, "param1");
         assert_eq!(result[2].name, "param2");
+    }
+
+    mod authenticate_undo {
+        use super::*;
+        use crate::assembly::tests::new_assembly_for_tests;
+        use crate::test_helpers::make_node_actor_defexp;
+        use libeval::actor::Role;
+        use std::sync::Arc;
+
+        #[tokio::test]
+        async fn test_noop() {
+            let asm = Arc::new(new_assembly_for_tests(None).await);
+            let undo = AuthenticateUndo::default();
+            undo.undo(&asm).await; // must not panic
+        }
+
+        #[tokio::test]
+        async fn test_releases_zpr_addr() {
+            let asm = Arc::new(new_assembly_for_tests(None).await);
+            let addr = asm.net_mgr.get_next_zpr_addr(&Role::Node).unwrap();
+
+            let mut undo = AuthenticateUndo::default();
+            undo.took_zpr_addr(&addr);
+            undo.undo(&asm).await;
+
+            // Address was released back to the pool, so take_zpr_addr should succeed.
+            assert!(
+                asm.net_mgr.take_zpr_addr(&addr).is_ok(),
+                "address should have been released by undo"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_removes_node_from_router() {
+            let asm = Arc::new(new_assembly_for_tests(None).await);
+            let addr: IpAddr = "fd5a:5052:90de:1::1".parse().unwrap();
+
+            asm.router.add_node(&addr).unwrap();
+
+            let mut undo = AuthenticateUndo::default();
+            undo.added_node_to_router(&addr);
+            undo.undo(&asm).await;
+
+            // Node was removed, so add_node must succeed again.
+            assert!(
+                asm.router.add_node(&addr).is_ok(),
+                "node should have been removed from router by undo"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_removes_node_from_actor_mgr() {
+            let asm = Arc::new(new_assembly_for_tests(None).await);
+            let addr: IpAddr = "fd5a:5052:90de:1::2".parse().unwrap();
+            let actor =
+                make_node_actor_defexp("fd5a:5052:90de:1::2", "test-node", "[fd5a:5052::100]:1234");
+
+            asm.actor_mgr.add_node(&actor, false).await.unwrap();
+
+            let mut undo = AuthenticateUndo::default();
+            undo.added_node_to_actor_mgr(&addr);
+            undo.undo(&asm).await;
+
+            let result = asm.actor_mgr.get_actor_by_zpr_addr(&addr).await.unwrap();
+            assert!(
+                result.is_none(),
+                "node should have been removed from actor_mgr by undo"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_all_three_undone() {
+            let asm = Arc::new(new_assembly_for_tests(None).await);
+            let addr = asm.net_mgr.get_next_zpr_addr(&Role::Node).unwrap();
+            let actor =
+                make_node_actor_defexp(&addr.to_string(), "test-node-2", "[fd5a:5052::101]:1234");
+
+            asm.actor_mgr.add_node(&actor, false).await.unwrap();
+            asm.router.add_node(&addr).unwrap();
+
+            let mut undo = AuthenticateUndo::default();
+            undo.took_zpr_addr(&addr);
+            undo.added_node_to_actor_mgr(&addr);
+            undo.added_node_to_router(&addr);
+            undo.undo(&asm).await;
+
+            assert!(
+                asm.router.add_node(&addr).is_ok(),
+                "node should have been removed from router"
+            );
+            asm.router.remove_node(&addr);
+
+            let actor_result = asm.actor_mgr.get_actor_by_zpr_addr(&addr).await.unwrap();
+            assert!(
+                actor_result.is_none(),
+                "node should have been removed from actor_mgr"
+            );
+
+            assert!(
+                asm.net_mgr.take_zpr_addr(&addr).is_ok(),
+                "zpr address should have been released"
+            );
+        }
     }
 }

--- a/vs/src/vsapi_worker.rs
+++ b/vs/src/vsapi_worker.rs
@@ -974,7 +974,8 @@ impl vsapi::v_s_handle::Server for VSHandleImpl {
             .await
         {
             Ok(decision) => match decision {
-                VisaDecision::Allow(visa) => {
+                VisaDecision::Allow(visa, _route) => {
+                    // TODO: Do something with the route
                     let res_builder = response.get().init_resp();
                     let mut visa_bldr = res_builder.init_allow();
                     visa.write_to(&mut visa_bldr);

--- a/vs/src/vsapi_worker.rs
+++ b/vs/src/vsapi_worker.rs
@@ -22,11 +22,46 @@ use zpr::write_to::WriteTo;
 use crate::assembly::Assembly;
 use crate::config;
 use crate::counters::CounterType;
-use crate::error::ServiceError;
+use crate::error::{ServiceError, TopologyError};
 use crate::event_mgr::VsEvent;
 use crate::logging::targets::API;
 use crate::net_mgr;
 use crate::visareq_worker::{VisaDecision, request_visa_wait_response};
+
+// During node authentication we keep track in here of what state we have
+// changed so that we can do an undo in case of an error in the sequence.
+#[derive(Default)]
+struct AuthenticateUndo {
+    taken_zpr_addr: Option<IpAddr>,
+    actor_mgr_add_node: Option<IpAddr>,
+    added_node_to_router: Option<IpAddr>,
+}
+
+impl AuthenticateUndo {
+    fn took_zpr_addr(&mut self, addr: &IpAddr) {
+        self.taken_zpr_addr = Some(addr.clone());
+    }
+
+    fn added_node_to_actor_mgr(&mut self, addr: &IpAddr) {
+        self.actor_mgr_add_node = Some(addr.clone());
+    }
+
+    fn added_node_to_router(&mut self, addr: &IpAddr) {
+        self.added_node_to_router = Some(addr.clone());
+    }
+
+    fn undo(self, asm: &Assembly) {
+        if let Some(addr) = self.added_node_to_router {
+            let _ = asm.router.remove_node(&addr);
+        }
+        if let Some(addr) = self.actor_mgr_add_node {
+            let _ = asm.actor_mgr.remove_node(&addr);
+        }
+        if let Some(addr) = self.taken_zpr_addr {
+            let _ = asm.net_mgr.release_zpr_addr(addr);
+        }
+    }
+}
 
 pub async fn launch_capnp(
     asm: Arc<Assembly>,
@@ -537,27 +572,36 @@ impl vsapi::v_s_gate::Server for VSGateImpl {
             }
         };
 
+        // At this point we may have taken an IP addr and assigned it to the actor.
+        let mut undo = AuthenticateUndo::default();
+
         // Sanity check - every node has a CN and a ZPR address.
         // If this fails it means our authentication code is broken.
-        let node_cn = match node_actor.get_cn() {
-            Some(cn) => cn.to_owned(),
-            None => {
-                error!(target: API, "auth subsystem failed to set a CN on an authenticated node");
-                return self.ok_with_authenticate_error(
-                    results,
-                    vsapi::ErrorCode::Internal,
-                    "assertion failed (CN)",
-                );
-            }
-        };
         let node_zpr_addr = match node_actor.get_zpr_addr() {
             Some(addr) => addr.clone(),
             None => {
                 error!(target: API, "auth subsystem failed to set a ZPR address on an authenticated node");
+                undo.undo(&self.asm);
                 return self.ok_with_authenticate_error(
                     results,
                     vsapi::ErrorCode::Internal,
                     "assertion failed (ADDR)",
+                );
+            }
+        };
+        if self.asm.net_mgr.is_managed_address(&node_zpr_addr) {
+            undo.took_zpr_addr(&node_zpr_addr);
+        }
+
+        let node_cn = match node_actor.get_cn() {
+            Some(cn) => cn.to_owned(),
+            None => {
+                error!(target: API, "auth subsystem failed to set a CN on an authenticated node");
+                undo.undo(&self.asm);
+                return self.ok_with_authenticate_error(
+                    results,
+                    vsapi::ErrorCode::Internal,
+                    "assertion failed (CN)",
                 );
             }
         };
@@ -588,14 +632,17 @@ impl vsapi::v_s_gate::Server for VSGateImpl {
         if !self.reconnect {
             if let Err(e) = self.asm.visa_mgr.clear_node_state(&node_zpr_addr).await {
                 error!(target: API, "failed to clear node state for {:?}: {}", &node_cn, e);
+                undo.undo(&self.asm);
                 return self.ok_with_authenticate_error(
                     results,
                     vsapi::ErrorCode::Internal,
                     "failed to clear node state",
                 );
             }
+            self.asm.router.remove_node(&node_zpr_addr);
         }
 
+        // The add_node call will clean up after ifself if it fails.
         if let Err(e) = self
             .asm
             .actor_mgr
@@ -603,6 +650,7 @@ impl vsapi::v_s_gate::Server for VSGateImpl {
             .await
         {
             error!(target: API, "failed to add authenticated node {:?} to actor db: {}", &node_cn, e);
+            undo.undo(&self.asm);
             return self.ok_with_authenticate_error(
                 results,
                 vsapi::ErrorCode::Internal,
@@ -610,9 +658,43 @@ impl vsapi::v_s_gate::Server for VSGateImpl {
             );
         }
 
+        undo.added_node_to_actor_mgr(&node_zpr_addr);
+
+        // Add the node to the router.
+        match self.asm.router.add_node(&node_zpr_addr) {
+            Ok(()) => (),
+            Err(TopologyError::NodeExists(_)) => {
+                // Attempt to remove and re-add.
+                warn!(target: API, "node {:?} already exists in router, attempting to remove and re-add", &node_cn);
+                self.asm.router.remove_node(&node_zpr_addr);
+                if let Err(e) = self.asm.router.add_node(&node_zpr_addr) {
+                    // Failed to add the node to the router. We won't be able to route visas through this node.
+                    // Best to just abort this connect.
+                    error!(target: API, "router: failed to add node {} to router after removing existing: {}", node_zpr_addr, e);
+                    undo.undo(&self.asm);
+                    return self.ok_with_authenticate_error(
+                        results,
+                        vsapi::ErrorCode::Internal,
+                        "router update failed",
+                    );
+                }
+            }
+            Err(e) => {
+                unreachable!("unexpected error adding node to router: {}", e);
+            }
+        }
+
+        undo.added_node_to_router(&node_zpr_addr);
+
         let evt = VsEvent::ActorJoins(node_zpr_addr);
         if let Err(e) = self.asm.event_mgr.record_event(evt).await {
-            warn!(target: API, "failed to record actor joins event for node {:?}: {}", &node_cn, e);
+            error!(target: API, "failed to record actor joins event for node {:?}: {}", &node_cn, e);
+            undo.undo(&self.asm);
+            return self.ok_with_authenticate_error(
+                results,
+                vsapi::ErrorCode::Internal,
+                "event enqueue failed",
+            );
         }
         self.asm.counters.incr(CounterType::NodeConnectionsSuccess);
 

--- a/vs/src/vsapi_worker.rs
+++ b/vs/src/vsapi_worker.rs
@@ -38,14 +38,17 @@ struct AuthenticateUndo {
 }
 
 impl AuthenticateUndo {
+    /// We checked out one of our ZPR addresses.
     fn took_zpr_addr(&mut self, addr: &IpAddr) {
         self.taken_zpr_addr = Some(addr.clone());
     }
 
+    /// We added a node to state.
     fn added_node_to_actor_mgr(&mut self, addr: &IpAddr) {
         self.actor_mgr_add_node = Some(addr.clone());
     }
 
+    /// We added a node to the router.
     fn added_node_to_router(&mut self, addr: &IpAddr) {
         self.added_node_to_router = Some(addr.clone());
     }
@@ -55,6 +58,7 @@ impl AuthenticateUndo {
             let _ = asm.router.remove_node(&addr);
         }
         if let Some(addr) = self.actor_mgr_add_node {
+            // Will also remove the vs-docking mapping.
             let _ = asm.actor_mgr.remove_node(&addr);
         }
         if let Some(addr) = self.taken_zpr_addr {
@@ -657,8 +661,43 @@ impl vsapi::v_s_gate::Server for VSGateImpl {
                 "state update failed",
             );
         }
-
         undo.added_node_to_actor_mgr(&node_zpr_addr);
+
+        // TODO: This is a hack: the visa service "actor" needs to know what node it's adapter is docked to.
+        //       Ideally we would query our adapter directly.
+        {
+            if let Ok(maybe_visa_service_actor) =
+                self.asm.actor_mgr.get_actor_by_cn(config::VS_CN).await
+            {
+                if let Some(visa_service_actor) = maybe_visa_service_actor {
+                    if self
+                        .asm
+                        .actor_mgr
+                        .get_docking_node_for_actor(&visa_service_actor)
+                        .is_none()
+                    {
+                        // VS does not yet have a docking address.  ASSUME this node is our dock.
+                        // This does not update the 'connect_via' attribute on the vs actor. (TODO - rethink that)
+
+                        if let Err(e) = self
+                            .asm
+                            .actor_mgr
+                            .hack_set_vs_docking_node(&node_zpr_addr)
+                            .await
+                        {
+                            error!(target: API, "failed to set VS docking node to {:?}: {}", &node_cn, e);
+                            undo.undo(&self.asm);
+                            return self.ok_with_authenticate_error(
+                                results,
+                                vsapi::ErrorCode::Internal,
+                                "vs docking node update failed",
+                            );
+                        }
+                        // No need to update the `undo` here since undoing the node-add will also remove the vs docking mapping.
+                    }
+                }
+            }
+        }
 
         // Add the node to the router.
         match self.asm.router.add_node(&node_zpr_addr) {

--- a/vs/src/vss_mgr.rs
+++ b/vs/src/vss_mgr.rs
@@ -333,7 +333,7 @@ async fn vss_worker_loop(
         }
     };
 
-    info!(target: VSS, "connected to VSS at {}", node_addr);
+    info!(target: VSS, "now connected to VSS at {}", node_addr);
 
     do_vss_initialization(&asm, &node_addr.ip(), &vss_handle).await;
 


### PR DESCRIPTION
# Topology prep: router, route types, and adapter-node connection table

Groundwork for topology-aware routing in the visa service.

## Changes

**New `vs/src/router.rs`**
Introduces a `Router` struct that maintains a graph of ZPR nodes and links and can enumerate all simple paths between two nodes via DFS. Results are memoized with targeted cache invalidation: reverse indices (`link → cache keys`, `node → cache keys`) ensure that only affected entries are evicted when topology changes, rather than flushing the whole cache.

**New `libeval/src/eval_route.rs`**
Defines the second-phase policy evaluator (`RouteResidualEvaluator`) and `RouteHint` for pruning candidate routes before full evaluation. The evaluator itself is stubbed — route predicates in ZPL don't exist yet.

**`libeval/src/route.rs`** (rewritten)
Fleshes out `Route`, `RouteKind`, `NodeId`, `LinkId`, and `RoutePredicate` types that were previously stubs.

**`vs/src/actor_mgr.rs`**
Adds an in-memory `connection_table` (`DashMap<IpAddr, IpAddr>`: adapter ZPR addr → docking node ZPR addr), kept in sync as nodes and adapters arrive and leave. Used by the request path to resolve adapter-to-node mappings without a DB round-trip.

**`vs/src/visareq_worker.rs` / `vs/src/vsapi_worker.rs`**
Integrates the router and connection table into the existing single-node request flow, threading topology context through visa request handling.
