### PR TITLE
add slack notify for pr req

### DIFF
--- a/.github/workflows/pr-notify.yml
+++ b/.github/workflows/pr-notify.yml
@@ -1,0 +1,13 @@
+name: PR Notifications
+
+on:
+  pull_request:
+    types:
+      - review_requested
+
+jobs:
+  notify:
+    uses: org-zpr/.github/.github/workflows/pr-review-notify.yml@main
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK_URL }}
+

--- a/.github/workflows/pr-notify.yml
+++ b/.github/workflows/pr-notify.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   notify:
-    uses: org-zpr/.github/.github/workflows/pr-review-notify.yml@main
+    uses: org-zpr/zpr-dev-tools/.github/workflows/pr-review-notify.yml@main
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK_URL }}
 


### PR DESCRIPTION
Make use of the new slack-alerts notifier hook in dev-tools repo to send a notice when a review is requested in this repo.