### PR TITLE
remove casting of ipaddr to string for packetdesc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5259,8 +5259,8 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zpr"
-version = "0.16.0"
-source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.16.0#05dd786c44382e8683ef8118fbe1f20e9676e6c4"
+version = "0.17.1"
+source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.17.1#8292918d0c193f4d4c4f0c2b2388f39309ad2b58"
 dependencies = [
  "capnp",
  "capnpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ serde_with = { version = "3.18.0", default-features = false, features = ["std", 
 thiserror = "2.0.18"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.20"
-zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.16.0", features = ["vsapi", "policy"]}
+zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.17.1", features = ["vsapi", "policy"]}
 

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -234,14 +234,12 @@ impl VisaMgr {
     ) -> Result<Visa, ServiceError> {
         // TODO: We may have this visa on hand already, if so return it and do not re-generate.
 
-        // TODO: PacketDesc should have new_xxx functions that take IpAddr (not just string)
-        let pkt_data = PacketDesc::new_tcp(
-            &asm.config.get_vs_addr().to_string(),
-            &node_addr.to_string(),
+        let pkt_data = PacketDesc::new_tcp_with_addr(
+            asm.config.get_vs_addr(),
+            *node_addr,
             0,
             vss_port,
-        )
-        .unwrap();
+        )?;
 
         // TODO: This call to return a FULL visa plus Route info.
         // then we need to do some work.
@@ -947,9 +945,9 @@ mod tests {
         let src_adapter: IpAddr = "fd5a:5052:1234::a100".parse().unwrap();
         let dst_adapter: IpAddr = "fd5a:5052:1234::a200".parse().unwrap();
 
-        let pdesc = PacketDesc::new_tcp(
-            &src_adapter.to_string(),
-            &dst_adapter.to_string(),
+        let pdesc = PacketDesc::new_tcp_with_addr(
+            src_adapter,
+            dst_adapter,
             12345,
             80,
         )
@@ -981,9 +979,9 @@ mod tests {
         let dst: IpAddr = MH_DST.parse().unwrap();
         let src_adapter: IpAddr = "fd5a:5052:1234::a100".parse().unwrap();
         let dst_adapter: IpAddr = "fd5a:5052:1234::a200".parse().unwrap();
-        let pdesc = PacketDesc::new_tcp(
-            &src_adapter.to_string(),
-            &dst_adapter.to_string(),
+        let pdesc = PacketDesc::new_tcp_with_addr(
+            src_adapter,
+            dst_adapter,
             12345,
             80,
         )
@@ -1033,9 +1031,9 @@ mod tests {
         let dst_adapter: IpAddr = "fd5a:5052:1234::a200".parse().unwrap();
 
         // Reverse packet: dst is the sender, src is the destination.
-        let pdesc = PacketDesc::new_tcp(
-            &dst_adapter.to_string(),
-            &src_adapter.to_string(),
+        let pdesc = PacketDesc::new_tcp_with_addr(
+            dst_adapter,
+            src_adapter,
             54321,
             80,
         )
@@ -1078,9 +1076,9 @@ mod tests {
         let dst: IpAddr = MH_DST.parse().unwrap();
         let src_adapter: IpAddr = "fd5a:5052:1234::a100".parse().unwrap();
         let dst_adapter: IpAddr = "fd5a:5052:1234::a200".parse().unwrap();
-        let pdesc = PacketDesc::new_tcp(
-            &src_adapter.to_string(),
-            &dst_adapter.to_string(),
+        let pdesc = PacketDesc::new_tcp_with_addr(
+            src_adapter,
+            dst_adapter,
             12345,
             80,
         )

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -234,12 +234,8 @@ impl VisaMgr {
     ) -> Result<Visa, ServiceError> {
         // TODO: We may have this visa on hand already, if so return it and do not re-generate.
 
-        let pkt_data = PacketDesc::new_tcp_with_addr(
-            asm.config.get_vs_addr(),
-            *node_addr,
-            0,
-            vss_port,
-        )?;
+        let pkt_data =
+            PacketDesc::new_tcp_with_addr(asm.config.get_vs_addr(), *node_addr, 0, vss_port)?;
 
         // TODO: This call to return a FULL visa plus Route info.
         // then we need to do some work.
@@ -945,13 +941,7 @@ mod tests {
         let src_adapter: IpAddr = "fd5a:5052:1234::a100".parse().unwrap();
         let dst_adapter: IpAddr = "fd5a:5052:1234::a200".parse().unwrap();
 
-        let pdesc = PacketDesc::new_tcp_with_addr(
-            src_adapter,
-            dst_adapter,
-            12345,
-            80,
-        )
-        .unwrap();
+        let pdesc = PacketDesc::new_tcp_with_addr(src_adapter, dst_adapter, 12345, 80).unwrap();
         let hit = Hit::new_no_signal(0, Direction::Forward);
         let route = asm.topo_mgr.get_best_route(&src, &dst).unwrap(); // route between the nodes
 
@@ -979,13 +969,7 @@ mod tests {
         let dst: IpAddr = MH_DST.parse().unwrap();
         let src_adapter: IpAddr = "fd5a:5052:1234::a100".parse().unwrap();
         let dst_adapter: IpAddr = "fd5a:5052:1234::a200".parse().unwrap();
-        let pdesc = PacketDesc::new_tcp_with_addr(
-            src_adapter,
-            dst_adapter,
-            12345,
-            80,
-        )
-        .unwrap();
+        let pdesc = PacketDesc::new_tcp_with_addr(src_adapter, dst_adapter, 12345, 80).unwrap();
         let hit = Hit::new_no_signal(0, Direction::Forward);
         let route = asm.topo_mgr.get_best_route(&src, &dst).unwrap();
 
@@ -1031,13 +1015,7 @@ mod tests {
         let dst_adapter: IpAddr = "fd5a:5052:1234::a200".parse().unwrap();
 
         // Reverse packet: dst is the sender, src is the destination.
-        let pdesc = PacketDesc::new_tcp_with_addr(
-            dst_adapter,
-            src_adapter,
-            54321,
-            80,
-        )
-        .unwrap();
+        let pdesc = PacketDesc::new_tcp_with_addr(dst_adapter, src_adapter, 54321, 80).unwrap();
         let hit = Hit::new_no_signal(0, Direction::Reverse);
         let route = asm.topo_mgr.get_best_route(&dst, &src).unwrap();
 
@@ -1076,13 +1054,7 @@ mod tests {
         let dst: IpAddr = MH_DST.parse().unwrap();
         let src_adapter: IpAddr = "fd5a:5052:1234::a100".parse().unwrap();
         let dst_adapter: IpAddr = "fd5a:5052:1234::a200".parse().unwrap();
-        let pdesc = PacketDesc::new_tcp_with_addr(
-            src_adapter,
-            dst_adapter,
-            12345,
-            80,
-        )
-        .unwrap();
+        let pdesc = PacketDesc::new_tcp_with_addr(src_adapter, dst_adapter, 12345, 80).unwrap();
         let hit = Hit::new_no_signal(0, Direction::Forward);
         let route = asm.topo_mgr.get_best_route(&src, &dst).unwrap();
 


### PR DESCRIPTION
I did not change which function we use in most of the tests, since in that case it is just a raw string, so we would just have to repeatedly convert the string to an IpAddr before we call the function.