### PR TITLE
Mk/misc fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,10 +293,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bit-set"
@@ -565,6 +577,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,6 +669,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,6 +698,33 @@ checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
  "phf",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -765,6 +822,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,7 +885,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -853,10 +923,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "embedded-io"
@@ -998,6 +1127,22 @@ dependencies = [
  "rustix",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filedescriptor"
@@ -1188,6 +1333,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1228,6 +1374,17 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1298,6 +1455,24 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"
@@ -1709,6 +1884,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "10.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+dependencies = [
+ "base64",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hmac",
+ "js-sys",
+ "p256",
+ "p384",
+ "pem",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha2",
+ "signature",
+ "simple_asn1",
+]
+
+[[package]]
 name = "kasuari"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,6 +1928,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1757,6 +1958,12 @@ dependencies = [
  "tracing-subscriber",
  "zpr",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "line-clipping"
@@ -1950,6 +2157,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1976,12 +2199,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2088,6 +2323,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2124,6 +2383,15 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64",
  "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -2234,6 +2502,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,6 +2566,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -2381,6 +2679,8 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -2390,8 +2690,18 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2409,6 +2719,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -2659,6 +2972,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2670,6 +2993,26 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2877,6 +3220,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3075,10 +3432,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "siphasher"
@@ -3106,6 +3485,22 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -3729,6 +4124,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "ipnet",
+ "jsonwebtoken",
  "libeval",
  "openssl",
  "percent-encoding",

--- a/admin-api-types/src/admin_api_types.rs
+++ b/admin-api-types/src/admin_api_types.rs
@@ -161,8 +161,9 @@ impl fmt::Display for VisaDescriptor {
     }
 }
 
-// intentionally match the zpr::vsapi_types KeySet and KeyFormat, but
-// reproduced here to prevent coupling of the API types from the internal types
+/// Intentionally match the zpr::vsapi_types KeySet and KeyFormat, but
+/// reproduced here to prevent coupling of the API types from the internal types
+/// Note these keys are encrypted.
 #[serde_as]
 #[derive(Default, Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct ApiKeySet {

--- a/libeval/src/eval.rs
+++ b/libeval/src/eval.rs
@@ -310,8 +310,8 @@ impl EvalContext {
             .unwrap();
 
         // Policy configuration also tells us what attributes are tied to identity.
-        // TODO: use policy to figure out the identity attributes.
-        // For now this is just a hack.  We try CN, address, or if those fail we use the hash.
+        // TODO: use policy to figure out the identity attributes. (https://github.com/org-zpr/zpr-visaservice/issues/201)
+        // For now this is just a hack: we try CN, address, and if those fail we use the hash.
         if actor.has_attribute_named(key::CN) {
             // use cn
             actor.add_identity_key(0, key::CN).unwrap();

--- a/vs/Cargo.toml
+++ b/vs/Cargo.toml
@@ -28,6 +28,7 @@ http-body-util = "0.1.3"
 hyper = "1.7.0"
 hyper-util = "0.1.17"
 ipnet = "2.11.0"
+jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
 libeval = { path = "../libeval" }
 openssl.workspace = true
 percent-encoding = "2.3.2"

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -145,6 +145,8 @@ async fn require_api_key(
         .and_then(|hv| hv.to_str().ok())
         .ok_or(StatusCode::UNAUTHORIZED)?;
 
+    // TODO: Add exponential backoff on unauthorizied requests.
+
     let perm = validate_api_key(&state, api_key).await?;
     req.extensions_mut().insert(perm);
     Ok(next.run(req).await)
@@ -586,21 +588,29 @@ async fn get_service(
     debug!(target: ADMIN, "GET /admin/service CN={}", cn);
     let rstate = state.read().await;
 
-    if let Some(detail) = rstate.asm.actor_mgr.get_service_detail(&cn).await.unwrap() {
-        let connect_via = match detail.connect_via.as_ref() {
-            Some(cv_addr) => cv_addr.to_string(),
-            None => "".to_string(),
-        };
-        let sd = ServiceDescriptor {
-            service_name: detail.service_name,
-            zpr_addr: detail.zpr_addr.to_string(),
-            actor_cn: detail.actor_cn,
-            dock_zpr_addr: connect_via,
-        };
-        return Ok(Json(sd));
+    match rstate.asm.actor_mgr.get_service_detail(&cn).await {
+        Err(e) => {
+            error!(target: ADMIN, "error getting service detail for CN {}: {}", cn, e);
+            Err(StatusCode::INTERNAL_SERVER_ERROR)
+        }
+        Ok(opt_detail) => {
+            if let Some(detail) = opt_detail {
+                let connect_via = match detail.connect_via.as_ref() {
+                    Some(cv_addr) => cv_addr.to_string(),
+                    None => "".to_string(),
+                };
+                let sd = ServiceDescriptor {
+                    service_name: detail.service_name,
+                    zpr_addr: detail.zpr_addr.to_string(),
+                    actor_cn: detail.actor_cn,
+                    dock_zpr_addr: connect_via,
+                };
+                Ok(Json(sd))
+            } else {
+                Err(StatusCode::NOT_FOUND)
+            }
+        }
     }
-
-    Err(StatusCode::NOT_FOUND)
 }
 
 async fn get_revokes() -> impl IntoResponse {

--- a/vs/src/assembly.rs
+++ b/vs/src/assembly.rs
@@ -108,7 +108,7 @@ pub mod tests {
             config: VSConfig::default(),
             counters: counters.clone(),
             system_start_time: std::time::Instant::now(),
-            cc: ConnectionControl::new(),
+            cc: ConnectionControl::new("vs_ident".to_string()),
             policy_mgr: PolicyMgr::new_with_initial_policy(initial_policy, policy_repo)
                 .await
                 .expect("failed to initialize PolicyMgr"),

--- a/vs/src/connection_control.rs
+++ b/vs/src/connection_control.rs
@@ -15,6 +15,9 @@
 //! Finally, if everything goes well an address is assigned and the actor is
 //! returned.
 
+use chrono::Utc;
+use jsonwebtoken as jwt;
+use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -40,13 +43,71 @@ const CLASS_ENDPOINT: &str = "endpoint";
 const CLASS_USER: &str = "user";
 const CLASS_SERVICE: &str = "service";
 
+const ATTR_KEY_VS_IDENT: &str = "zpr.vs.bootstrap.ident";
+
+#[derive(Debug, Serialize, Deserialize)]
+struct JwtClaims {
+    iss: String, // Issuer eg, 'vs.zpr/<IDENT>'
+    sub: String, // Subject (user id), eg 'node/<CN>'
+    exp: u64,    // Expiration time (as UNIX timestamp)
+    iat: u64,    // Issued at time (as UNIX timestamp)
+    jti: String, // JWT ID - unique identifier for the token, can be used for revocation
+}
+
 pub struct ConnectionControl {
-    // Placeholder for connection control data and methods
+    vs_ident: String,
+    jwt_key: jwt::EncodingKey,
+    authority: String,
 }
 
 impl ConnectionControl {
-    pub fn new() -> Self {
-        ConnectionControl {}
+    pub fn new(vs_ident: String) -> Self {
+        // massage ident into valid chars -> [a-zA-Z0-9.-_]
+        let vs_ident: String = vs_ident
+            .chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' {
+                    c
+                } else {
+                    '_'
+                }
+            })
+            .collect();
+
+        let jwt_key = jwt::EncodingKey::from_secret(vs_ident.as_bytes());
+
+        ConnectionControl {
+            authority: format!("vs.zpr/{}", &vs_ident),
+            vs_ident,
+            jwt_key,
+        }
+    }
+
+    /// VS uses this to create an "identity" token for bootstrap authenticated actors.
+    ///
+    /// `sub` should be 'node/<CN>' or 'adapter/<CN>'
+    fn gen_jwt(&self, sub: String) -> Result<String, ServiceError> {
+        let expiration = Utc::now()
+            .checked_add_signed(chrono::Duration::seconds(
+                config::DEFAULT_AUTH_EXPIRATION.as_secs() as i64,
+            ))
+            .expect("valid timestamp")
+            .timestamp() as u64;
+        let claims = JwtClaims {
+            iss: self.authority.clone(),
+            sub,
+            exp: expiration,
+            iat: SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .expect("time went backwards")
+                .as_secs(),
+            jti: uuid::Uuid::new_v4().to_string(),
+        };
+        let token = jwt::encode(&jwt::Header::default(), &claims, &self.jwt_key).map_err(|e| {
+            error!(target: CC, "failed to generate JWT: {}", e);
+            ServiceError::Internal("JWT generation failed".into())
+        })?;
+        Ok(token)
     }
 
     /// Perform node specific authentication and run the connect request through policy.
@@ -94,10 +155,18 @@ impl ConnectionControl {
         let mut authd_claims: Vec<Attribute> = Vec::new();
 
         authd_claims.push(Attribute::builder(key::SUBSTRATE_ADDR).value(remote.to_string()));
+
+        // We passed our RSA auth, so we set ourselves as authority and add our own ident.
+        let node_jwt = self.gen_jwt(format!("node/{}", cn))?;
+        authd_claims.push(
+            Attribute::builder(ATTR_KEY_VS_IDENT)
+                .expires(SystemTime::now() + config::DEFAULT_AUTH_EXPIRATION)
+                .value(node_jwt),
+        );
         authd_claims.push(
             Attribute::builder(key::AUTHORITY)
                 .expires(SystemTime::now() + config::DEFAULT_AUTH_EXPIRATION)
-                .value(format!("fake_jwt_token:node:{cn}")),
+                .value(format!("vs.zpr/{}", self.vs_ident)),
         );
 
         // Technically we don't know if the node claim is authenticated until it passes policy check.
@@ -187,10 +256,7 @@ impl ConnectionControl {
     ) -> Result<Actor, ServiceError> {
         let mut authd_claims = Vec::new();
 
-        authd_claims.push(
-            Attribute::builder(key::AUTHORITY)
-                .value(format!("fake_jwt_token:adapter:{}", config::VS_CN)),
-        );
+        authd_claims.push(Attribute::builder(key::AUTHORITY).value(&self.authority));
 
         for claim in claims {
             authd_claims.push(Attribute::builder(claim.key).value(claim.value));
@@ -254,11 +320,16 @@ impl ConnectionControl {
         // In prototype we make a JWT here and use that as an identity attribute.
         // TODO: implement jwt creation.
 
-        // FAKE identity token.
         authd_claims.push(
             Attribute::builder(key::AUTHORITY)
                 .expires(SystemTime::now() + config::DEFAULT_AUTH_EXPIRATION)
-                .value(format!("fake_jwt_token:adapter:{}", ssb.cn)),
+                .value(&self.authority),
+        );
+        let adapter_jwt = self.gen_jwt(format!("adapter/{}", ssb.cn))?;
+        authd_claims.push(
+            Attribute::builder(ATTR_KEY_VS_IDENT)
+                .expires(SystemTime::now() + config::DEFAULT_AUTH_EXPIRATION)
+                .value(adapter_jwt),
         );
 
         unauthd_claims.push(Attribute::builder(key::ROLE).value(ROLE_ADAPTER));
@@ -319,7 +390,8 @@ impl ConnectionControl {
             }
         };
 
-        // Use AUTHORITY as one of the identity keys if present.
+        // Use our own ident key and AUTHORITY as identity keys if present.
+        let _ = authd_actor.add_identity_key(0, ATTR_KEY_VS_IDENT);
         let _ = authd_actor.add_identity_key(usize::MAX, key::AUTHORITY);
 
         let actor_role = if authd_actor.is_node() {
@@ -452,7 +524,7 @@ fn check_adapter_required_claims(req: &ConnectRequest) -> Result<(), ServiceErro
 }
 
 // Gatekeep claims. Claims are considered to be adapter _requests_ which may
-// or may not be honored by policy.  But we set attributes from them and need
+// or may not be honored by policy.  But we set attributes from them and
 // and some are for internal use only.
 //
 // Generally no claims that start with "zpr." are allowed except:
@@ -503,6 +575,46 @@ fn scrub_adapter_claims(claims: Vec<Claim>) -> Result<Vec<Attribute>, ServiceErr
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn make_cc(ident: &str) -> ConnectionControl {
+        ConnectionControl::new(ident.to_string())
+    }
+
+    fn decode_jwt(token: &str, secret: &str) -> Result<JwtClaims, jwt::errors::Error> {
+        let key = jwt::DecodingKey::from_secret(secret.as_bytes());
+        let validation = jwt::Validation::new(jwt::Algorithm::HS256);
+        jwt::decode::<JwtClaims>(token, &key, &validation).map(|d| d.claims)
+    }
+
+    #[test]
+    fn new_preserves_valid_ident_chars() {
+        let cc = make_cc("valid-ident_1.2");
+        assert_eq!(cc.vs_ident, "valid-ident_1.2");
+    }
+
+    #[test]
+    fn new_sanitizes_special_chars() {
+        let cc = make_cc("test@host:port/path");
+        assert_eq!(cc.vs_ident, "test_host_port_path");
+    }
+
+    #[test]
+    fn gen_jwt_node_has_correct_claims() {
+        let cc = make_cc("test-vs");
+        let token = cc.gen_jwt("node/my-node".to_string()).unwrap();
+        let claims = decode_jwt(&token, "test-vs").expect("token must decode");
+
+        assert_eq!(claims.sub, "node/my-node");
+        assert_eq!(claims.iss, "vs.zpr/test-vs");
+    }
+
+    #[test]
+    fn gen_jwt_jti_is_unique_per_call() {
+        let cc = make_cc("test-vs");
+        let t1 = decode_jwt(&cc.gen_jwt("node/cn".to_string()).unwrap(), "test-vs").unwrap();
+        let t2 = decode_jwt(&cc.gen_jwt("node/cn".to_string()).unwrap(), "test-vs").unwrap();
+        assert_ne!(t1.jti, t2.jti);
+    }
 
     fn claim(key: &str, value: &str) -> Claim {
         Claim::new(key.to_string(), value.to_string())

--- a/vs/src/connection_control.rs
+++ b/vs/src/connection_control.rs
@@ -390,9 +390,8 @@ impl ConnectionControl {
             }
         };
 
-        // Use our own ident key and AUTHORITY as identity keys if present.
+        // Use our own ident key as identity key if present.
         let _ = authd_actor.add_identity_key(0, ATTR_KEY_VS_IDENT);
-        let _ = authd_actor.add_identity_key(usize::MAX, key::AUTHORITY);
 
         let actor_role = if authd_actor.is_node() {
             Role::Node
@@ -576,6 +575,14 @@ fn scrub_adapter_claims(claims: Vec<Claim>) -> Result<Vec<Attribute>, ServiceErr
 mod tests {
     use super::*;
 
+    use bytes::Bytes;
+    use openssl::hash::MessageDigest;
+    use openssl::pkey::{PKey, Private};
+    use openssl::rsa::Rsa;
+    use openssl::sign::Signer;
+    use std::sync::Arc;
+    use zpr::policy::v1;
+
     fn make_cc(ident: &str) -> ConnectionControl {
         ConnectionControl::new(ident.to_string())
     }
@@ -666,5 +673,227 @@ mod tests {
         let scrubbed = scrub_adapter_claims(claims).expect("scrub should succeed");
 
         assert_eq!(keys(&scrubbed), vec![key::CN, "custom.zpr.value"]);
+    }
+
+    // --- authenticate_node helpers ---
+
+    fn gen_rsa_test_keypair() -> (PKey<Private>, Vec<u8>) {
+        let rsa = Rsa::generate(2048).unwrap();
+        let privkey = PKey::from_rsa(rsa).unwrap();
+        let pubkey_der = privkey.public_key_to_der().unwrap();
+        (privkey, pubkey_der)
+    }
+
+    fn sign_node_challenge(
+        privkey: &PKey<Private>,
+        timestamp: u64,
+        cn: &str,
+        challenge: &[u8],
+    ) -> Vec<u8> {
+        let mut signer = Signer::new(MessageDigest::sha256(), privkey).unwrap();
+        signer.update(&timestamp.to_be_bytes()).unwrap();
+        signer.update(cn.as_bytes()).unwrap();
+        signer.update(challenge).unwrap();
+        signer.sign_to_vec().unwrap()
+    }
+
+    fn make_policy_with_bootstrap_key(cn: &str, pubkey_der: &[u8]) -> libeval::policy::Policy {
+        let mut msg = capnp::message::Builder::new_default();
+        {
+            let mut policy_bldr = msg.init_root::<v1::policy::Builder>();
+            policy_bldr.set_created("2024-01-01T00:00:00Z");
+            policy_bldr.set_version(1);
+            policy_bldr.set_metadata("");
+            let mut keys = policy_bldr.reborrow().init_keys(1);
+            keys.reborrow().get(0).set_id(cn);
+            keys.reborrow()
+                .get(0)
+                .set_key_type(v1::KeyMaterialT::RsaPub);
+            keys.reborrow()
+                .get(0)
+                .init_key_allows(1)
+                .set(0, v1::KeyAllowance::Bootstrap);
+            keys.reborrow().get(0).set_key_data(pubkey_der);
+        }
+        let mut bytes: Vec<u8> = Vec::new();
+        capnp::serialize::write_message(&mut bytes, &msg).unwrap();
+        libeval::policy::Policy::new_from_policy_bytes(Bytes::copy_from_slice(&bytes)).unwrap()
+    }
+
+    // --- authenticate_node tests ---
+
+    #[tokio::test]
+    async fn authenticate_node_unknown_cn() {
+        let asm = Arc::new(crate::assembly::tests::new_assembly_for_tests(None).await);
+        let cc = make_cc("test-vs");
+        let result = cc
+            .authenticate_node(
+                asm,
+                b"challenge",
+                12345678,
+                "unknown.zpr",
+                &[],
+                "127.0.0.1:1234".parse().unwrap(),
+                "fd5a:5052::1".parse().unwrap(),
+            )
+            .await;
+        assert!(matches!(result, Err(ServiceError::AuthenticationFailed(_))));
+    }
+
+    #[tokio::test]
+    async fn authenticate_node_invalid_signature() {
+        let asm = Arc::new(crate::assembly::tests::new_assembly_for_tests(None).await);
+        let cn = "test-node.zpr";
+        let (_, pubkey_der) = gen_rsa_test_keypair();
+        asm.policy_mgr
+            .update_policy(make_policy_with_bootstrap_key(cn, &pubkey_der))
+            .unwrap();
+        let cc = make_cc("test-vs");
+        let result = cc
+            .authenticate_node(
+                asm,
+                b"challenge",
+                12345678,
+                cn,
+                b"not-a-valid-rsa-sig",
+                "127.0.0.1:1234".parse().unwrap(),
+                "fd5a:5052::1".parse().unwrap(),
+            )
+            .await;
+        assert!(matches!(result, Err(ServiceError::AuthenticationFailed(_))));
+    }
+
+    #[tokio::test]
+    async fn authenticate_node_signature_wrong_content() {
+        let asm = Arc::new(crate::assembly::tests::new_assembly_for_tests(None).await);
+        let cn = "test-node.zpr";
+        let (privkey, pubkey_der) = gen_rsa_test_keypair();
+        asm.policy_mgr
+            .update_policy(make_policy_with_bootstrap_key(cn, &pubkey_der))
+            .unwrap();
+        let cc = make_cc("test-vs");
+        let challenge = b"my-challenge";
+        let timestamp = 12345678u64;
+        let bad_sig = sign_node_challenge(&privkey, timestamp + 1, cn, challenge);
+        let result = cc
+            .authenticate_node(
+                asm,
+                challenge,
+                timestamp,
+                cn,
+                &bad_sig,
+                "127.0.0.1:1234".parse().unwrap(),
+                "fd5a:5052::1".parse().unwrap(),
+            )
+            .await;
+        assert!(matches!(result, Err(ServiceError::AuthenticationFailed(_))));
+    }
+
+    fn make_policy_with_node_join_policy(cn: &str, pubkey_der: &[u8]) -> libeval::policy::Policy {
+        let mut msg = capnp::message::Builder::new_default();
+        {
+            let mut policy_bldr = msg.init_root::<v1::policy::Builder>();
+            policy_bldr.set_created("2024-01-01T00:00:00Z");
+            policy_bldr.set_version(1);
+            policy_bldr.set_metadata("");
+            {
+                let mut keys = policy_bldr.reborrow().init_keys(1);
+                keys.reborrow().get(0).set_id(cn);
+                keys.reborrow()
+                    .get(0)
+                    .set_key_type(v1::KeyMaterialT::RsaPub);
+                keys.reborrow()
+                    .get(0)
+                    .init_key_allows(1)
+                    .set(0, v1::KeyAllowance::Bootstrap);
+                keys.reborrow().get(0).set_key_data(pubkey_der);
+            }
+            {
+                // Empty match list → matches any connection; JoinFlag::Node marks this as a node.
+                let mut jps = policy_bldr.reborrow().init_join_policies(1);
+                jps.reborrow()
+                    .get(0)
+                    .init_flags(1)
+                    .set(0, v1::JoinFlag::Node);
+            }
+        }
+        let mut bytes: Vec<u8> = Vec::new();
+        capnp::serialize::write_message(&mut bytes, &msg).unwrap();
+        libeval::policy::Policy::new_from_policy_bytes(Bytes::copy_from_slice(&bytes)).unwrap()
+    }
+
+    #[tokio::test]
+    async fn authenticate_node_policy_denied() {
+        let asm = Arc::new(crate::assembly::tests::new_assembly_for_tests(None).await);
+        let cn = "test-node.zpr";
+        let (privkey, pubkey_der) = gen_rsa_test_keypair();
+        asm.policy_mgr
+            .update_policy(make_policy_with_bootstrap_key(cn, &pubkey_der))
+            .unwrap();
+        let cc = make_cc("test-vs");
+        let challenge = b"my-challenge";
+        let timestamp = 12345678u64;
+        let sig = sign_node_challenge(&privkey, timestamp, cn, challenge);
+        let result = cc
+            .authenticate_node(
+                asm,
+                challenge,
+                timestamp,
+                cn,
+                &sig,
+                "127.0.0.1:1234".parse().unwrap(),
+                "fd5a:5052::1".parse().unwrap(),
+            )
+            .await;
+        assert!(matches!(result, Err(ServiceError::Eval(_))));
+    }
+
+    #[tokio::test]
+    async fn authenticate_node_success() {
+        let asm = Arc::new(crate::assembly::tests::new_assembly_for_tests(None).await);
+        let cn = "test-node.zpr";
+        let (privkey, pubkey_der) = gen_rsa_test_keypair();
+        asm.policy_mgr
+            .update_policy(make_policy_with_node_join_policy(cn, &pubkey_der))
+            .unwrap();
+        let cc = make_cc("test-vs");
+        let challenge = b"my-challenge";
+        let timestamp = 12345678u64;
+        let sig = sign_node_challenge(&privkey, timestamp, cn, challenge);
+
+        let actor = cc
+            .authenticate_node(
+                asm,
+                challenge,
+                timestamp,
+                cn,
+                &sig,
+                "127.0.0.1:1234".parse().unwrap(),
+                "fd5a:5052::1".parse().unwrap(),
+            )
+            .await
+            .expect("authentication should succeed");
+
+        assert!(actor.is_node());
+
+        // zpr.vs.bootstrap.ident must be present and be a valid node JWT
+        let jwt_str = actor
+            .get_attribute(ATTR_KEY_VS_IDENT)
+            .expect("bootstrap ident attribute must be present")
+            .get_value()[0]
+            .clone();
+        let claims = decode_jwt(&jwt_str, "test-vs").expect("ident attribute must be a valid JWT");
+        assert_eq!(claims.sub, format!("node/{}", cn));
+        assert_eq!(claims.iss, "vs.zpr/test-vs");
+
+        // get_identity() returns [jwt, cn, authority] in that order
+        let identity = actor
+            .get_identity()
+            .expect("actor must have identity values");
+        assert_eq!(identity[0], jwt_str);
+
+        // Due to libeval not actually paying attention to what attributes are part of "identity",
+        // it will add the CN claim.
+        assert_eq!(identity[1], cn);
     }
 }

--- a/vs/src/main.rs
+++ b/vs/src/main.rs
@@ -273,7 +273,7 @@ async fn main() -> std::process::ExitCode {
         config: cfg.clone(),
         counters,
         system_start_time: std::time::Instant::now(),
-        cc: ConnectionControl::new(),
+        cc: ConnectionControl::new(identity),
         policy_mgr: policy_mgr,
         actor_mgr: Arc::new(actor_mgr),
         state_db: db_handle,


### PR DESCRIPTION
# Branch changes: mk/misc-fix

This just tightens up some loose ends in visa service that were bugging me.

## Real JWT identity tokens (`vs/src/connection_control.rs`, `vs/Cargo.toml`)

`ConnectionControl` now issues real JWTs instead of placeholder strings.

- `ConnectionControl::new()` now accepts a `vs_ident: String`. The ident is sanitized to `[a-zA-Z0-9._-]` and used as the HMAC signing secret.
- Added `JwtClaims` (iss, sub, exp, iat, jti) and `gen_jwt(sub)` which produces a short-lived HS256 token with a unique `jti` per call.
- `AUTHORITY` claim is now set to `vs.zpr/<ident>` (was `fake_jwt_token:…`).
- A new `zpr.vs.bootstrap.ident` attribute is added for both node and adapter connections, carrying the JWT. The identity key now uses this attribute (priority 0) instead of `AUTHORITY`.
- Added `jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }` to `vs/Cargo.toml`.

## Bug fix: `get_service` no longer panics on DB error (`vs/src/admin_service.rs`)

The `GET /admin/service` handler called `.unwrap()` on the actor-manager query.  This is replaced with explicit match arms: DB errors return `500 INTERNAL SERVER ERROR` with a logged message; missing service returns `404 NOT FOUND`.

Also added a `TODO` placeholder for exponential back-off on unauthorized requests.

## Call-site updates (`vs/src/main.rs`, `vs/src/assembly.rs`)

`ConnectionControl::new()` now receives the VS identity string from config at startup (`main.rs`) and a fixed test ident in the test assembly helper (`assembly.rs`).

## Minor comment/doc fixes

- `admin-api-types`: converted an inline comment on `ApiKeySet` to a doc comment and added a note that the keys are encrypted.
- `libeval/src/eval.rs`: tightened the identity-attribute TODO comment and added the tracking issue URL (`#201`).

## Tests

Unit tests added to `connection_control.rs`:

- `new_preserves_valid_ident_chars` / `new_sanitizes_special_chars` — ident sanitization.
- `gen_jwt_node_has_correct_claims` / `gen_jwt_jti_is_unique_per_call` — JWT correctness.
- `authenticate_node_unknown_cn` — unknown CN → `AuthenticationFailed`.
- `authenticate_node_invalid_signature` — bad bytes → `AuthenticationFailed`.
- `authenticate_node_signature_wrong_content` — signature over wrong data → `AuthenticationFailed`.
- `authenticate_node_policy_denied` — valid sig, no join policy → `Eval` error.
- `authenticate_node_success` — full happy-path: actor is a node, carries a valid `zpr.vs.bootstrap.ident` JWT, identity resolves to the JWT token.