### PR TITLE
Mk/178 peers - VS now sends link info to nodes, also pushes visas to nodes on path.

### DIFF
--- a/libeval/src/policy.rs
+++ b/libeval/src/policy.rs
@@ -260,6 +260,14 @@ impl Policy {
             .map(|v| v.as_slice())
     }
 
+    /// Returns list of node addresses that have peers (or empty vec).
+    pub fn all_peered_nodes(&self) -> Vec<IpAddr> {
+        match &self.peer_table {
+            Some(table) => table.keys().copied().collect(),
+            None => Vec::new(),
+        }
+    }
+
     /// A link may have attributes on it, this returns them.
     pub fn get_link_attrs(&self, link_id: &str) -> Option<&[AttrExp]> {
         self.link_attrs.as_ref()?.get(link_id).map(|v| v.as_slice())

--- a/libeval/src/policy.rs
+++ b/libeval/src/policy.rs
@@ -260,12 +260,9 @@ impl Policy {
             .map(|v| v.as_slice())
     }
 
-    /// Returns list of node addresses that have peers (or empty vec).
-    pub fn all_peered_nodes(&self) -> Vec<IpAddr> {
-        match &self.peer_table {
-            Some(table) => table.keys().copied().collect(),
-            None => Vec::new(),
-        }
+    /// Returns an iterator over node addresses that have peers (empty if none).
+    pub fn all_peered_nodes(&self) -> impl Iterator<Item = &IpAddr> + '_ {
+        self.peer_table.iter().flat_map(|table| table.keys())
     }
 
     /// A link may have attributes on it, this returns them.

--- a/vs/src/actor_mgr.rs
+++ b/vs/src/actor_mgr.rs
@@ -803,7 +803,7 @@ mod test {
         let policy = make_policy_with_services(vec![auth_service, regular_service]);
 
         let asm = new_assembly_for_tests(None).await;
-        asm.policy_mgr.update_policy(policy).unwrap();
+        asm.policy_mgr.update_policy(policy).await.unwrap();
         let asm = Arc::new(asm);
 
         let mut services = mgr.get_auth_services_list(asm).await.unwrap();
@@ -843,7 +843,7 @@ mod test {
         let policy = make_policy_with_services(vec![regular_service]);
 
         let asm = new_assembly_for_tests(None).await;
-        asm.policy_mgr.update_policy(policy).unwrap();
+        asm.policy_mgr.update_policy(policy).await.unwrap();
         let asm = Arc::new(asm);
 
         let services = mgr.get_auth_services_list(asm).await.unwrap();

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -770,13 +770,13 @@ mod tests {
         let route = Route::new_direct(node_addr.into());
 
         // Add a visa.
-        let v = asm
+        let vwmd = asm
             .visa_mgr
             .create_visa(&asm, &node_addr, &pdesc, &hit, &route, "", 0)
             .await
             .unwrap();
 
-        let created_id = v.issuer_id;
+        let created_id = vwmd.visa.issuer_id;
         assert!(created_id > 0);
 
         let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
@@ -835,7 +835,7 @@ mod tests {
             .await
             .unwrap();
 
-        let mut created_ids = vec![v0.issuer_id, v1.issuer_id, v2.issuer_id];
+        let mut created_ids = vec![v0.visa.issuer_id, v1.visa.issuer_id, v2.visa.issuer_id];
         created_ids.sort_unstable();
 
         let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
@@ -1077,7 +1077,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("GET")
-                    .uri(&format!("/admin/visas/{}", v.issuer_id))
+                    .uri(&format!("/admin/visas/{}", v.visa.issuer_id))
                     .header("X-API-Key", &api_key)
                     .body(Body::empty())
                     .unwrap(),
@@ -1089,7 +1089,7 @@ mod tests {
         let body = response.into_body().collect().await.unwrap().to_bytes();
         let vd: VisaDescriptor = serde_json::from_slice(&body).unwrap();
 
-        assert_eq!(vd.id, v.issuer_id);
+        assert_eq!(vd.id, v.visa.issuer_id);
         assert_eq!(vd.policy_id, "42");
         assert_eq!(vd.zpl, zpl_str);
         assert_eq!(vd.direction, VisaMatchDirection::Forward);
@@ -1123,7 +1123,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("GET")
-                    .uri(&format!("/admin/visas/{}", v.issuer_id))
+                    .uri(&format!("/admin/visas/{}", v.visa.issuer_id))
                     .header("X-API-Key", &api_key)
                     .body(Body::empty())
                     .unwrap(),
@@ -1167,7 +1167,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("GET")
-                    .uri(&format!("/admin/visas/{}", v.issuer_id))
+                    .uri(&format!("/admin/visas/{}", v.visa.issuer_id))
                     .header("X-API-Key", &api_key)
                     .body(Body::empty())
                     .unwrap(),

--- a/vs/src/assembly.rs
+++ b/vs/src/assembly.rs
@@ -57,6 +57,7 @@ pub mod tests {
     use crate::db::FakeDb;
     use crate::db::{ActorRepo, NodeRepo, PolicyRepo, VisaRepo};
     use crate::policy_mgr::PolicyMgr;
+    use crate::test_helpers::FakeResolver;
     use crate::visa_mgr::VisaMgr;
     use crate::visareq_worker::VisaRequestJob;
     use crate::vss_mgr::VssMgr;
@@ -111,9 +112,13 @@ pub mod tests {
             counters: counters.clone(),
             system_start_time: std::time::Instant::now(),
             cc: ConnectionControl::new("vs_ident".to_string()),
-            policy_mgr: PolicyMgr::new_with_initial_policy(initial_policy, policy_repo)
-                .await
-                .expect("failed to initialize PolicyMgr"),
+            policy_mgr: PolicyMgr::new_with_initial_policy(
+                initial_policy,
+                policy_repo,
+                Arc::new(FakeResolver::ip_only()),
+            )
+            .await
+            .expect("failed to initialize PolicyMgr"),
             actor_mgr: Arc::new(ActorMgr::new(actor_repo, node_repo, counters)),
             state_db: db_handle,
             vreq_chan: vreq_tx,

--- a/vs/src/config.rs
+++ b/vs/src/config.rs
@@ -75,6 +75,9 @@ pub const VSS_START_DELAY: std::time::Duration = std::time::Duration::from_secs(
 /// VSS worker pings the node VSS API at this interval.
 pub const VSS_PING_INTERVAL: std::time::Duration = std::time::Duration::from_secs(7);
 
+/// VSS wakes up to check for visas or other housekeeping this often.
+pub const VSS_HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
+
 /// Number of allowed consecutive VSS ping failures before we drop the node.
 pub const VSS_MAX_PING_FAILURES: usize = 3;
 

--- a/vs/src/config.rs
+++ b/vs/src/config.rs
@@ -76,7 +76,7 @@ pub const VSS_START_DELAY: std::time::Duration = std::time::Duration::from_secs(
 pub const VSS_PING_INTERVAL: std::time::Duration = std::time::Duration::from_secs(7);
 
 /// VSS wakes up to check for visas or other housekeeping this often.
-pub const VSS_HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
+pub const VSS_HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_millis(800);
 
 /// Number of allowed consecutive VSS ping failures before we drop the node.
 pub const VSS_MAX_PING_FAILURES: usize = 3;

--- a/vs/src/connection_control.rs
+++ b/vs/src/connection_control.rs
@@ -744,6 +744,7 @@ mod tests {
         let (_, pubkey_der) = gen_rsa_test_keypair();
         asm.policy_mgr
             .update_policy(make_policy_with_bootstrap_key(cn, &pubkey_der))
+            .await
             .unwrap();
         let cc = make_cc("test-vs");
         let result = cc
@@ -767,6 +768,7 @@ mod tests {
         let (privkey, pubkey_der) = gen_rsa_test_keypair();
         asm.policy_mgr
             .update_policy(make_policy_with_bootstrap_key(cn, &pubkey_der))
+            .await
             .unwrap();
         let cc = make_cc("test-vs");
         let challenge = b"my-challenge";
@@ -826,6 +828,7 @@ mod tests {
         let (privkey, pubkey_der) = gen_rsa_test_keypair();
         asm.policy_mgr
             .update_policy(make_policy_with_bootstrap_key(cn, &pubkey_der))
+            .await
             .unwrap();
         let cc = make_cc("test-vs");
         let challenge = b"my-challenge";
@@ -852,6 +855,7 @@ mod tests {
         let (privkey, pubkey_der) = gen_rsa_test_keypair();
         asm.policy_mgr
             .update_policy(make_policy_with_node_join_policy(cn, &pubkey_der))
+            .await
             .unwrap();
         let cc = make_cc("test-vs");
         let challenge = b"my-challenge";

--- a/vs/src/error.rs
+++ b/vs/src/error.rs
@@ -63,6 +63,9 @@ pub enum ServiceError {
 
     #[error("topology error: {0}")]
     Topology(#[from] TopologyError),
+
+    #[error("resolver error: {0}")]
+    Resolver(#[from] ResolverError),
 }
 
 #[derive(Debug, Error)]

--- a/vs/src/error.rs
+++ b/vs/src/error.rs
@@ -150,6 +150,15 @@ pub enum TopologyError {
     LinkNotFound(String),
 }
 
+#[derive(Debug, Error)]
+pub enum ResolverError {
+    #[error("no addresses found for {0}")]
+    NoAddresses(String),
+
+    #[error("i/o error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
 impl From<ApiResponseError> for VssSyncError {
     fn from(err: ApiResponseError) -> Self {
         VssSyncError::ApiResponse(err.code, err.message, err.retry_in)

--- a/vs/src/main.rs
+++ b/vs/src/main.rs
@@ -33,7 +33,9 @@ mod topology_mgr;
 mod visa_mgr;
 mod visareq_worker;
 mod vsapi_worker;
+mod vss;
 mod vss_mgr;
+mod vss_worker;
 
 #[cfg(test)]
 mod test_helpers;

--- a/vs/src/main.rs
+++ b/vs/src/main.rs
@@ -54,7 +54,7 @@ use crate::event_mgr::VsEvent;
 use crate::logging::enable_logging;
 use crate::logging::targets::MAIN;
 use crate::net_mgr::NetMgr;
-use crate::policy_mgr::PolicyMgr;
+use crate::policy_mgr::{PolicyMgr, SystemResolver};
 use crate::topology_mgr::TopologyMgr;
 use crate::visa_mgr::VisaMgr;
 use crate::vss_mgr::VssMgr;
@@ -223,9 +223,20 @@ async fn main() -> std::process::ExitCode {
 
     let policy_mgr_res = match initial_policy {
         Some(p) => {
-            PolicyMgr::new_with_initial_policy(p, db::PolicyRepo::new(db_handle.clone())).await
+            PolicyMgr::new_with_initial_policy(
+                p,
+                db::PolicyRepo::new(db_handle.clone()),
+                Arc::new(SystemResolver),
+            )
+            .await
         }
-        None => PolicyMgr::new_from_state(db::PolicyRepo::new(db_handle.clone())).await,
+        None => {
+            PolicyMgr::new_from_state(
+                db::PolicyRepo::new(db_handle.clone()),
+                Arc::new(SystemResolver),
+            )
+            .await
+        }
     };
 
     let net_mgr = NetMgr::new_v6().expect("failed to create NetMgr");

--- a/vs/src/policy_mgr.rs
+++ b/vs/src/policy_mgr.rs
@@ -234,9 +234,9 @@ impl PolicyResolver {
     ) -> Result<HashMap<IpAddr, Vec<Link>>, ResolverError> {
         let mut links_by_node: HashMap<IpAddr, Vec<Link>> = HashMap::new();
         for node_addr in policy.all_peered_nodes() {
-            if let Some(peers) = policy.get_peers_for_node(&node_addr) {
+            if let Some(peers) = policy.get_peers_for_node(node_addr) {
                 let links = self.peers_to_links(peers).await?;
-                links_by_node.insert(node_addr, links);
+                links_by_node.insert(*node_addr, links);
             }
         }
         Ok(links_by_node)

--- a/vs/src/policy_mgr.rs
+++ b/vs/src/policy_mgr.rs
@@ -12,15 +12,19 @@
 //! accessible by concurrent threads.
 
 use arc_swap::ArcSwap;
-use std::net::IpAddr;
+use std::collections::HashMap;
+use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use tracing::{debug, info};
 
 use libeval::attribute::Attribute;
-use libeval::policy::Policy;
+use libeval::policy::{Peer, Policy};
+
+use zpr::policy_types::{NetAddr, NetworkHost};
+use zpr::vsapi_types::{Link, LinkRole, SockAddr};
 
 use crate::db;
-use crate::error::{ServiceError, StoreError, TopologyError};
+use crate::error::{ResolverError, ServiceError, TopologyError};
 use crate::logging::targets::MAIN;
 
 // TODO: move to libeval::attribute::key
@@ -32,7 +36,15 @@ const DEFAULT_LINK_COST: u32 = 1;
 #[allow(dead_code)]
 pub struct PolicyMgr {
     inner: ArcSwap<Policy>,
+    resolved_topology: ArcSwap<ResolvedTopology>,
     repo: db::PolicyRepo,
+    /// Serializes concurrent policy updates; reads remain lock-free via ArcSwap.
+    update_lock: tokio::sync::Mutex<()>,
+}
+
+struct ResolvedTopology {
+    vinst: u64,
+    links_by_node: HashMap<IpAddr, Vec<Link>>,
 }
 
 #[derive(Debug, Clone)]
@@ -48,33 +60,47 @@ impl PolicyMgr {
     ///
     /// Note that policy is written to DB for backup purposes. It is kept in memory
     /// here for general access by rest of visa service.
+    ///
+    /// This also runs DNS lookups on all the peerings in the policy. Will throw a
+    /// [ResolverError] if any of the peerings fail to resolve.  We may revisit this
+    /// later if we decide to eventually pass DNS names down to nodes.
     pub async fn new_with_initial_policy(
         mut policy: Policy,
         repo: db::PolicyRepo,
-    ) -> Result<Self, StoreError> {
+    ) -> Result<Self, ServiceError> {
         debug!(target: MAIN, "initializing policy manager");
         policy.set_vinst(1);
 
+        let resolved = resolve_topology(&policy).await?;
         let _db_updated = repo.set_current_policy(&policy, false).await?;
 
         debug!(target: MAIN, "policy manager initialized successfully");
         Ok(PolicyMgr {
             inner: ArcSwap::from_pointee(policy),
+            resolved_topology: ArcSwap::from_pointee(resolved),
             repo,
+            update_lock: tokio::sync::Mutex::new(()),
         })
     }
 
     /// Create a new policy manager, initializing it with the current policy in the database. If there is no
     /// policy in the database, this will return an error.
-    pub async fn new_from_state(repo: db::PolicyRepo) -> Result<Self, StoreError> {
+    ///
+    /// If the policy contains hostnames and DNS is not working, this returns an error.
+    pub async fn new_from_state(repo: db::PolicyRepo) -> Result<Self, ServiceError> {
         debug!(target: MAIN, "initializing policy manager from state");
         let policy = repo.get_current_policy().await?;
         info!(target: MAIN, "loaded policy from state version:{}, created:{}", policy.get_version().unwrap_or(0),
             policy.get_created().unwrap_or("unknown").to_string());
         debug!(target: MAIN, "policy manager initialized successfully");
+
+        // TODO: dump the resolved stuff into state too.
+        let resolved = resolve_topology(&policy).await?;
         Ok(PolicyMgr {
             inner: ArcSwap::from_pointee(policy),
+            resolved_topology: ArcSwap::from_pointee(resolved),
             repo,
+            update_lock: tokio::sync::Mutex::new(()),
         })
     }
 
@@ -89,13 +115,24 @@ impl PolicyMgr {
     /// TODO: There is a lot of housekeeping that needs to happen around a policy update. None of that
     /// is implemented here. Right now this is just to support unit tests.
     #[allow(dead_code)]
-    pub fn update_policy(&self, new_policy: Policy) -> Result<(), StoreError> {
-        let mut np = Arc::new(new_policy);
-        self.inner.rcu(move |op| {
-            Arc::get_mut(&mut np).unwrap().set_vinst(op.vinst() + 1);
-            np.clone()
-        });
+    pub async fn update_policy(&self, new_policy: Policy) -> Result<(), ServiceError> {
+        let _guard = self.update_lock.lock().await;
+
+        let mut new_policy = new_policy;
+        new_policy.set_vinst(self.inner.load().vinst() + 1);
+
+        let resolved = resolve_topology(&new_policy).await?;
+
+        self.resolved_topology.store(Arc::new(resolved));
+        self.inner.store(Arc::new(new_policy));
         Ok(())
+    }
+
+    /// When policy is updated, all the peer tables have their DNS names resolved and cached
+    /// here along with the policy.
+    pub fn resolved_links_for_node(&self, node: &IpAddr) -> Vec<Link> {
+        let topo = self.resolved_topology.load_full();
+        topo.links_by_node.get(node).cloned().unwrap_or_default()
     }
 
     /// Consult policy to get a description of the link between `node_a` and `node_b`.
@@ -127,6 +164,59 @@ impl PolicyMgr {
             }
         }
         Err(TopologyError::LinkNotFound(format!("{node_a} <-> {node_b}")).into())
+    }
+}
+
+async fn resolve_topology(policy: &Policy) -> Result<ResolvedTopology, ResolverError> {
+    let mut links_by_node: HashMap<IpAddr, Vec<Link>> = HashMap::new();
+    for node_addr in policy.all_peered_nodes() {
+        if let Some(peers) = policy.get_peers_for_node(&node_addr) {
+            let links = peers_to_links(peers).await?;
+            links_by_node.insert(node_addr, links);
+        }
+    }
+    Ok(ResolvedTopology {
+        vinst: policy.vinst(),
+        links_by_node,
+    })
+}
+
+/// Peers from policy may include hostnames. Here we run any hostnames through a
+/// DNS lookup and create concrete `Link` objects with IP addresses. Returns an error
+/// if any peer's address fails to resolve.
+async fn peers_to_links(peers: &[Peer]) -> Result<Vec<Link>, ResolverError> {
+    // Parallelize the DNS lookups then check for the first error.
+    let futs = peers
+        .iter()
+        .map(|peer| async move { (peer, resolve_netaddr(&peer.remote_substrate).await) });
+
+    futures::future::join_all(futs)
+        .await
+        .into_iter()
+        .map(|(peer, result)| {
+            result.map(|sock_addr| Link {
+                link_id: peer.link_id.clone(),
+                role: LinkRole::Active, // only "active" support at the moment.
+                peer: SockAddr {
+                    addr: sock_addr.ip(),
+                    port: sock_addr.port(),
+                },
+            })
+        })
+        .collect()
+}
+
+/// If the passed `NetAddr` contains a hostname, perform a DNS lookup to resolve it to an IP address.
+/// Otherwise this quickly just returns a SocketAddr.
+async fn resolve_netaddr(naddr: &NetAddr) -> Result<SocketAddr, ResolverError> {
+    match &naddr.host {
+        NetworkHost::Ip(ip_addr) => Ok(SocketAddr::new(ip_addr.clone(), naddr.port)),
+        NetworkHost::Hostname(hostname) => {
+            let mut addrs = tokio::net::lookup_host((hostname.as_str(), naddr.port)).await?;
+            addrs
+                .next()
+                .ok_or_else(|| ResolverError::NoAddresses(hostname.clone()))
+        }
     }
 }
 
@@ -346,5 +436,73 @@ mod tests {
             .unwrap();
         assert_eq!(result.attrs.len(), 1);
         assert_eq!(result.attrs[0].get_key(), "link.class");
+    }
+
+    fn ip_peer(link_id: &str, ip: IpAddr, port: u16) -> Peer {
+        Peer {
+            link_id: link_id.to_string(),
+            remote_zpr_addr: "fd5a:5052::1".parse().unwrap(),
+            remote_substrate: NetAddr {
+                host: NetworkHost::Ip(ip),
+                port,
+            },
+        }
+    }
+
+    /// Empty peer slice produces an empty link list.
+    #[tokio::test]
+    async fn test_peers_to_links_empty() {
+        let links = peers_to_links(&[]).await.unwrap();
+        assert!(links.is_empty());
+    }
+
+    /// A single IP peer maps to a single Link with the correct fields.
+    #[tokio::test]
+    async fn test_peers_to_links_single_ip() {
+        let ip: IpAddr = "192.0.2.1".parse().unwrap();
+        let peer = ip_peer("link-a", ip, 4000);
+
+        let links = peers_to_links(&[peer]).await.unwrap();
+
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].link_id, "link-a");
+        assert_eq!(links[0].role, LinkRole::Active);
+        assert_eq!(links[0].peer.addr, ip);
+        assert_eq!(links[0].peer.port, 4000);
+    }
+
+    /// Multiple IP peers produce one Link each, in the same order.
+    #[tokio::test]
+    async fn test_peers_to_links_multiple_ips() {
+        let ip_a: IpAddr = "192.0.2.1".parse().unwrap();
+        let ip_b: IpAddr = "192.0.2.2".parse().unwrap();
+        let peers = [ip_peer("link-a", ip_a, 4000), ip_peer("link-b", ip_b, 5000)];
+
+        let links = peers_to_links(&peers).await.unwrap();
+
+        assert_eq!(links.len(), 2);
+        assert_eq!(links[0].link_id, "link-a");
+        assert_eq!(links[0].peer.addr, ip_a);
+        assert_eq!(links[1].link_id, "link-b");
+        assert_eq!(links[1].peer.addr, ip_b);
+    }
+
+    /// A peer with an unresolvable hostname causes peers_to_links to return an error.
+    #[tokio::test]
+    async fn test_peers_to_links_bad_hostname_errors() {
+        let ip: IpAddr = "192.0.2.1".parse().unwrap();
+        let good = ip_peer("link-good", ip, 4000);
+        let bad = Peer {
+            link_id: "link-bad".to_string(),
+            remote_zpr_addr: "fd5a:5052::2".parse().unwrap(),
+            remote_substrate: NetAddr {
+                host: NetworkHost::Hostname("this.hostname.does.not.exist.invalid".to_string()),
+                port: 4000,
+            },
+        };
+
+        let result = peers_to_links(&[good, bad]).await;
+
+        assert!(result.is_err());
     }
 }

--- a/vs/src/policy_mgr.rs
+++ b/vs/src/policy_mgr.rs
@@ -12,6 +12,7 @@
 //! accessible by concurrent threads.
 
 use arc_swap::ArcSwap;
+use async_trait::async_trait;
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
@@ -27,6 +28,13 @@ use crate::db;
 use crate::error::{ResolverError, ServiceError, TopologyError};
 use crate::logging::targets::MAIN;
 
+/// Abstracts DNS hostname resolution so it can be swapped out in tests.
+#[async_trait]
+pub trait DnsResolver: Send + Sync {
+    /// Resolve `host` to a `SocketAddr` on the given `port`.
+    async fn resolve(&self, host: &str, port: u16) -> Result<SocketAddr, ResolverError>;
+}
+
 // TODO: move to libeval::attribute::key
 const LINK_COST_ATTR_KEY: &str = "link.zpr.cost";
 
@@ -40,6 +48,7 @@ pub struct PolicyMgr {
     repo: db::PolicyRepo,
     /// Serializes concurrent policy updates; reads remain lock-free via ArcSwap.
     update_lock: tokio::sync::Mutex<()>,
+    resolver: PolicyResolver,
 }
 
 struct ResolvedTopology {
@@ -52,6 +61,19 @@ pub struct LinkDescription {
     pub link_id: String,
     pub attrs: Vec<Attribute>,
     pub cost: u32,
+}
+
+/// Production resolver that uses the OS/system resolver via `tokio::net::lookup_host`.
+pub struct SystemResolver;
+
+#[async_trait]
+impl DnsResolver for SystemResolver {
+    async fn resolve(&self, host: &str, port: u16) -> Result<SocketAddr, ResolverError> {
+        let mut addrs = tokio::net::lookup_host((host, port)).await?;
+        addrs
+            .next()
+            .ok_or_else(|| ResolverError::NoAddresses(host.to_string()))
+    }
 }
 
 impl PolicyMgr {
@@ -67,11 +89,14 @@ impl PolicyMgr {
     pub async fn new_with_initial_policy(
         mut policy: Policy,
         repo: db::PolicyRepo,
+        resolver: Arc<dyn DnsResolver>,
     ) -> Result<Self, ServiceError> {
         debug!(target: MAIN, "initializing policy manager");
         policy.set_vinst(1);
 
-        let resolved = resolve_topology(&policy).await?;
+        let presolver = PolicyResolver::new(resolver);
+
+        let resolved = presolver.resolve_topology(&policy).await?;
         let _db_updated = repo.set_current_policy(&policy, false).await?;
 
         debug!(target: MAIN, "policy manager initialized successfully");
@@ -80,6 +105,7 @@ impl PolicyMgr {
             resolved_topology: ArcSwap::from_pointee(resolved),
             repo,
             update_lock: tokio::sync::Mutex::new(()),
+            resolver: presolver,
         })
     }
 
@@ -87,20 +113,26 @@ impl PolicyMgr {
     /// policy in the database, this will return an error.
     ///
     /// If the policy contains hostnames and DNS is not working, this returns an error.
-    pub async fn new_from_state(repo: db::PolicyRepo) -> Result<Self, ServiceError> {
+    pub async fn new_from_state(
+        repo: db::PolicyRepo,
+        resolver: Arc<dyn DnsResolver>,
+    ) -> Result<Self, ServiceError> {
         debug!(target: MAIN, "initializing policy manager from state");
         let policy = repo.get_current_policy().await?;
         info!(target: MAIN, "loaded policy from state version:{}, created:{}", policy.get_version().unwrap_or(0),
             policy.get_created().unwrap_or("unknown").to_string());
         debug!(target: MAIN, "policy manager initialized successfully");
 
+        let presolver = PolicyResolver::new(resolver);
+
         // TODO: dump the resolved stuff into state too.
-        let resolved = resolve_topology(&policy).await?;
+        let resolved = presolver.resolve_topology(&policy).await?;
         Ok(PolicyMgr {
             inner: ArcSwap::from_pointee(policy),
             resolved_topology: ArcSwap::from_pointee(resolved),
             repo,
             update_lock: tokio::sync::Mutex::new(()),
+            resolver: presolver,
         })
     }
 
@@ -121,7 +153,7 @@ impl PolicyMgr {
         let mut new_policy = new_policy;
         new_policy.set_vinst(self.inner.load().vinst() + 1);
 
-        let resolved = resolve_topology(&new_policy).await?;
+        let resolved = self.resolver.resolve_topology(&new_policy).await?;
 
         self.resolved_topology.store(Arc::new(resolved));
         self.inner.store(Arc::new(new_policy));
@@ -167,56 +199,67 @@ impl PolicyMgr {
     }
 }
 
-async fn resolve_topology(policy: &Policy) -> Result<ResolvedTopology, ResolverError> {
-    let mut links_by_node: HashMap<IpAddr, Vec<Link>> = HashMap::new();
-    for node_addr in policy.all_peered_nodes() {
-        if let Some(peers) = policy.get_peers_for_node(&node_addr) {
-            let links = peers_to_links(peers).await?;
-            links_by_node.insert(node_addr, links);
-        }
-    }
-    Ok(ResolvedTopology {
-        vinst: policy.vinst(),
-        links_by_node,
-    })
+pub struct PolicyResolver {
+    resolver: Arc<dyn DnsResolver>,
 }
 
-/// Peers from policy may include hostnames. Here we run any hostnames through a
-/// DNS lookup and create concrete `Link` objects with IP addresses. Returns an error
-/// if any peer's address fails to resolve.
-async fn peers_to_links(peers: &[Peer]) -> Result<Vec<Link>, ResolverError> {
-    // Parallelize the DNS lookups then check for the first error.
-    let futs = peers
-        .iter()
-        .map(|peer| async move { (peer, resolve_netaddr(&peer.remote_substrate).await) });
+impl PolicyResolver {
+    pub fn new(resolver: Arc<dyn DnsResolver>) -> Self {
+        PolicyResolver { resolver }
+    }
 
-    futures::future::join_all(futs)
-        .await
-        .into_iter()
-        .map(|(peer, result)| {
-            result.map(|sock_addr| Link {
-                link_id: peer.link_id.clone(),
-                role: LinkRole::Active, // only "active" support at the moment.
-                peer: SockAddr {
-                    addr: sock_addr.ip(),
-                    port: sock_addr.port(),
-                },
-            })
+    async fn resolve_topology(&self, policy: &Policy) -> Result<ResolvedTopology, ResolverError> {
+        let mut links_by_node: HashMap<IpAddr, Vec<Link>> = HashMap::new();
+        for node_addr in policy.all_peered_nodes() {
+            if let Some(peers) = policy.get_peers_for_node(&node_addr) {
+                let links = self.peers_to_links(peers).await?;
+                links_by_node.insert(node_addr, links);
+            }
+        }
+        Ok(ResolvedTopology {
+            vinst: policy.vinst(),
+            links_by_node,
         })
-        .collect()
+    }
+
+    /// Peers from policy may include hostnames. Here we run any hostnames through a
+    /// DNS lookup and create concrete `Link` objects with IP addresses. Returns an error
+    /// if any peer's address fails to resolve.
+    async fn peers_to_links(&self, peers: &[Peer]) -> Result<Vec<Link>, ResolverError> {
+        // Parallelize the DNS lookups then check for the first error.
+        let futs = peers.iter().map(|peer| async move {
+            (
+                peer,
+                resolve_netaddr(&peer.remote_substrate, self.resolver.as_ref()).await,
+            )
+        });
+
+        futures::future::join_all(futs)
+            .await
+            .into_iter()
+            .map(|(peer, result)| {
+                result.map(|sock_addr| Link {
+                    link_id: peer.link_id.clone(),
+                    role: LinkRole::Active, // only "active" support at the moment.
+                    peer: SockAddr {
+                        addr: sock_addr.ip(),
+                        port: sock_addr.port(),
+                    },
+                })
+            })
+            .collect()
+    }
 }
 
 /// If the passed `NetAddr` contains a hostname, perform a DNS lookup to resolve it to an IP address.
 /// Otherwise this quickly just returns a SocketAddr.
-async fn resolve_netaddr(naddr: &NetAddr) -> Result<SocketAddr, ResolverError> {
+async fn resolve_netaddr(
+    naddr: &NetAddr,
+    resolver: &dyn DnsResolver,
+) -> Result<SocketAddr, ResolverError> {
     match &naddr.host {
-        NetworkHost::Ip(ip_addr) => Ok(SocketAddr::new(ip_addr.clone(), naddr.port)),
-        NetworkHost::Hostname(hostname) => {
-            let mut addrs = tokio::net::lookup_host((hostname.as_str(), naddr.port)).await?;
-            addrs
-                .next()
-                .ok_or_else(|| ResolverError::NoAddresses(hostname.clone()))
-        }
+        NetworkHost::Ip(ip_addr) => Ok(SocketAddr::new(*ip_addr, naddr.port)),
+        NetworkHost::Hostname(hostname) => resolver.resolve(hostname, naddr.port).await,
     }
 }
 
@@ -268,6 +311,7 @@ mod tests {
     use zpr::write_to::WriteTo;
 
     use crate::db::{FakeDb, PolicyRepo};
+    use crate::test_helpers::FakeResolver;
 
     fn ip(s: &str) -> IpAddr {
         s.parse().unwrap()
@@ -300,7 +344,7 @@ mod tests {
     async fn make_policy_mgr(policy: Policy) -> PolicyMgr {
         let db = Arc::new(FakeDb::new());
         let repo = PolicyRepo::new(db);
-        PolicyMgr::new_with_initial_policy(policy, repo)
+        PolicyMgr::new_with_initial_policy(policy, repo, Arc::new(FakeResolver::ip_only()))
             .await
             .unwrap()
     }
@@ -452,7 +496,8 @@ mod tests {
     /// Empty peer slice produces an empty link list.
     #[tokio::test]
     async fn test_peers_to_links_empty() {
-        let links = peers_to_links(&[]).await.unwrap();
+        let presolver = PolicyResolver::new(Arc::new(FakeResolver::ip_only()));
+        let links = presolver.peers_to_links(&[]).await.unwrap();
         assert!(links.is_empty());
     }
 
@@ -461,8 +506,9 @@ mod tests {
     async fn test_peers_to_links_single_ip() {
         let ip: IpAddr = "192.0.2.1".parse().unwrap();
         let peer = ip_peer("link-a", ip, 4000);
+        let presolver = PolicyResolver::new(Arc::new(FakeResolver::ip_only()));
 
-        let links = peers_to_links(&[peer]).await.unwrap();
+        let links = presolver.peers_to_links(&[peer]).await.unwrap();
 
         assert_eq!(links.len(), 1);
         assert_eq!(links[0].link_id, "link-a");
@@ -477,8 +523,9 @@ mod tests {
         let ip_a: IpAddr = "192.0.2.1".parse().unwrap();
         let ip_b: IpAddr = "192.0.2.2".parse().unwrap();
         let peers = [ip_peer("link-a", ip_a, 4000), ip_peer("link-b", ip_b, 5000)];
+        let presolver = PolicyResolver::new(Arc::new(FakeResolver::ip_only()));
 
-        let links = peers_to_links(&peers).await.unwrap();
+        let links = presolver.peers_to_links(&peers).await.unwrap();
 
         assert_eq!(links.len(), 2);
         assert_eq!(links[0].link_id, "link-a");
@@ -488,6 +535,7 @@ mod tests {
     }
 
     /// A peer with an unresolvable hostname causes peers_to_links to return an error.
+    /// FakeResolver has no entries, so any hostname lookup returns NoAddresses.
     #[tokio::test]
     async fn test_peers_to_links_bad_hostname_errors() {
         let ip: IpAddr = "192.0.2.1".parse().unwrap();
@@ -496,13 +544,41 @@ mod tests {
             link_id: "link-bad".to_string(),
             remote_zpr_addr: "fd5a:5052::2".parse().unwrap(),
             remote_substrate: NetAddr {
-                host: NetworkHost::Hostname("this.hostname.does.not.exist.invalid".to_string()),
+                host: NetworkHost::Hostname("some.unresolvable.host".to_string()),
                 port: 4000,
             },
         };
+        let presolver = PolicyResolver::new(Arc::new(FakeResolver::ip_only()));
 
-        let result = peers_to_links(&[good, bad]).await;
+        let result = presolver.peers_to_links(&[good, bad]).await;
 
         assert!(result.is_err());
+    }
+
+    /// A hostname peer is resolved to the expected IP address via the FakeResolver.
+    #[tokio::test]
+    async fn test_peers_to_links_hostname_resolved() {
+        let resolved_ip: IpAddr = "192.0.2.99".parse().unwrap();
+        let peer = Peer {
+            link_id: "link-h".to_string(),
+            remote_zpr_addr: "fd5a:5052::10".parse().unwrap(),
+            remote_substrate: NetAddr {
+                host: NetworkHost::Hostname("peer.example.com".to_string()),
+                port: 5000,
+            },
+        };
+        let mut entries = HashMap::new();
+        entries.insert(
+            ("peer.example.com".to_string(), 5000),
+            SocketAddr::new(resolved_ip, 5000),
+        );
+        let presolver = PolicyResolver::new(Arc::new(FakeResolver::new(entries)));
+
+        let links = presolver.peers_to_links(&[peer]).await.unwrap();
+
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].link_id, "link-h");
+        assert_eq!(links[0].peer.addr, resolved_ip);
+        assert_eq!(links[0].peer.port, 5000);
     }
 }

--- a/vs/src/policy_mgr.rs
+++ b/vs/src/policy_mgr.rs
@@ -41,19 +41,19 @@ const LINK_COST_ATTR_KEY: &str = "link.zpr.cost";
 /// The default and the minimum.
 const DEFAULT_LINK_COST: u32 = 1;
 
+/// Combined policy and resolved topology — swapped atomically as a unit.
+struct PolicyState {
+    policy: Arc<Policy>,
+    links_by_node: HashMap<IpAddr, Vec<Link>>,
+}
+
 #[allow(dead_code)]
 pub struct PolicyMgr {
-    inner: ArcSwap<Policy>,
-    resolved_topology: ArcSwap<ResolvedTopology>,
+    state: ArcSwap<PolicyState>,
     repo: db::PolicyRepo,
     /// Serializes concurrent policy updates; reads remain lock-free via ArcSwap.
     update_lock: tokio::sync::Mutex<()>,
     resolver: PolicyResolver,
-}
-
-struct ResolvedTopology {
-    vinst: u64,
-    links_by_node: HashMap<IpAddr, Vec<Link>>,
 }
 
 #[derive(Debug, Clone)]
@@ -96,23 +96,29 @@ impl PolicyMgr {
 
         let presolver = PolicyResolver::new(resolver);
 
-        let resolved = presolver.resolve_topology(&policy).await?;
+        let links_by_node = presolver.resolve_topology(&policy).await?;
         let _db_updated = repo.set_current_policy(&policy, false).await?;
 
         debug!(target: MAIN, "policy manager initialized successfully");
         Ok(PolicyMgr {
-            inner: ArcSwap::from_pointee(policy),
-            resolved_topology: ArcSwap::from_pointee(resolved),
+            state: ArcSwap::from_pointee(PolicyState {
+                policy: Arc::new(policy),
+                links_by_node,
+            }),
             repo,
             update_lock: tokio::sync::Mutex::new(()),
             resolver: presolver,
         })
     }
 
-    /// Create a new policy manager, initializing it with the current policy in the database. If there is no
-    /// policy in the database, this will return an error.
+    /// Create a new policy manager, initializing it with the current policy in
+    /// the database. If there is no policy in the database, this will return an
+    /// error.  This will also run DNS on the policy so if there are any DNS
+    /// issues with the peer hostnames (or if DNS is required and is not
+    /// working) this will fail.
     ///
-    /// If the policy contains hostnames and DNS is not working, this returns an error.
+    /// If the policy contains hostnames and DNS is not working, this returns an
+    /// error.
     pub async fn new_from_state(
         repo: db::PolicyRepo,
         resolver: Arc<dyn DnsResolver>,
@@ -125,20 +131,16 @@ impl PolicyMgr {
 
         let presolver = PolicyResolver::new(resolver);
 
-        // TODO: dump the resolved stuff into state too.
-        let resolved = presolver.resolve_topology(&policy).await?;
+        let links_by_node = presolver.resolve_topology(&policy).await?;
         Ok(PolicyMgr {
-            inner: ArcSwap::from_pointee(policy),
-            resolved_topology: ArcSwap::from_pointee(resolved),
+            state: ArcSwap::from_pointee(PolicyState {
+                policy: Arc::new(policy),
+                links_by_node,
+            }),
             repo,
             update_lock: tokio::sync::Mutex::new(()),
             resolver: presolver,
         })
-    }
-
-    /// Callers should drop the policy as quickly as possible to avoid missing a policy update.
-    pub fn get_current(&self) -> Arc<Policy> {
-        self.inner.load_full()
     }
 
     /// Update the current policy.  The new policy will be assigned a new version instance number (vinst)
@@ -151,20 +153,38 @@ impl PolicyMgr {
         let _guard = self.update_lock.lock().await;
 
         let mut new_policy = new_policy;
-        new_policy.set_vinst(self.inner.load().vinst() + 1);
+        new_policy.set_vinst(self.state.load().policy.vinst() + 1);
 
-        let resolved = self.resolver.resolve_topology(&new_policy).await?;
+        let links_by_node = self.resolver.resolve_topology(&new_policy).await?;
 
-        self.resolved_topology.store(Arc::new(resolved));
-        self.inner.store(Arc::new(new_policy));
+        self.state.store(Arc::new(PolicyState {
+            policy: Arc::new(new_policy),
+            links_by_node,
+        }));
         Ok(())
     }
 
-    /// When policy is updated, all the peer tables have their DNS names resolved and cached
-    /// here along with the policy.
+    /// Callers should drop the policy as quickly as possible to avoid missing a policy update.
+    ///
+    /// Currently there is no way to get a consistent view of policy AND the node resolution cache.
+    /// If we find we need that we can add a snapshot mechanism.
+    pub fn get_current(&self) -> Arc<Policy> {
+        self.state.load().policy.clone()
+    }
+
+    /// When policy is updated, all the peer tables have their DNS names resolved and cached.
+    /// Use this to get the links specified by policy for a node.
+    ///
+    /// Currently there is no way to get a consistent view of policy AND the node resolution cache.
+    /// If we find we need that we can add a snapshot mechanism.
+    ///
     pub fn resolved_links_for_node(&self, node: &IpAddr) -> Vec<Link> {
-        let topo = self.resolved_topology.load_full();
-        topo.links_by_node.get(node).cloned().unwrap_or_default()
+        self.state
+            .load()
+            .links_by_node
+            .get(node)
+            .cloned()
+            .unwrap_or_default()
     }
 
     /// Consult policy to get a description of the link between `node_a` and `node_b`.
@@ -208,7 +228,10 @@ impl PolicyResolver {
         PolicyResolver { resolver }
     }
 
-    async fn resolve_topology(&self, policy: &Policy) -> Result<ResolvedTopology, ResolverError> {
+    async fn resolve_topology(
+        &self,
+        policy: &Policy,
+    ) -> Result<HashMap<IpAddr, Vec<Link>>, ResolverError> {
         let mut links_by_node: HashMap<IpAddr, Vec<Link>> = HashMap::new();
         for node_addr in policy.all_peered_nodes() {
             if let Some(peers) = policy.get_peers_for_node(&node_addr) {
@@ -216,10 +239,7 @@ impl PolicyResolver {
                 links_by_node.insert(node_addr, links);
             }
         }
-        Ok(ResolvedTopology {
-            vinst: policy.vinst(),
-            links_by_node,
-        })
+        Ok(links_by_node)
     }
 
     /// Peers from policy may include hostnames. Here we run any hostnames through a

--- a/vs/src/router.rs
+++ b/vs/src/router.rs
@@ -308,7 +308,8 @@ impl Router {
         inner.topo_generation += 1;
     }
 
-    /// Given a node address, return the connected peers.
+    /// Given a node address, return the connected peers,
+    /// or empty list if the node is not in the graph or has no peers.
     pub fn get_peers(&self, zpr_addr: &IpAddr) -> Vec<IpAddr> {
         let inner = self.inner.read().unwrap();
         let node_id: NodeId = zpr_addr.into();
@@ -790,6 +791,51 @@ mod tests {
             no_link_has: vec![],
             all_links_have: vec![],
         }
+    }
+
+    #[test]
+    fn test_get_peers_unknown_node_returns_empty() {
+        // Node not in the graph: get_peers returns empty vec rather than panicking.
+        let r = Router::new();
+        let unknown = ip("10.0.0.99");
+        assert!(r.get_peers(&unknown).is_empty());
+    }
+
+    #[test]
+    fn test_get_peers_no_links_returns_empty() {
+        // Node exists but has no links: get_peers returns empty vec.
+        let a = ip("10.0.0.1");
+        let r = Router::new();
+        r.add_node(a).unwrap();
+        assert!(r.get_peers(&a).is_empty());
+    }
+
+    #[test]
+    fn test_get_peers_single_link() {
+        // Node connected to one other node: get_peers returns exactly that peer.
+        let (r, a, b, _c) = make_router_abc();
+        r.add_link(a, b, LinkId("ab".into()), vec![], 1).unwrap();
+        let peers_a = r.get_peers(&a);
+        assert_eq!(peers_a, vec![b]);
+        // Symmetry: b also sees a as its peer.
+        let peers_b = r.get_peers(&b);
+        assert_eq!(peers_b, vec![a]);
+    }
+
+    #[test]
+    fn test_get_peers_multiple_links() {
+        // Node connected to two peers: get_peers returns both, regardless of order.
+        let (r, a, b, c) = make_router_abc();
+        r.add_link(a, b, LinkId("ab".into()), vec![], 1).unwrap();
+        r.add_link(a, c, LinkId("ac".into()), vec![], 1).unwrap();
+        let mut peers = r.get_peers(&a);
+        peers.sort();
+        let mut expected = vec![b, c];
+        expected.sort();
+        assert_eq!(peers, expected);
+        // b and c are not connected to each other.
+        assert_eq!(r.get_peers(&b), vec![a]);
+        assert_eq!(r.get_peers(&c), vec![a]);
     }
 
     #[test]

--- a/vs/src/test_helpers.rs
+++ b/vs/src/test_helpers.rs
@@ -2,11 +2,17 @@
 
 #![cfg(test)]
 
+use async_trait::async_trait;
 use libeval::actor::Actor;
 use libeval::attribute::{Attribute, ROLE_ADAPTER, ROLE_NODE, key};
+use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::time::Duration;
 use std::time::SystemTime;
 use zpr::vsapi_types::{DockPepType, EndpointT, KeySet, TcpUdpPep, Visa};
+
+use crate::error::ResolverError;
+use crate::policy_mgr::DnsResolver;
 
 const DEFAULT_EXPIRES: Duration = Duration::from_secs(3600);
 
@@ -105,6 +111,34 @@ pub fn make_actor_with_services_defexp(
     cn: &str,
 ) -> Actor {
     make_actor_with_services(role, zpr_addr, services, cn, DEFAULT_EXPIRES)
+}
+
+/// A DNS resolver for tests. IP-only peerings short-circuit before calling this,
+/// so an empty map suffices for tests that use only IP-addressed peers.
+/// Populate the map to test hostname-resolution paths.
+pub struct FakeResolver {
+    entries: HashMap<(String, u16), SocketAddr>,
+}
+
+impl FakeResolver {
+    pub fn new(entries: HashMap<(String, u16), SocketAddr>) -> Self {
+        FakeResolver { entries }
+    }
+
+    /// A resolver with no hostname entries — suitable for tests that only use IP peers.
+    pub fn ip_only() -> Self {
+        FakeResolver::new(HashMap::new())
+    }
+}
+
+#[async_trait]
+impl DnsResolver for FakeResolver {
+    async fn resolve(&self, host: &str, port: u16) -> Result<SocketAddr, ResolverError> {
+        self.entries
+            .get(&(host.to_string(), port))
+            .copied()
+            .ok_or_else(|| ResolverError::NoAddresses(host.to_string()))
+    }
 }
 
 /// Build a [Visa] with the provided ID and expiry offset.

--- a/vs/src/topology_mgr.rs
+++ b/vs/src/topology_mgr.rs
@@ -1,4 +1,5 @@
 //! Topology manager - maintains the graph of nodes and links, and provides pathfinding and route selection.
+//! Note that this topology as it exists. For toplogy as it is intended to be you need to look at policy.
 use std::net::IpAddr;
 use tracing::{error, warn};
 

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -62,7 +62,6 @@ impl VisaMgr {
         &self,
         mut visa: Visa,
         target_node: &IpAddr,
-        direction: Direction,
     ) -> Result<Visa, ServiceError> {
         let md = self.repo.get_visa_metadata_by_id(visa.issuer_id).await?;
 
@@ -74,24 +73,31 @@ impl VisaMgr {
             return Ok(visa);
         }
 
-        let vctx = if path.first().unwrap() == target_node {
-            match direction {
-                Direction::Forward => VCtx::Ingress,
-                Direction::Reverse => VCtx::Egress,
-            }
-        } else if path.last().unwrap() == target_node {
-            match direction {
-                Direction::Forward => VCtx::Egress,
-                Direction::Reverse => VCtx::Ingress,
-            }
-        } else {
-            VCtx::Intermediary
-        };
+        // Metadata includes the requesting node addr.
+        // If our `target_node` is first or last then we are in an ingress or egress context.
+        // If target_node is requesting_node then this is ingress, else this is egress.
+
+        let vctx =
+            if (path.first().unwrap() == target_node) || (path.last().unwrap() == target_node) {
+                if target_node == &md.requesting_node {
+                    VCtx::Ingress
+                } else {
+                    VCtx::Egress
+                }
+            } else {
+                VCtx::Intermediary
+            };
 
         match vctx {
             VCtx::Ingress => {
                 // We already know path is at least 2 so there is a forwarding instruction.
-                if let Some(next_hop) = next_hop_in_path(path, target_node, direction) {
+                // We are ingress so we are at one end of the path, so next hop is trivial.
+                let next_hop = if path.first().unwrap() == target_node {
+                    path.get(1)
+                } else {
+                    path.get(path.len() - 2)
+                };
+                if let Some(next_hop) = next_hop {
                     let fwd_pep = FwdPep {
                         next_hop: *next_hop,
                         style: FwdPepStyle::OneWay, // TODO: Not sure when to set this to symmetric.
@@ -99,7 +105,7 @@ impl VisaMgr {
                     visa.fwd_pep = Some(fwd_pep);
                     return Ok(visa);
                 } else {
-                    error!(target: VISA, "error actualizing visa for ingress node {target_node} on path is {path:?}: no next_hop found");
+                    error!(target: VISA, "error actualizing visa for ingress node {target_node} using context {vctx:?} on path {path:?}: no next_hop found");
                     return Err(ServiceError::Internal(format!("failed to actualize visa")));
                 }
             }
@@ -108,8 +114,13 @@ impl VisaMgr {
                 return Ok(visa);
             }
             VCtx::Intermediary => {
+                // We are an intermediate node, but are we going forward on the path or backwards?
+                //
+                // Given path [A, B, C, D] and and the fact that A requested the visa (and so is ingress) then,
+                // Node D is egress.  Node B needs to forward to C, and C to D.
+
                 // Build a forwardingOnly visa ...
-                match next_hop_in_path(path, target_node, direction) {
+                match next_hop_in_path(path, target_node, &md.requesting_node) {
                     Some(next_hop) => {
                         let fpep = FwdPep {
                             next_hop: *next_hop,
@@ -153,9 +164,7 @@ impl VisaMgr {
         if let Ok(pendings) = self.get_pending_visas_for_node(node_addr).await {
             for v in pendings {
                 let md = self.repo.get_visa_metadata_by_id(v.issuer_id).await?;
-                let av = self
-                    .actualize_visa_for_target_node(v, node_addr, md.direction)
-                    .await?;
+                let av = self.actualize_visa_for_target_node(v, node_addr).await?;
                 visas.push(av);
             }
         }
@@ -572,17 +581,19 @@ fn to_forwarding_visa(mut visa: Visa, fwd_pep: FwdPep) -> Visa {
 }
 
 /// Returns the adjacent node after `target_node` in `path`, stepping forward or backward
-/// according to `direction`. Returns None if `target_node` is not in the path or there is
-/// no neighbor in the requested direction.
+/// according to the specified ingress node.
+///
+/// `ingress_node` must be either the first or last node in the path.
 fn next_hop_in_path<'a>(
     path: &'a [IpAddr],
     target_node: &IpAddr,
-    direction: Direction,
+    ingress_node: &IpAddr,
 ) -> Option<&'a IpAddr> {
     let pos = path.iter().position(|n| n == target_node)?;
-    match direction {
-        Direction::Forward => path.get(pos + 1),
-        Direction::Reverse => pos.checked_sub(1).and_then(|i| path.get(i)),
+    if path.first()? == ingress_node {
+        path.get(pos + 1)
+    } else {
+        pos.checked_sub(1).and_then(|i| path.get(i))
     }
 }
 
@@ -605,6 +616,46 @@ mod tests {
     const NODE_ADDR: &str = "fd5a:5052::1";
     const SRC_ADDR: &str = "fd5a:5052::10";
     const DST_ADDR: &str = "fd5a:5052::20";
+
+    #[test]
+    fn test_next_hop_empty() {
+        let path = vec![];
+        let ingress = "fd5a:5052::1".parse().unwrap();
+        let target = "fd5a:5052::2".parse().unwrap();
+        assert_eq!(next_hop_in_path(&path, &target, &ingress), None);
+    }
+
+    #[test]
+    fn test_next_hop_two_elem() {
+        let n0 = "fd5a:5052::1".parse().unwrap();
+        let n1 = "fd5a:5052::2".parse().unwrap();
+        let path = vec![n0, n1];
+        assert_eq!(next_hop_in_path(&path, &n0, &n0), Some(&n1));
+        assert_eq!(next_hop_in_path(&path, &n1, &n0), None);
+        assert_eq!(next_hop_in_path(&path, &n1, &n1), Some(&n0));
+        assert_eq!(next_hop_in_path(&path, &n0, &n1), None);
+    }
+
+    #[test]
+    fn test_next_hop_three_elem() {
+        let n0 = "fd5a:5052::1".parse().unwrap();
+        let n1 = "fd5a:5052::2".parse().unwrap();
+        let n2 = "fd5a:5052::3".parse().unwrap();
+        let unknown = "fd5a:5052::4".parse().unwrap();
+        let path = vec![n0, n1, n2];
+        assert_eq!(next_hop_in_path(&path, &n0, &n0), Some(&n1));
+        assert_eq!(next_hop_in_path(&path, &n1, &n0), Some(&n2));
+        assert_eq!(next_hop_in_path(&path, &n2, &n0), None);
+
+        assert_eq!(next_hop_in_path(&path, &n0, &n2), None);
+        assert_eq!(next_hop_in_path(&path, &n1, &n2), Some(&n0));
+        assert_eq!(next_hop_in_path(&path, &n2, &n2), Some(&n1));
+
+        assert_eq!(next_hop_in_path(&path, &unknown, &n2), None);
+        assert_eq!(next_hop_in_path(&path, &n0, &unknown), None);
+
+        assert_eq!(next_hop_in_path(&path, &n0, &n1), None);
+    }
 
     #[tokio::test]
     async fn test_get_node_visa_by_five_tuple_found() {
@@ -770,6 +821,27 @@ mod tests {
         visa
     }
 
+    async fn store_test_visa_with_reqesting_node(
+        mgr: &VisaMgr,
+        id: u64,
+        path: Option<Vec<IpAddr>>,
+        requesting_node: IpAddr,
+    ) -> Visa {
+        let visa = make_visa(id, Duration::from_secs(60));
+        let metadata = db::VisaMetadata::new(
+            requesting_node,
+            0,
+            "zpl".to_string(),
+            Direction::Forward,
+            path,
+        );
+        mgr.repo
+            .store_visa(&visa, metadata, db::NodeVisaState::PendingInstall)
+            .await
+            .unwrap();
+        visa
+    }
+
     /// No path in metadata → visa returned unchanged with no fwd_pep.
     #[tokio::test]
     async fn test_actualize_no_path_returns_unchanged() {
@@ -778,7 +850,7 @@ mod tests {
         let visa = store_test_visa(&mgr, 1, None).await;
 
         let result = mgr
-            .actualize_visa_for_target_node(visa, &node_addr, Direction::Forward)
+            .actualize_visa_for_target_node(visa, &node_addr)
             .await
             .unwrap();
         assert_eq!(result.issuer_id, 1);
@@ -793,7 +865,7 @@ mod tests {
         let visa = store_test_visa(&mgr, 1, Some(vec![node_addr.clone()])).await;
 
         let result = mgr
-            .actualize_visa_for_target_node(visa, &node_addr, Direction::Forward)
+            .actualize_visa_for_target_node(visa, &node_addr)
             .await
             .unwrap();
         assert_eq!(result.issuer_id, 1);
@@ -809,7 +881,7 @@ mod tests {
         let visa = store_test_visa(&mgr, 1, Some(three_node_path())).await;
 
         let result = mgr
-            .actualize_visa_for_target_node(visa, &node_a, Direction::Forward)
+            .actualize_visa_for_target_node(visa, &node_a)
             .await
             .unwrap();
         let fwd_pep = result.fwd_pep.expect("expected fwd_pep on ingress visa");
@@ -825,7 +897,7 @@ mod tests {
         let visa = store_test_visa(&mgr, 1, Some(three_node_path())).await;
 
         let result = mgr
-            .actualize_visa_for_target_node(visa, &node_c, Direction::Forward)
+            .actualize_visa_for_target_node(visa, &node_c)
             .await
             .unwrap();
         assert!(result.fwd_pep.is_none());
@@ -838,10 +910,11 @@ mod tests {
         let mgr = make_mgr().await;
         let node_b: IpAddr = PATH_NODE_B.parse().unwrap();
         let node_c: IpAddr = PATH_NODE_C.parse().unwrap();
-        let visa = store_test_visa(&mgr, 1, Some(three_node_path())).await;
+        let visa =
+            store_test_visa_with_reqesting_node(&mgr, 1, Some(three_node_path()), node_c).await;
 
         let result = mgr
-            .actualize_visa_for_target_node(visa, &node_c, Direction::Reverse)
+            .actualize_visa_for_target_node(visa, &node_c)
             .await
             .unwrap();
         let fwd_pep = result
@@ -859,11 +932,14 @@ mod tests {
     #[tokio::test]
     async fn test_actualize_egress_reverse_returns_full_visa() {
         let mgr = make_mgr().await;
+        let requesting_node: IpAddr = PATH_NODE_C.parse().unwrap();
         let node_a: IpAddr = PATH_NODE_A.parse().unwrap();
-        let visa = store_test_visa(&mgr, 1, Some(three_node_path())).await;
+        let visa =
+            store_test_visa_with_reqesting_node(&mgr, 1, Some(three_node_path()), requesting_node)
+                .await;
 
         let result = mgr
-            .actualize_visa_for_target_node(visa, &node_a, Direction::Reverse)
+            .actualize_visa_for_target_node(visa, &node_a)
             .await
             .unwrap();
         assert!(result.fwd_pep.is_none());
@@ -884,7 +960,7 @@ mod tests {
         let visa = store_test_visa(&mgr, 1, Some(three_node_path())).await;
 
         let result = mgr
-            .actualize_visa_for_target_node(visa, &node_b, Direction::Forward)
+            .actualize_visa_for_target_node(visa, &node_b)
             .await
             .unwrap();
         assert_eq!(result.visa_type, VisaType::ForwardOnly);
@@ -906,7 +982,7 @@ mod tests {
         let visa = store_test_visa(&mgr, 1, Some(three_node_path())).await;
 
         let result = mgr
-            .actualize_visa_for_target_node(visa, &node_b, Direction::Forward)
+            .actualize_visa_for_target_node(visa, &node_b)
             .await
             .unwrap();
         assert_eq!(result.visa_type, VisaType::ForwardOnly);
@@ -1048,7 +1124,7 @@ mod tests {
         // dst is the ingress for reverse traffic; it must get fwd_pep pointing to mid.
         let actualized = asm
             .visa_mgr
-            .actualize_visa_for_target_node(visawmd.visa.clone(), &dst, Direction::Reverse)
+            .actualize_visa_for_target_node(visawmd.visa.clone(), &dst)
             .await
             .unwrap();
 
@@ -1086,7 +1162,7 @@ mod tests {
 
         let actualized = asm
             .visa_mgr
-            .actualize_visa_for_target_node(visawmd.visa.clone(), &src, Direction::Forward)
+            .actualize_visa_for_target_node(visawmd.visa.clone(), &src)
             .await
             .unwrap();
 

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -93,21 +93,16 @@ impl VisaMgr {
                 // We already know path is at least 2 so there is a forwarding instruction.
                 // We are ingress so we are at one end of the path, so next hop is trivial.
                 let next_hop = if path.first().unwrap() == target_node {
-                    path.get(1)
+                    path[1]
                 } else {
-                    path.get(path.len() - 2)
+                    path[path.len() - 2]
                 };
-                if let Some(next_hop) = next_hop {
-                    let fwd_pep = FwdPep {
-                        next_hop: *next_hop,
-                        style: FwdPepStyle::OneWay, // TODO: Not sure when to set this to symmetric.
-                    };
-                    visa.fwd_pep = Some(fwd_pep);
-                    return Ok(visa);
-                } else {
-                    error!(target: VISA, "error actualizing visa for ingress node {target_node} using context {vctx:?} on path {path:?}: no next_hop found");
-                    return Err(ServiceError::Internal(format!("failed to actualize visa")));
-                }
+                let fwd_pep = FwdPep {
+                    next_hop: next_hop,
+                    style: FwdPepStyle::OneWay, // TODO: Not sure when to set this to symmetric.
+                };
+                visa.fwd_pep = Some(fwd_pep);
+                return Ok(visa);
             }
             VCtx::Egress => {
                 // Just return the full visa.
@@ -583,12 +578,14 @@ fn to_forwarding_visa(mut visa: Visa, fwd_pep: FwdPep) -> Visa {
 /// Returns the adjacent node after `target_node` in `path`, stepping forward or backward
 /// according to the specified ingress node.
 ///
-/// `ingress_node` must be either the first or last node in the path.
+/// ### Panics
+/// - if `ingress_node` is not either the first or last node in the path.
 fn next_hop_in_path<'a>(
     path: &'a [IpAddr],
     target_node: &IpAddr,
     ingress_node: &IpAddr,
 ) -> Option<&'a IpAddr> {
+    assert!(path.first()? == ingress_node || path.last()? == ingress_node);
     let pos = path.iter().position(|n| n == target_node)?;
     if path.first()? == ingress_node {
         path.get(pos + 1)
@@ -626,6 +623,15 @@ mod tests {
     }
 
     #[test]
+    fn test_next_hop_one_elem() {
+        let n0 = "fd5a:5052::1".parse().unwrap();
+        let n1 = "fd5a:5052::2".parse().unwrap();
+        let path = vec![n0];
+        assert_eq!(next_hop_in_path(&path, &n0, &n0), None);
+        assert_eq!(next_hop_in_path(&path, &n1, &n0), None);
+    }
+
+    #[test]
     fn test_next_hop_two_elem() {
         let n0 = "fd5a:5052::1".parse().unwrap();
         let n1 = "fd5a:5052::2".parse().unwrap();
@@ -652,9 +658,6 @@ mod tests {
         assert_eq!(next_hop_in_path(&path, &n2, &n2), Some(&n1));
 
         assert_eq!(next_hop_in_path(&path, &unknown, &n2), None);
-        assert_eq!(next_hop_in_path(&path, &n0, &unknown), None);
-
-        assert_eq!(next_hop_in_path(&path, &n0, &n1), None);
     }
 
     #[tokio::test]

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -7,6 +7,7 @@ use tracing::{debug, error, warn};
 use crate::assembly::Assembly;
 use crate::config;
 use crate::db;
+use crate::db::VisaMetadata;
 use crate::error::{ServiceError, StoreError};
 use crate::logging::targets::VISA;
 use crate::packet::make_fivetuple_tcp;
@@ -36,6 +37,12 @@ enum VCtx {
     Ingress,
     Intermediary,
     Egress,
+}
+
+impl VisaWithMetadata {
+    pub fn new(visa: Visa, metadata: db::VisaMetadata) -> Self {
+        VisaWithMetadata { visa, metadata }
+    }
 }
 
 impl VisaMgr {
@@ -293,7 +300,7 @@ impl VisaMgr {
         route: &Route,
         source_zpl: impl Into<String>,
         policy_version: u64,
-    ) -> Result<Visa, ServiceError> {
+    ) -> Result<VisaWithMetadata, ServiceError> {
         let expiration_time = std::time::SystemTime::now()
             .checked_add(config::DEFAULT_VISA_EXPIRATION)
             .ok_or_else(|| {
@@ -397,11 +404,11 @@ impl VisaMgr {
 
         // The store also updates the visa state along the path.
         self.repo
-            .store_visa(&visa, metadata, db::NodeVisaState::PendingInstall)
+            .store_visa(&visa, metadata.clone(), db::NodeVisaState::PendingInstall)
             .await?;
 
         info!("created visa {visa_id}");
-        Ok(visa)
+        Ok(VisaWithMetadata::new(visa, metadata))
     }
 
     pub async fn get_pending_visas_for_node(
@@ -528,6 +535,19 @@ impl VisaMgr {
                 Err(StoreError::NotFound(_)) => Ok(None),
                 Err(e) => Err(ServiceError::from(e)),
             },
+            Err(StoreError::NotFound(_)) => Ok(None),
+            Err(e) => Err(ServiceError::from(e)),
+        }
+    }
+
+    /// Get just the visa metadata using the visa ID.
+    /// Returns None if not found.
+    pub async fn get_visa_metadata_by_id(
+        &self,
+        visa_id: u64,
+    ) -> Result<Option<VisaMetadata>, ServiceError> {
+        match self.repo.get_visa_metadata_by_id(visa_id).await {
+            Ok(md) => Ok(Some(md)),
             Err(StoreError::NotFound(_)) => Ok(None),
             Err(e) => Err(ServiceError::from(e)),
         }
@@ -945,7 +965,7 @@ mod tests {
         let hit = Hit::new_no_signal(0, Direction::Forward);
         let route = asm.topo_mgr.get_best_route(&src, &dst).unwrap(); // route between the nodes
 
-        let visa = asm
+        let visawmd = asm
             .visa_mgr
             .create_visa(&asm, &src, &pdesc, &hit, &route, "", 0)
             .await
@@ -954,7 +974,7 @@ mod tests {
         let metadata = asm
             .visa_mgr
             .repo
-            .get_visa_metadata_by_id(visa.issuer_id)
+            .get_visa_metadata_by_id(visawmd.visa.issuer_id)
             .await
             .unwrap();
         assert_eq!(metadata.path, Some(vec![src, mid, dst]));
@@ -973,13 +993,13 @@ mod tests {
         let hit = Hit::new_no_signal(0, Direction::Forward);
         let route = asm.topo_mgr.get_best_route(&src, &dst).unwrap();
 
-        let visa = asm
+        let visawmd = asm
             .visa_mgr
             .create_visa(&asm, &src, &pdesc, &hit, &route, "", 0)
             .await
             .unwrap();
 
-        let visa_id = visa.issuer_id;
+        let visa_id = visawmd.visa.issuer_id;
         let pending_src = asm.visa_mgr.get_pending_visas_for_node(&src).await.unwrap();
         let pending_mid = asm.visa_mgr.get_pending_visas_for_node(&mid).await.unwrap();
         let pending_dst = asm.visa_mgr.get_pending_visas_for_node(&dst).await.unwrap();
@@ -1019,7 +1039,7 @@ mod tests {
         let hit = Hit::new_no_signal(0, Direction::Reverse);
         let route = asm.topo_mgr.get_best_route(&dst, &src).unwrap();
 
-        let visa = asm
+        let visawmd = asm
             .visa_mgr
             .create_visa(&asm, &dst, &pdesc, &hit, &route, "", 0)
             .await
@@ -1028,7 +1048,7 @@ mod tests {
         // dst is the ingress for reverse traffic; it must get fwd_pep pointing to mid.
         let actualized = asm
             .visa_mgr
-            .actualize_visa_for_target_node(visa, &dst, Direction::Reverse)
+            .actualize_visa_for_target_node(visawmd.visa.clone(), &dst, Direction::Reverse)
             .await
             .unwrap();
 
@@ -1058,7 +1078,7 @@ mod tests {
         let hit = Hit::new_no_signal(0, Direction::Forward);
         let route = asm.topo_mgr.get_best_route(&src, &dst).unwrap();
 
-        let visa = asm
+        let visawmd = asm
             .visa_mgr
             .create_visa(&asm, &src, &pdesc, &hit, &route, "", 0)
             .await
@@ -1066,7 +1086,7 @@ mod tests {
 
         let actualized = asm
             .visa_mgr
-            .actualize_visa_for_target_node(visa, &src, Direction::Forward)
+            .actualize_visa_for_target_node(visawmd.visa.clone(), &src, Direction::Forward)
             .await
             .unwrap();
 

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -163,7 +163,6 @@ impl VisaMgr {
         // Start with any visas that may already be pending.
         if let Ok(pendings) = self.get_pending_visas_for_node(node_addr).await {
             for v in pendings {
-                let md = self.repo.get_visa_metadata_by_id(v.issuer_id).await?;
                 let av = self.actualize_visa_for_target_node(v, node_addr).await?;
                 visas.push(av);
             }
@@ -551,6 +550,7 @@ impl VisaMgr {
 
     /// Get just the visa metadata using the visa ID.
     /// Returns None if not found.
+    #[allow(dead_code)]
     pub async fn get_visa_metadata_by_id(
         &self,
         visa_id: u64,

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -24,12 +24,12 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use futures::StreamExt;
-use futures::future::FutureExt;
+use futures::future::{FutureExt, join_all};
 
 use libeval::actor::Actor;
 use libeval::attribute::{Attribute, ROLE_ADAPTER, key};
 use libeval::eval::EvalContext;
-use libeval::eval_result::{FinalDeny, FinalEvalResult, Hit, PartialEvalResult};
+use libeval::eval_result::{Direction, FinalDeny, FinalEvalResult, Hit, PartialEvalResult};
 use libeval::policy::Policy;
 use libeval::route::Route;
 
@@ -42,6 +42,7 @@ use crate::assembly::Assembly;
 use crate::counters::CounterType;
 use crate::error::ServiceError;
 use crate::logging::targets::VREQ;
+use crate::visa_mgr::VisaWithMetadata;
 use crate::{config, net_mgr};
 
 pub enum VisaDecision {
@@ -285,7 +286,7 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
             Ok(VisaDecision::Deny(DenyCode::NoMatch))
         }
         PartialEvalResult::AllowWithoutRoute(hits) => {
-            visa_from_allow(&asm, job, &hits, &policy, Some(default_route)).await
+            visa_from_allow(asm.clone(), job, &hits, &policy, Some(default_route)).await
         }
         PartialEvalResult::Deny(FinalDeny::Deny(_hits)) => {
             info!(target: VREQ,
@@ -303,7 +304,7 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
             match residual_evaluator.eval_routes(&routes, &asm.topo_mgr) {
                 // TODO: Note that when we get a match using routes, the route it returned in the hit.
                 Ok(FinalEvalResult::Allow(hits)) => {
-                    visa_from_allow(&asm, job, &hits, &policy, None).await
+                    visa_from_allow(asm.clone(), job, &hits, &policy, None).await
                 }
                 Ok(FinalEvalResult::Deny(_hits)) => {
                     info!(target: VREQ,
@@ -366,8 +367,10 @@ fn fabricate_aaa_actor(anon_addr: &IpAddr, expiration: SystemTime) -> Actor {
 ///
 /// `hits` - Positive hits from the evaluator. We choose the first one.
 /// `default_route` - A default route for the visa, only used if there is no route on the first hit.
+/// Creates and returns the visa for the requesting node, then spawns a background task to
+/// push actualized copies to any other nodes on the multihop path.
 async fn visa_from_allow(
-    asm: &Assembly,
+    asm: Arc<Assembly>,
     job: &VisaRequestJob,
     hits: &[Hit],
     policy: &Policy,
@@ -390,10 +393,10 @@ async fn visa_from_allow(
         })?,
     };
 
-    let visa = asm
+    let visawmd = asm
         .visa_mgr
         .create_visa(
-            asm,
+            &asm,
             &job.requesting_node,
             &job.packet_desc,
             &hits[0],
@@ -403,12 +406,93 @@ async fn visa_from_allow(
         )
         .await?;
 
+    // Clone the visa for the requesting node before moving visawmd into the background task.
+    let visa_for_requester = visawmd.visa.clone();
+    let req_node = job.requesting_node;
+    let direction = hits[0].direction;
+    let asm_bg = asm.clone();
+    tokio::spawn(async move {
+        distribute_visa_on_path(asm_bg, visawmd, req_node, direction).await;
+    });
+
     let visa = asm
         .visa_mgr
-        .actualize_visa_for_target_node(visa, &job.requesting_node, hits[0].direction)
+        .actualize_visa_for_target_node(visa_for_requester, &job.requesting_node, direction)
         .await?;
 
     Ok(VisaDecision::Allow(visa, allowed_route))
+}
+
+/// Pushes actualized copies of a visa to all non-requesting nodes on the path.
+/// Runs all pushes concurrently. Intended to be called as a background task after the
+/// requesting node has already received its visa.
+///
+/// Note that if these fail the visas should have already been marked as pending-install
+/// for the target nodes before calling this, so the vss worker will pick up on that
+/// during housekeeping.
+async fn distribute_visa_on_path(
+    asm: Arc<Assembly>,
+    visa_with_metadata: VisaWithMetadata,
+    requesting_node: IpAddr,
+    direction: Direction,
+) {
+    let issuer_id = visa_with_metadata.visa.issuer_id;
+
+    let Some(ref path) = visa_with_metadata.metadata.path else {
+        return;
+    };
+
+    // Build one future per non-requesting path node and drive them all concurrently.
+    // Each node has its own VssHandle (independent channel), so there is no contention.
+    let push_futures: Vec<_> = path
+        .iter()
+        .filter(|node_addr| **node_addr != requesting_node)
+        .map(|node_addr| {
+            let asm = asm.clone();
+            let onpath_visa = visa_with_metadata.visa.clone();
+            let node_addr = *node_addr;
+            async move {
+                match asm
+                    .visa_mgr
+                    .actualize_visa_for_target_node(onpath_visa, &node_addr, direction)
+                    .await
+                {
+                    Ok(onpath_visa) => {
+                        if let Some(vss_handle) = asm.vss_mgr.get_handle(&node_addr) {
+                            match vss_handle.push_visas(vec![onpath_visa]).await {
+                                Ok(1) => {
+                                    if let Err(e) =
+                                        asm.visa_mgr.visa_installed(issuer_id, &node_addr).await
+                                    {
+                                        warn!(target: VREQ,
+                                            "error marking visa {issuer_id} as installed for node {node_addr}: {e}"
+                                        );
+                                    }
+                                }
+                                Ok(_) => {
+                                    warn!(target: VREQ,
+                                        "failed to push visa {issuer_id} to node {node_addr}"
+                                    );
+                                }
+                                Err(e) => {
+                                    debug!(target: VREQ,
+                                        "error pushing visa {issuer_id} for node {node_addr} in VSS: {e}"
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    Err(_) => {
+                        warn!(target: VREQ,
+                            "error actualizing visa {issuer_id} for node {node_addr}"
+                        );
+                    }
+                }
+            }
+        })
+        .collect();
+
+    join_all(push_futures).await;
 }
 
 /// Resolves a pair of optional actors into concrete actors, handling the case where one is
@@ -641,7 +725,7 @@ mod tests {
     // Verifies that visa_from_allow issues a visa and returns Allow when given a valid hit and route.
     #[tokio::test]
     async fn visa_from_allow_issues_visa_on_allow() {
-        let asm = new_assembly_for_tests(None).await;
+        let asm = Arc::new(new_assembly_for_tests(None).await);
         let requesting_node: IpAddr = "fd5a:5052:3000::ff".parse().unwrap();
         let pkt_data =
             PacketDesc::new_tcp("fd5a:5052:3000::1", "fd5a:5052:3000::2", 12345, 80).unwrap();
@@ -651,7 +735,7 @@ mod tests {
         let policy = Policy::new_empty();
         let route = Route::new_direct(requesting_node.into());
 
-        let result = visa_from_allow(&asm, &job, &hits, &policy, Some(route)).await;
+        let result = visa_from_allow(asm, &job, &hits, &policy, Some(route)).await;
         assert!(matches!(result, Ok(VisaDecision::Allow(_, _))));
     }
 

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -409,7 +409,6 @@ async fn visa_from_allow(
     // Clone the visa for the requesting node before moving visawmd into the background task.
     let visa_for_requester = visawmd.visa.clone();
     let req_node = job.requesting_node;
-    let direction = hits[0].direction;
     let asm_bg = asm.clone();
     tokio::spawn(async move {
         distribute_visa_on_path(asm_bg, visawmd, req_node).await;
@@ -419,7 +418,6 @@ async fn visa_from_allow(
         .visa_mgr
         .actualize_visa_for_target_node(visa_for_requester, &job.requesting_node)
         .await?;
-
     Ok(VisaDecision::Allow(visa, allowed_route))
 }
 

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -29,7 +29,7 @@ use futures::future::{FutureExt, join_all};
 use libeval::actor::Actor;
 use libeval::attribute::{Attribute, ROLE_ADAPTER, key};
 use libeval::eval::EvalContext;
-use libeval::eval_result::{Direction, FinalDeny, FinalEvalResult, Hit, PartialEvalResult};
+use libeval::eval_result::{FinalDeny, FinalEvalResult, Hit, PartialEvalResult};
 use libeval::policy::Policy;
 use libeval::route::Route;
 
@@ -412,12 +412,12 @@ async fn visa_from_allow(
     let direction = hits[0].direction;
     let asm_bg = asm.clone();
     tokio::spawn(async move {
-        distribute_visa_on_path(asm_bg, visawmd, req_node, direction).await;
+        distribute_visa_on_path(asm_bg, visawmd, req_node).await;
     });
 
     let visa = asm
         .visa_mgr
-        .actualize_visa_for_target_node(visa_for_requester, &job.requesting_node, direction)
+        .actualize_visa_for_target_node(visa_for_requester, &job.requesting_node)
         .await?;
 
     Ok(VisaDecision::Allow(visa, allowed_route))
@@ -434,7 +434,6 @@ async fn distribute_visa_on_path(
     asm: Arc<Assembly>,
     visa_with_metadata: VisaWithMetadata,
     requesting_node: IpAddr,
-    direction: Direction,
 ) {
     let issuer_id = visa_with_metadata.visa.issuer_id;
 
@@ -454,7 +453,7 @@ async fn distribute_visa_on_path(
             async move {
                 match asm
                     .visa_mgr
-                    .actualize_visa_for_target_node(onpath_visa, &node_addr, direction)
+                    .actualize_visa_for_target_node(onpath_visa, &node_addr)
                     .await
                 {
                     Ok(onpath_visa) => {

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -828,6 +828,7 @@ mod tests {
         asm_inner
             .policy_mgr
             .update_policy(make_policy_with_auth_service("svc:auth"))
+            .await
             .unwrap();
 
         let asm = Arc::new(asm_inner);
@@ -890,6 +891,7 @@ mod tests {
         asm_inner
             .policy_mgr
             .update_policy(make_policy_with_auth_service("svc:auth"))
+            .await
             .unwrap();
 
         let asm = Arc::new(asm_inner);
@@ -963,6 +965,7 @@ mod tests {
 
         asm.policy_mgr
             .update_policy(make_policy_with_auth_service("svc:auth"))
+            .await
             .unwrap();
 
         Arc::new(asm)

--- a/vs/src/vsapi_worker.rs
+++ b/vs/src/vsapi_worker.rs
@@ -1349,7 +1349,6 @@ impl vsapi::v_s_handle::Server for VSHandleImpl {
                                 .actualize_visa_for_target_node(
                                     visa_with_metadata.visa,
                                     requestor_addr,
-                                    visa_with_metadata.metadata.direction,
                                 )
                                 .await
                             {

--- a/vs/src/vss.rs
+++ b/vs/src/vss.rs
@@ -1,0 +1,26 @@
+//! Shared VSS related types.
+
+use std::net::IpAddr;
+use tokio::sync::oneshot;
+
+use zpr::vsapi_types::{Param, ServiceDescriptor, Visa};
+
+use crate::error::VssSyncError;
+
+pub type VssPushResponse = Result<usize, VssSyncError>; // usize is number items pushed.
+pub type VssRevokeAuthResponse = Result<usize, VssSyncError>; // usize is number of items revoked.
+pub type VssSetServicesResponse = Result<(), VssSyncError>;
+pub type VssConfigureResponse = Result<(), VssSyncError>;
+
+// Each API call is expressed as a message using this enum.
+pub enum VssCmd {
+    Stop(),
+    PushVisas(Vec<Visa>, oneshot::Sender<VssPushResponse>),
+    RevokeVisasById(Vec<u64>, oneshot::Sender<VssPushResponse>),
+    RevokeAuthsByZprAddr(Vec<IpAddr>, oneshot::Sender<VssRevokeAuthResponse>),
+    SetServices(
+        Vec<ServiceDescriptor>,
+        oneshot::Sender<VssSetServicesResponse>,
+    ), // (version, services-descriptor-list, channel)
+    Configure(Vec<Param>, oneshot::Sender<VssConfigureResponse>),
+}

--- a/vs/src/vss.rs
+++ b/vs/src/vss.rs
@@ -13,6 +13,7 @@ pub type VssSetServicesResponse = Result<(), VssSyncError>;
 pub type VssConfigureResponse = Result<(), VssSyncError>;
 
 // Each API call is expressed as a message using this enum.
+#[allow(dead_code)]
 pub enum VssCmd {
     Stop(),
     PushVisas(Vec<Visa>, oneshot::Sender<VssPushResponse>),

--- a/vs/src/vss_mgr.rs
+++ b/vs/src/vss_mgr.rs
@@ -1,35 +1,19 @@
 use dashmap::DashMap;
-use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
-use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
-use rustls::{DigitallySignedStruct, SignatureScheme};
-use std::future::Future;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::runtime::Builder;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::task::LocalSet;
-use tokio_rustls::TlsConnector;
-use tokio_util::compat::*;
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, info};
 
-use zpr::vsapi::v1;
-use zpr::vsapi_types::{ApiResponseError, Param, ServiceDescriptor, Visa, pname};
-use zpr::write_to::WriteTo;
+use zpr::vsapi_types::{ServiceDescriptor, Visa};
 
 use crate::assembly::Assembly;
-use crate::config;
-use crate::counters::CounterType;
 use crate::error::VssSyncError;
 use crate::logging::targets::VSS;
-use crate::net_mgr;
-
-/// Minimum (and initial) timeout for a ping RPC call.
-const PING_MIN_TIMEOUT: Duration = Duration::from_secs(1);
-
-/// Default timeout for a single Cap'n Proto RPC call.
-const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(10);
+use crate::vss::VssCmd;
+use crate::vss_worker;
 
 pub struct VssMgr {
     // Each node has an entry here, handle is a thread monitoring the nodes VSS.
@@ -56,25 +40,6 @@ enum Job {
     },
 }
 
-type VssPushResponse = Result<usize, VssSyncError>; // usize is number items pushed.
-type VssRevokeAuthResponse = Result<usize, VssSyncError>; // usize is number of items revoked.
-type VssSetServicesResponse = Result<(), VssSyncError>;
-type VssConfigureResponse = Result<(), VssSyncError>;
-
-// Each API call is expressed as a message using this enum.
-#[allow(dead_code)]
-enum VssCmd {
-    Stop(),
-    PushVisas(Vec<Visa>, oneshot::Sender<VssPushResponse>),
-    RevokeVisasById(Vec<u64>, oneshot::Sender<VssPushResponse>),
-    RevokeAuthsByZprAddr(Vec<IpAddr>, oneshot::Sender<VssRevokeAuthResponse>),
-    SetServices(
-        Vec<ServiceDescriptor>,
-        oneshot::Sender<VssSetServicesResponse>,
-    ), // (version, services-descriptor-list, channel)
-    Configure(Vec<Param>, oneshot::Sender<VssConfigureResponse>),
-}
-
 /// The Vss Manager manages VSS connections for each node.
 impl VssMgr {
     pub fn new() -> Self {
@@ -99,7 +64,9 @@ impl VssMgr {
     }
 
     /// Start a task to manage the VSS connection to a node.  Waits for `delay` before starting.
-    /// Once this starts, the first thing it does is send the services list across.
+    /// Once this starts, the first thing it does is send the services list across and if there
+    /// is peer information from topology that is sent too.
+    ///
     /// It them will periodically ping the vss API.
     ///
     /// Error is returned if a worker is already running for the node. If that happens caller
@@ -260,361 +227,12 @@ async fn run_vss_job(job: Job) {
         } => {
             debug!(target: VSS, "starting VSS worker for node {} at {}", node_addr, vss_addr);
             tokio::time::sleep(delay).await;
-            vss_worker_loop(asm.clone(), vss_addr, cmd_rx).await;
+            vss_worker::vss_worker_loop(asm.clone(), vss_addr, cmd_rx).await;
             // When we exit the worker loop, we are done but the handle is still sitting in
             // the manager. So we clean it out here:
             asm.vss_mgr.clear_handle(&node_addr);
             info!(target: VSS, "VSS worker for node {} has exited", node_addr);
             // TODO: Do we need to track somewhere that we are no longer in communication with this node?
         }
-    }
-}
-
-// Run-loop for a thread that manages a VSS connection to a node.
-async fn vss_worker_loop(
-    asm: Arc<Assembly>,
-    node_addr: SocketAddr,
-    mut cmd_rx: mpsc::Receiver<VssCmd>,
-) {
-    // Open connect to VSS.
-    info!(target: VSS, "connecting to VSS at {}", node_addr);
-
-    let sock = match tokio::net::TcpStream::connect(node_addr).await {
-        Ok(sock) => sock,
-        Err(e) => {
-            error!(target: VSS, "failed to connect to VSS at {}: {}", node_addr, e);
-            asm.counters.incr(CounterType::VssErrors);
-            return; // TODO: How to signal manager?
-        }
-    };
-
-    let connector = tls_connect();
-    let tls = connector
-        .connect(node_addr.ip().into(), sock)
-        .await
-        .unwrap();
-    let (reader, writer) = tokio::io::split(tls);
-
-    let network = capnp_rpc::twoparty::VatNetwork::new(
-        tokio::io::BufReader::new(reader).compat(),
-        tokio::io::BufWriter::new(writer).compat_write(),
-        capnp_rpc::rpc_twoparty_capnp::Side::Client,
-        capnp::message::ReaderOptions::new(),
-    );
-
-    let mut rpc_system = capnp_rpc::RpcSystem::new(Box::new(network), None);
-
-    let vss_service: v1::visa_support_service::Client =
-        rpc_system.bootstrap(capnp_rpc::rpc_twoparty_capnp::Side::Server);
-
-    tokio::task::spawn_local(rpc_system);
-
-    let req = vss_service.connect_request();
-
-    let handle_result_rdr =
-        match rpc_with_timeout("connect", DEFAULT_RPC_TIMEOUT, req.send().promise).await {
-            Ok(req_resp) => req_resp,
-            Err(e) => {
-                error!(target: VSS, "VSS connect request failed: {}", e);
-                asm.counters.incr(CounterType::VssErrors);
-                return; // TODO: Signal manager?
-            }
-        };
-
-    let handle_result_ok_or_error = handle_result_rdr.get().unwrap().get_resp().unwrap();
-
-    let vss_handle: v1::v_s_s_handle::Client = match handle_result_ok_or_error.which().unwrap() {
-        v1::result::Which::Ok(vss_handle_obj) => vss_handle_obj.unwrap(),
-        v1::result::Which::Error(err_obj) => {
-            let err_obj = err_obj.unwrap();
-            error!(target: VSS, "VSS connect error: code={:?} msg={:?}", err_obj.get_code(), err_obj.get_message());
-            asm.counters.incr(CounterType::VssErrors);
-            return; // TODO: Signal manager?
-        }
-    };
-
-    info!(target: VSS, "now connected to VSS at {}", node_addr);
-
-    do_vss_initialization(&asm, &node_addr.ip(), &vss_handle).await;
-
-    let ping_timeout = tokio::time::sleep(config::VSS_PING_INTERVAL);
-    tokio::pin!(ping_timeout);
-    let mut ping_failures = 0;
-
-    loop {
-        tokio::select! {
-            cmd_opt = cmd_rx.recv() => {
-                match cmd_opt {
-                    Some(cmd) => match cmd {
-                        VssCmd::Stop() => {
-                            info!(target: VSS, "stop called on VSS worker for {}", node_addr);
-                            break;
-                        }
-                        VssCmd::PushVisas(_visas, resp_tx) => {
-                            if let Err(e) = resp_tx.send(Err(VssSyncError::Internal("push-visas not implemented".to_string()))) {
-                                error!(target: VSS, "failed to send response for push-visas command: {:?}", e);
-                                asm.counters.incr(CounterType::VssErrors);
-                            }
-                        }
-                        VssCmd::RevokeVisasById(_visa_id, resp_tx) => {
-                            if let Err(e) = resp_tx.send(Err(VssSyncError::Internal("revoke-visas not implemented".to_string()))) {
-                                error!(target: VSS, "failed to send response for revoke-visas command: {:?}", e);
-                                asm.counters.incr(CounterType::VssErrors);
-                            }
-                        }
-                        VssCmd::RevokeAuthsByZprAddr(_zpr_addr, resp_tx) => {
-                            if let Err(e) = resp_tx.send(Err(VssSyncError::Internal("revoke-auths not implemented".to_string()))) {
-                                error!(target: VSS, "failed to send response for revoke-auths command: {:?}", e);
-                                asm.counters.incr(CounterType::VssErrors);
-                            }
-                        }
-                        VssCmd::SetServices(services, resp_tx) => {
-                            if let Err(e) = resp_tx.send(do_set_services(&vss_handle, services).await) {
-                                error!(target: VSS, "failed to send response for set-services command: {:?}", e);
-                                asm.counters.incr(CounterType::VssErrors);
-                            }
-                        }
-                        VssCmd::Configure(params, resp_tx) => {
-                            if let Err(e) = resp_tx.send(do_configure(&vss_handle, params).await) {
-                                error!(target: VSS, "failed to send response for configure command: {:?}", e);
-                                asm.counters.incr(CounterType::VssErrors);
-                            }
-                        }
-                    }
-                    None => {
-                        // Uh oh - channel closed.
-                        warn!(target: VSS, "command channel closed for VSS worker for {}", node_addr);
-                        break;
-                    }
-                }
-            }
-
-            () = &mut ping_timeout => {
-                let ping_dur = PING_MIN_TIMEOUT + Duration::from_secs(ping_failures);
-                match rpc_with_timeout("ping", ping_dur, vss_handle.ping_request().send().promise).await {
-                    Ok(ping_response_rdr) => {
-                        match ping_response_rdr.get().unwrap().get_res().unwrap().which().unwrap() {
-                            v1::ok_or_error::Which::Ok(_) => {
-                                trace!(target: VSS, "ping to VSS at {} succeeded", node_addr);
-                                asm.actor_mgr.update_node_last_seen(&node_addr.ip()).await.ok(); // Ignore errors.
-                                ping_failures = 0;
-                            }
-                            v1::ok_or_error::Which::Error(err_rdr) => {
-                                let err_obj = err_rdr.unwrap();
-                                error!(target: VSS, "VSS ping returns error: code={:?} msg={:?}", err_obj.get_code(), err_obj.get_message());
-                                asm.counters.incr(CounterType::VssErrors);
-                                // TODO: What does this even mean? We got a reply but it is a coded error message? Should we just disconnect from node?
-                                ping_failures += 1;
-                            }
-                        }
-                    }
-                    Err(VssSyncError::Timeout(_)) => {
-                        warn!(target: VSS, "ping to VSS at {} timed out", node_addr);
-                        asm.counters.incr(CounterType::VssErrors);
-                        ping_failures += 1;
-                    }
-                    Err(_) => {
-                        warn!(target: VSS, "ping to VSS at {} failed", node_addr);
-                        asm.counters.incr(CounterType::VssErrors);
-                        ping_failures += 1;
-                    }
-                }
-                if ping_failures == 0 {
-                    ping_timeout.as_mut().reset(tokio::time::Instant::now() + config::VSS_PING_INTERVAL);
-                } else if ping_failures < config::VSS_MAX_PING_FAILURES as u64 {
-                    ping_timeout.as_mut().reset(tokio::time::Instant::now() + Duration::from_secs(1));
-                } else {
-                    error!(target: VSS, "too many VSS ping failures to {}, exiting VSS worker", node_addr);
-                    return;
-                }
-            }
-        }
-    }
-}
-
-/// When the vss worker starts up the node expects a couple of calls immediately.
-/// 1. to the configure endpoint to set the params (only AAA prefix for now).
-/// 2. to the setServices endpoing to tell node about the available auth services.
-async fn do_vss_initialization(
-    asm: &Arc<Assembly>,
-    node_addr: &IpAddr,
-    vss_handle: &v1::v_s_s_handle::Client,
-) {
-    // The AAA net is stored in the actor properties, but it is statically tied to
-    // the node ZPR address so we just recompute it here.
-    let aaa_net = net_mgr::aaa_network_for_node(node_addr);
-    let params = vec![Param::new_str(
-        pname::AAA_PREFIX.into(),
-        aaa_net.to_string(),
-    )];
-    debug!(target: VSS, "sending configure to VSS at {node_addr}");
-    match do_configure(vss_handle, params).await {
-        Ok(_) => {
-            debug!(target: VSS, "{node_addr} configured successfully");
-        }
-        Err(e) => {
-            warn!(target: VSS, "failed to configure VSS at {node_addr}: {e}");
-            asm.counters.incr(CounterType::VssErrors);
-        }
-    }
-
-    match asm.actor_mgr.get_auth_services_list(asm.clone()).await {
-        Ok(services) => {
-            debug!(target: VSS, "sending initial auth services list to VSS at {}", node_addr);
-            if let Err(e) = do_set_services(&vss_handle, services).await {
-                error!(target: VSS, "failed to send initial auth services list to VSS at {}: {}", node_addr, e);
-                asm.counters.incr(CounterType::VssErrors);
-            } else {
-                debug!(target: VSS, "initial auth services list sent to VSS at {}", node_addr);
-            }
-        }
-        Err(e) => {
-            warn!(target: VSS, "failed to get auth services list for VSS at {}: {}", node_addr, e);
-        }
-    }
-}
-
-#[derive(Debug)]
-struct NoVerification;
-
-// Implement the dangerous trait ServerCertVerifier NoVerification which will
-// just always approve the connection
-impl ServerCertVerifier for NoVerification {
-    fn verify_server_cert(
-        &self,
-        _: &CertificateDer<'_>,
-        _: &[CertificateDer<'_>],
-        _: &ServerName<'_>,
-        _: &[u8],
-        _: UnixTime,
-    ) -> Result<ServerCertVerified, rustls::Error> {
-        Ok(ServerCertVerified::assertion())
-    }
-
-    fn verify_tls12_signature(
-        &self,
-        _: &[u8],
-        _: &CertificateDer<'_>,
-        _: &DigitallySignedStruct,
-    ) -> Result<HandshakeSignatureValid, rustls::Error> {
-        Ok(HandshakeSignatureValid::assertion())
-    }
-
-    fn verify_tls13_signature(
-        &self,
-        _: &[u8],
-        _: &CertificateDer<'_>,
-        _: &DigitallySignedStruct,
-    ) -> Result<HandshakeSignatureValid, rustls::Error> {
-        Ok(HandshakeSignatureValid::assertion())
-    }
-
-    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        vec![
-            SignatureScheme::RSA_PKCS1_SHA1,
-            SignatureScheme::ECDSA_SHA1_Legacy,
-            SignatureScheme::RSA_PKCS1_SHA256,
-            SignatureScheme::ECDSA_NISTP256_SHA256,
-            SignatureScheme::RSA_PKCS1_SHA384,
-            SignatureScheme::ECDSA_NISTP384_SHA384,
-            SignatureScheme::RSA_PKCS1_SHA512,
-            SignatureScheme::ECDSA_NISTP521_SHA512,
-            SignatureScheme::RSA_PSS_SHA256,
-            SignatureScheme::RSA_PSS_SHA384,
-            SignatureScheme::RSA_PSS_SHA512,
-            SignatureScheme::ED25519,
-            SignatureScheme::ED448,
-            SignatureScheme::ML_DSA_44,
-            SignatureScheme::ML_DSA_65,
-            SignatureScheme::ML_DSA_87,
-        ]
-    }
-}
-
-// Create a dangerous connector - the verifier will always approve
-// TODO decide if we want to use an actual certificate
-fn tls_connect() -> TlsConnector {
-    let cfg = rustls::ClientConfig::builder()
-        .dangerous()
-        .with_custom_certificate_verifier(Arc::new(NoVerification))
-        .with_no_client_auth();
-
-    TlsConnector::from(Arc::new(cfg))
-}
-
-async fn do_set_services(
-    vss_handle: &v1::v_s_s_handle::Client,
-    services: Vec<ServiceDescriptor>,
-) -> Result<(), VssSyncError> {
-    let mut req = vss_handle.set_services_request();
-    let req_builder = req.get();
-
-    let mut svc_list_builder = req_builder.init_svcs(services.len() as u32);
-    for (i, svc) in services.iter().enumerate() {
-        let mut svc_builder = svc_list_builder.reborrow().get(i as u32);
-        svc.write_to(&mut svc_builder);
-    }
-
-    let set_response_rdr =
-        rpc_with_timeout("set-services", DEFAULT_RPC_TIMEOUT, req.send().promise).await?;
-
-    let set_response_ok_or_err = set_response_rdr.get()?;
-
-    match set_response_ok_or_err.get_res().unwrap().which().unwrap() {
-        v1::ok_or_error::Which::Ok(_) => (),
-        v1::ok_or_error::Which::Error(err_rdr) => {
-            let api_err = ApiResponseError::try_from(err_rdr.unwrap())?;
-            return Err(VssSyncError::from(api_err));
-        }
-    }
-
-    Ok(())
-}
-
-async fn do_configure(
-    vss_handle: &v1::v_s_s_handle::Client,
-    params: Vec<Param>,
-) -> Result<(), VssSyncError> {
-    let mut req = vss_handle.configure_request();
-    let req_builder = req.get();
-
-    let mut params_builder = req_builder.init_params(params.len() as u32);
-    for (i, param) in params.iter().enumerate() {
-        let mut param_builder = params_builder.reborrow().get(i as u32);
-        param.write_to(&mut param_builder);
-    }
-
-    let configure_response_rdr =
-        rpc_with_timeout("configure", DEFAULT_RPC_TIMEOUT, req.send().promise).await?;
-
-    let configure_response_ok_or_err = configure_response_rdr.get()?;
-
-    match configure_response_ok_or_err
-        .get_res()
-        .unwrap()
-        .which()
-        .unwrap()
-    {
-        v1::ok_or_error::Which::Ok(_) => Ok(()),
-        v1::ok_or_error::Which::Error(err_rdr) => {
-            let api_err = ApiResponseError::try_from(err_rdr.unwrap())?;
-            Err(VssSyncError::from(api_err))
-        }
-    }
-}
-
-/// Wrap a Cap'n Proto RPC future with a timeout, mapping errors.
-async fn rpc_with_timeout<F, T>(
-    name: &'static str,
-    duration: Duration,
-    fut: F,
-) -> Result<T, VssSyncError>
-where
-    F: Future<Output = Result<T, capnp::Error>>,
-{
-    match tokio::time::timeout(duration, fut).await {
-        Ok(Ok(result)) => Ok(result),
-        Ok(Err(capnp_err)) => Err(capnp_err.into()),
-        Err(_elapsed) => Err(VssSyncError::Timeout(name.to_string())),
     }
 }

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -547,3 +547,81 @@ async fn vss_do_set_topology(
     let set_response_ok_or_err = set_response_rdr.get()?;
     check_ok_or_error(set_response_ok_or_err.get_res().unwrap())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libeval::policy::Peer;
+    use std::net::IpAddr;
+    use zpr::policy_types::{NetAddr, NetworkHost};
+    use zpr::vsapi_types::LinkRole;
+
+    fn ip_peer(link_id: &str, ip: IpAddr, port: u16) -> Peer {
+        Peer {
+            link_id: link_id.to_string(),
+            remote_zpr_addr: "fd5a:5052::1".parse().unwrap(),
+            remote_substrate: NetAddr {
+                host: NetworkHost::Ip(ip),
+                port,
+            },
+        }
+    }
+
+    /// Empty peer slice produces an empty link list.
+    #[tokio::test]
+    async fn test_peers_to_links_empty() {
+        let links = peers_to_links(&[]).await;
+        assert!(links.is_empty());
+    }
+
+    /// A single IP peer maps to a single Link with the correct fields.
+    #[tokio::test]
+    async fn test_peers_to_links_single_ip() {
+        let ip: IpAddr = "192.0.2.1".parse().unwrap();
+        let peer = ip_peer("link-a", ip, 4000);
+
+        let links = peers_to_links(&[peer]).await;
+
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].link_id, "link-a");
+        assert_eq!(links[0].role, LinkRole::Active);
+        assert_eq!(links[0].peer.addr, ip);
+        assert_eq!(links[0].peer.port, 4000);
+    }
+
+    /// Multiple IP peers produce one Link each, in the same order.
+    #[tokio::test]
+    async fn test_peers_to_links_multiple_ips() {
+        let ip_a: IpAddr = "192.0.2.1".parse().unwrap();
+        let ip_b: IpAddr = "192.0.2.2".parse().unwrap();
+        let peers = [ip_peer("link-a", ip_a, 4000), ip_peer("link-b", ip_b, 5000)];
+
+        let links = peers_to_links(&peers).await;
+
+        assert_eq!(links.len(), 2);
+        assert_eq!(links[0].link_id, "link-a");
+        assert_eq!(links[0].peer.addr, ip_a);
+        assert_eq!(links[1].link_id, "link-b");
+        assert_eq!(links[1].peer.addr, ip_b);
+    }
+
+    /// A peer with an unresolvable hostname is silently dropped; valid IP peers survive.
+    #[tokio::test]
+    async fn test_peers_to_links_bad_hostname_skipped() {
+        let ip: IpAddr = "192.0.2.1".parse().unwrap();
+        let good = ip_peer("link-good", ip, 4000);
+        let bad = Peer {
+            link_id: "link-bad".to_string(),
+            remote_zpr_addr: "fd5a:5052::2".parse().unwrap(),
+            remote_substrate: NetAddr {
+                host: NetworkHost::Hostname("this.hostname.does.not.exist.invalid".to_string()),
+                port: 4000,
+            },
+        };
+
+        let links = peers_to_links(&[good, bad]).await;
+
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].link_id, "link-good");
+    }
+}

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -103,7 +103,9 @@ impl Default for AgedState {
     }
 }
 
-// Run-loop for a thread that manages a VSS connection to a node.
+/// Run-loop for a thread that manages a VSS connection to a node.
+///
+/// `node_addr` is the nodes ZPR address and the socket that its VSS is listening on.
 pub async fn vss_worker_loop(
     asm: Arc<Assembly>,
     node_addr: SocketAddr,

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -43,24 +43,34 @@ struct VssState {
 }
 
 impl VssState {
+    /// Indicates that the initial configuration call was performed.
     fn mark_configured(&mut self) {
         self.last_configure = Some(Instant::now());
     }
+
     fn needs_set_services(&self) -> bool {
         self.services_state.needs_sync()
     }
+
     fn mark_services_updated(&mut self) {
         self.services_state.last_update = Instant::now();
     }
-    fn needs_set_topology(&self) -> bool {
-        self.topology_state.needs_sync()
-    }
-    fn mark_topology_updated(&mut self) {
-        self.topology_state.last_update = Instant::now();
-    }
+
+    /// Indicates we have sent the services list across.
     fn mark_services_syncd(&mut self) {
         self.services_state.mark_syncd();
     }
+
+    fn needs_set_topology(&self) -> bool {
+        self.topology_state.needs_sync()
+    }
+
+    /// If topology effecting this node has been updated, indicate that here.
+    fn mark_topology_updated(&mut self) {
+        self.topology_state.last_update = Instant::now();
+    }
+
+    /// Indicates we have sent the topology information across.
     fn mark_topology_syncd(&mut self) {
         self.topology_state.mark_syncd();
     }
@@ -147,13 +157,14 @@ pub async fn vss_worker_loop(
                             }
                         }
                         VssCmd::SetServices(services, resp_tx) => {
-                            if let Err(e) = resp_tx.send(do_set_services(&vss_handle, services).await) {
+                            state.mark_services_updated();
+                            if let Err(e) = resp_tx.send(vss_do_set_services(&vss_handle, services).await) {
                                 error!(target: VSS, "failed to send response for set-services command: {:?}", e);
                                 asm.counters.incr(CounterType::VssErrors);
                             }
                         }
                         VssCmd::Configure(params, resp_tx) => {
-                            if let Err(e) = resp_tx.send(do_configure(&vss_handle, params).await) {
+                            if let Err(e) = resp_tx.send(vss_do_configure(&vss_handle, params).await) {
                                 error!(target: VSS, "failed to send response for configure command: {:?}", e);
                                 asm.counters.incr(CounterType::VssErrors);
                             }
@@ -289,10 +300,10 @@ async fn send_configure(
         aaa_net.to_string(),
     )];
     debug!(target: VSS, "sending configure to VSS at {node_addr}");
-    match do_configure(vss_handle, params).await {
+    match vss_do_configure(vss_handle, params).await {
         Ok(_) => {
             debug!(target: VSS, "{node_addr} configured successfully");
-            state.last_configure = Some(Instant::now());
+            state.mark_configured();
         }
         Err(e) => {
             warn!(target: VSS, "failed to configure VSS at {node_addr}: {e}");
@@ -310,7 +321,7 @@ async fn send_services(
     match asm.actor_mgr.get_auth_services_list(asm.clone()).await {
         Ok(services) => {
             debug!(target: VSS, "sending initial auth services list to VSS at {}", node_addr);
-            if let Err(e) = do_set_services(&vss_handle, services).await {
+            if let Err(e) = vss_do_set_services(&vss_handle, services).await {
                 error!(target: VSS, "failed to send initial auth services list to VSS at {}: {}", node_addr, e);
                 asm.counters.incr(CounterType::VssErrors);
             } else {
@@ -336,7 +347,7 @@ async fn send_topology(
     drop(cpol);
 
     debug!(target: VSS, "sending initial topology to VSS at {}", node_addr);
-    if let Err(e) = do_set_topology(vss_handle, &links).await {
+    if let Err(e) = vss_do_set_topology(vss_handle, &links).await {
         error!(target: VSS, "failed to send initial topology to VSS at {}: {}", node_addr, e);
         asm.counters.incr(CounterType::VssErrors);
     } else {
@@ -345,90 +356,37 @@ async fn send_topology(
     }
 }
 
-async fn do_set_services(
-    vss_handle: &v1::v_s_s_handle::Client,
-    services: Vec<ServiceDescriptor>,
-) -> Result<(), VssSyncError> {
-    let mut req = vss_handle.set_services_request();
-    let req_builder = req.get();
-    let mut svc_list_builder = req_builder.init_svcs(services.len() as u32);
-    for (i, svc) in services.iter().enumerate() {
-        let mut svc_builder = svc_list_builder.reborrow().get(i as u32);
-        svc.write_to(&mut svc_builder);
-    }
-    let set_response_rdr =
-        rpc_with_timeout("set-services", DEFAULT_RPC_TIMEOUT, req.send().promise).await?;
-    let set_response_ok_or_err = set_response_rdr.get()?;
-    check_ok_or_error(set_response_ok_or_err.get_res().unwrap())
-}
-
-async fn do_configure(
-    vss_handle: &v1::v_s_s_handle::Client,
-    params: Vec<Param>,
-) -> Result<(), VssSyncError> {
-    let mut req = vss_handle.configure_request();
-    let req_builder = req.get();
-    let mut params_builder = req_builder.init_params(params.len() as u32);
-    for (i, param) in params.iter().enumerate() {
-        let mut param_builder = params_builder.reborrow().get(i as u32);
-        param.write_to(&mut param_builder);
-    }
-    let configure_response_rdr =
-        rpc_with_timeout("configure", DEFAULT_RPC_TIMEOUT, req.send().promise).await?;
-    let configure_response_ok_or_err = configure_response_rdr.get()?;
-    check_ok_or_error(configure_response_ok_or_err.get_res().unwrap())
-}
-
-/// Pass an empty slice to indicate no peers.
-///
-async fn do_set_topology(
-    vss_handle: &v1::v_s_s_handle::Client,
-    peers: &[Link],
-) -> Result<(), VssSyncError> {
-    let mut req = vss_handle.set_topology_request();
-    let req_builder = req.get();
-    let mut peer_list_builder = req_builder.init_links(peers.len() as u32);
-
-    for (i, peer) in peers.iter().enumerate() {
-        let mut peer_builder = peer_list_builder.reborrow().get(i as u32);
-        peer.write_to(&mut peer_builder);
-    }
-    let set_response_rdr =
-        rpc_with_timeout("set-topology", DEFAULT_RPC_TIMEOUT, req.send().promise).await?;
-    let set_response_ok_or_err = set_response_rdr.get()?;
-    check_ok_or_error(set_response_ok_or_err.get_res().unwrap())
-}
-
 /// Peers from policy may include hostnames. Here we run any hostnames through a
 /// DNS lookup and create concrete `Link` objects with IP addresses. If any hostname fails
 /// to resolve we just skip that peer and log an error.
 async fn peers_to_links(peers: &[Peer]) -> Vec<Link> {
-    let mut links = Vec::new();
+    // Attempt to parallelize the DNS lookups.
+    let futs = peers
+        .iter()
+        .map(|peer| async move { (peer, resolve_netaddr(&peer.remote_substrate).await) });
 
-    for peer in peers {
-        match resolve_netaddr(&peer.remote_substrate).await {
-            Ok(sock_addr) => {
-                let sa: SockAddr = SockAddr {
+    futures::future::join_all(futs)
+        .await
+        .into_iter()
+        .filter_map(|(peer, result)| match result {
+            Ok(sock_addr) => Some(Link {
+                link_id: peer.link_id.clone(),
+                role: LinkRole::Active, // only "active" support at the moment.
+                peer: SockAddr {
                     addr: sock_addr.ip(),
                     port: sock_addr.port(),
-                };
-                let link = Link {
-                    link_id: peer.link_id.clone(),
-                    role: LinkRole::Active, // only "active" support at the moment.
-                    peer: sa,
-                };
-                links.push(link);
-            }
+                },
+            }),
             Err(e) => {
                 error!(target: VSS, "failed to resolve address for peer {}: {}, skipping peer in topology", peer.link_id, e);
-                continue;
+                None
             }
-        }
-    }
-
-    links
+        })
+        .collect()
 }
 
+/// If the passed `NetAddr` contains a hostname, perform a DNS lookup to resolve it to an IP address.
+/// Otherwise this quickly just returns a SocketAddr.
 async fn resolve_netaddr(naddr: &NetAddr) -> Result<SocketAddr, ResolverError> {
     match &naddr.host {
         NetworkHost::Ip(ip_addr) => Ok(SocketAddr::new(ip_addr.clone(), naddr.port)),
@@ -534,4 +492,58 @@ fn check_ok_or_error(r: v1::ok_or_error::Reader<'_>) -> Result<(), VssSyncError>
             Err(VssSyncError::from(api_err))
         }
     }
+}
+
+async fn vss_do_set_services(
+    vss_handle: &v1::v_s_s_handle::Client,
+    services: Vec<ServiceDescriptor>,
+) -> Result<(), VssSyncError> {
+    let mut req = vss_handle.set_services_request();
+    let req_builder = req.get();
+    let mut svc_list_builder = req_builder.init_svcs(services.len() as u32);
+    for (i, svc) in services.iter().enumerate() {
+        let mut svc_builder = svc_list_builder.reborrow().get(i as u32);
+        svc.write_to(&mut svc_builder);
+    }
+    let set_response_rdr =
+        rpc_with_timeout("set-services", DEFAULT_RPC_TIMEOUT, req.send().promise).await?;
+    let set_response_ok_or_err = set_response_rdr.get()?;
+    check_ok_or_error(set_response_ok_or_err.get_res().unwrap())
+}
+
+async fn vss_do_configure(
+    vss_handle: &v1::v_s_s_handle::Client,
+    params: Vec<Param>,
+) -> Result<(), VssSyncError> {
+    let mut req = vss_handle.configure_request();
+    let req_builder = req.get();
+    let mut params_builder = req_builder.init_params(params.len() as u32);
+    for (i, param) in params.iter().enumerate() {
+        let mut param_builder = params_builder.reborrow().get(i as u32);
+        param.write_to(&mut param_builder);
+    }
+    let configure_response_rdr =
+        rpc_with_timeout("configure", DEFAULT_RPC_TIMEOUT, req.send().promise).await?;
+    let configure_response_ok_or_err = configure_response_rdr.get()?;
+    check_ok_or_error(configure_response_ok_or_err.get_res().unwrap())
+}
+
+/// Pass an empty slice to indicate no peers.
+///
+async fn vss_do_set_topology(
+    vss_handle: &v1::v_s_s_handle::Client,
+    peers: &[Link],
+) -> Result<(), VssSyncError> {
+    let mut req = vss_handle.set_topology_request();
+    let req_builder = req.get();
+    let mut peer_list_builder = req_builder.init_links(peers.len() as u32);
+
+    for (i, peer) in peers.iter().enumerate() {
+        let mut peer_builder = peer_list_builder.reborrow().get(i as u32);
+        peer.write_to(&mut peer_builder);
+    }
+    let set_response_rdr =
+        rpc_with_timeout("set-topology", DEFAULT_RPC_TIMEOUT, req.send().promise).await?;
+    let set_response_ok_or_err = set_response_rdr.get()?;
+    check_ok_or_error(set_response_ok_or_err.get_res().unwrap())
 }

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -35,50 +35,59 @@ const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(10);
 /// Minimum (and initial) timeout for a ping RPC call.
 const PING_MIN_TIMEOUT: Duration = Duration::from_secs(1);
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct VssState {
     last_configure: Option<Instant>,
-    last_set_services: Option<Instant>,
-    last_set_topology: Option<Instant>,
-    last_services_update: Instant,
-    last_topology_update: Instant,
+    services_state: AgedState,
+    topology_state: AgedState,
 }
 
 impl VssState {
-    fn default() -> Self {
-        VssState {
-            last_configure: None,
-            last_set_services: None,
-            last_set_topology: None,
-            last_services_update: Instant::now(),
-            last_topology_update: Instant::now(),
-        }
+    fn mark_configured(&mut self) {
+        self.last_configure = Some(Instant::now());
     }
-
     fn needs_set_services(&self) -> bool {
-        self.last_set_services.is_none()
-            || self.last_services_update > self.last_set_services.unwrap()
+        self.services_state.needs_sync()
     }
-
+    fn mark_services_updated(&mut self) {
+        self.services_state.last_update = Instant::now();
+    }
     fn needs_set_topology(&self) -> bool {
-        self.last_set_topology.is_none()
-            || self.last_topology_update > self.last_set_topology.unwrap()
+        self.topology_state.needs_sync()
+    }
+    fn mark_topology_updated(&mut self) {
+        self.topology_state.last_update = Instant::now();
+    }
+    fn mark_services_syncd(&mut self) {
+        self.services_state.mark_syncd();
+    }
+    fn mark_topology_syncd(&mut self) {
+        self.topology_state.mark_syncd();
     }
 }
 
-/// Wrap a Cap'n Proto RPC future with a timeout, mapping errors.
-async fn rpc_with_timeout<F, T>(
-    name: &'static str,
-    duration: Duration,
-    fut: F,
-) -> Result<T, VssSyncError>
-where
-    F: Future<Output = Result<T, capnp::Error>>,
-{
-    match tokio::time::timeout(duration, fut).await {
-        Ok(Ok(result)) => Ok(result),
-        Ok(Err(capnp_err)) => Err(capnp_err.into()),
-        Err(_elapsed) => Err(VssSyncError::Timeout(name.to_string())),
+#[derive(Debug)]
+struct AgedState {
+    last_update: Instant,
+    last_sync: Instant,
+}
+
+impl AgedState {
+    fn needs_sync(&self) -> bool {
+        self.last_sync < self.last_update
+    }
+
+    fn mark_syncd(&mut self) {
+        self.last_sync = Instant::now();
+    }
+}
+
+impl Default for AgedState {
+    fn default() -> Self {
+        Self {
+            last_update: Instant::now(),
+            last_sync: Instant::now(),
+        }
     }
 }
 
@@ -148,8 +157,7 @@ pub async fn vss_worker_loop(
     };
 
     info!(target: VSS, "now connected to VSS at {}", node_addr);
-
-    do_vss_initialization(&mut state, &asm, &node_addr.ip(), &vss_handle).await;
+    do_housekeeping(&mut state, &asm, &node_addr.ip(), &vss_handle).await;
 
     let ping_timeout = tokio::time::sleep(config::VSS_PING_INTERVAL);
     tokio::pin!(ping_timeout);
@@ -271,26 +279,6 @@ async fn do_housekeeping(
     // TODO: Check for pending visas and revocations. And if found, send them.
 }
 
-/// When the vss worker starts up the node expects a couple of calls immediately.
-///
-/// 1. `configure()` to set the params (only AAA prefix for now).
-/// 2. `setServices()` to tell node about the available auth services.
-///
-/// And, if the node is supposed to have peers, we call:
-///
-/// 3. `setTopology()` to tell node about its links.
-///
-async fn do_vss_initialization(
-    state: &mut VssState,
-    asm: &Arc<Assembly>,
-    node_addr: &IpAddr,
-    vss_handle: &v1::v_s_s_handle::Client,
-) {
-    send_configure(state, asm, node_addr, vss_handle).await;
-    send_services(state, asm, node_addr, vss_handle).await;
-    send_topology(state, asm, node_addr, vss_handle).await;
-}
-
 async fn send_configure(
     state: &mut VssState,
     asm: &Arc<Assembly>,
@@ -331,7 +319,7 @@ async fn send_services(
                 asm.counters.incr(CounterType::VssErrors);
             } else {
                 debug!(target: VSS, "initial auth services list sent to VSS at {}", node_addr);
-                state.last_set_services = Some(Instant::now());
+                state.mark_services_syncd();
             }
         }
         Err(e) => {
@@ -357,7 +345,7 @@ async fn send_topology(
         asm.counters.incr(CounterType::VssErrors);
     } else {
         debug!(target: VSS, "initial topology sent to VSS at {}", node_addr);
-        state.last_set_topology = Some(Instant::now());
+        state.mark_topology_syncd();
     }
 }
 
@@ -367,27 +355,15 @@ async fn do_set_services(
 ) -> Result<(), VssSyncError> {
     let mut req = vss_handle.set_services_request();
     let req_builder = req.get();
-
     let mut svc_list_builder = req_builder.init_svcs(services.len() as u32);
     for (i, svc) in services.iter().enumerate() {
         let mut svc_builder = svc_list_builder.reborrow().get(i as u32);
         svc.write_to(&mut svc_builder);
     }
-
     let set_response_rdr =
         rpc_with_timeout("set-services", DEFAULT_RPC_TIMEOUT, req.send().promise).await?;
-
     let set_response_ok_or_err = set_response_rdr.get()?;
-
-    match set_response_ok_or_err.get_res().unwrap().which().unwrap() {
-        v1::ok_or_error::Which::Ok(_) => (),
-        v1::ok_or_error::Which::Error(err_rdr) => {
-            let api_err = ApiResponseError::try_from(err_rdr.unwrap())?;
-            return Err(VssSyncError::from(api_err));
-        }
-    }
-
-    Ok(())
+    check_ok_or_error(set_response_ok_or_err.get_res().unwrap())
 }
 
 async fn do_configure(
@@ -396,30 +372,15 @@ async fn do_configure(
 ) -> Result<(), VssSyncError> {
     let mut req = vss_handle.configure_request();
     let req_builder = req.get();
-
     let mut params_builder = req_builder.init_params(params.len() as u32);
     for (i, param) in params.iter().enumerate() {
         let mut param_builder = params_builder.reborrow().get(i as u32);
         param.write_to(&mut param_builder);
     }
-
     let configure_response_rdr =
         rpc_with_timeout("configure", DEFAULT_RPC_TIMEOUT, req.send().promise).await?;
-
     let configure_response_ok_or_err = configure_response_rdr.get()?;
-
-    match configure_response_ok_or_err
-        .get_res()
-        .unwrap()
-        .which()
-        .unwrap()
-    {
-        v1::ok_or_error::Which::Ok(_) => Ok(()),
-        v1::ok_or_error::Which::Error(err_rdr) => {
-            let api_err = ApiResponseError::try_from(err_rdr.unwrap())?;
-            Err(VssSyncError::from(api_err))
-        }
-    }
+    check_ok_or_error(configure_response_ok_or_err.get_res().unwrap())
 }
 
 /// Pass an empty slice to indicate no peers.
@@ -436,19 +397,10 @@ async fn do_set_topology(
         let mut peer_builder = peer_list_builder.reborrow().get(i as u32);
         peer.write_to(&mut peer_builder);
     }
-
     let set_response_rdr =
         rpc_with_timeout("set-topology", DEFAULT_RPC_TIMEOUT, req.send().promise).await?;
-
     let set_response_ok_or_err = set_response_rdr.get()?;
-
-    match set_response_ok_or_err.get_res().unwrap().which().unwrap() {
-        v1::ok_or_error::Which::Ok(_) => Ok(()),
-        v1::ok_or_error::Which::Error(err_rdr) => {
-            let api_err = ApiResponseError::try_from(err_rdr.unwrap())?;
-            Err(VssSyncError::from(api_err))
-        }
-    }
+    check_ok_or_error(set_response_ok_or_err.get_res().unwrap())
 }
 
 /// Peers from policy may include hostnames. Here we run any hostnames through a
@@ -464,7 +416,6 @@ async fn peers_to_links(peers: &[Peer]) -> Vec<Link> {
                     addr: sock_addr.ip(),
                     port: sock_addr.port(),
                 };
-                //resolved.insert(&peer.link_id, sa);
                 let link = Link {
                     link_id: peer.link_id.clone(),
                     role: LinkRole::Active, // only "active" support at the moment.
@@ -560,4 +511,31 @@ fn tls_connect() -> TlsConnector {
         .with_no_client_auth();
 
     TlsConnector::from(Arc::new(cfg))
+}
+
+/// Wrap a Cap'n Proto RPC future with a timeout, mapping errors.
+async fn rpc_with_timeout<F, T>(
+    name: &'static str,
+    duration: Duration,
+    fut: F,
+) -> Result<T, VssSyncError>
+where
+    F: Future<Output = Result<T, capnp::Error>>,
+{
+    match tokio::time::timeout(duration, fut).await {
+        Ok(Ok(result)) => Ok(result),
+        Ok(Err(capnp_err)) => Err(capnp_err.into()),
+        Err(_elapsed) => Err(VssSyncError::Timeout(name.to_string())),
+    }
+}
+
+/// Map a Cap'n Proto ok-or-error reader to a `Result`, converting API errors.
+fn check_ok_or_error(r: v1::ok_or_error::Reader<'_>) -> Result<(), VssSyncError> {
+    match r.which().unwrap() {
+        v1::ok_or_error::Which::Ok(_) => Ok(()),
+        v1::ok_or_error::Which::Error(err_rdr) => {
+            let api_err = ApiResponseError::try_from(err_rdr.unwrap())?;
+            Err(VssSyncError::from(api_err))
+        }
+    }
 }

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -8,6 +8,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
+use tokio::time::MissedTickBehavior;
 use tokio_rustls::TlsConnector;
 use tokio_util::compat::*;
 use tracing::{debug, error, info, trace, warn};
@@ -56,8 +57,8 @@ impl VssState {
     }
 
     /// Indicates we have sent the services list across.
-    fn mark_services_syncd(&mut self) {
-        self.services_state.mark_syncd();
+    fn mark_services_synced(&mut self) {
+        self.services_state.mark_synced();
     }
 
     /// TODO: This is not yet tracking policy changes. So only returns TRUE first time it is created.
@@ -73,8 +74,8 @@ impl VssState {
     }
 
     /// Indicates we have sent the topology information across.
-    fn mark_topology_syncd(&mut self) {
-        self.topology_state.mark_syncd();
+    fn mark_topology_synced(&mut self) {
+        self.topology_state.mark_synced();
     }
 }
 
@@ -89,7 +90,7 @@ impl AgedState {
         self.last_sync.is_none() || self.last_sync.as_ref().unwrap() < &self.last_update
     }
 
-    fn mark_syncd(&mut self) {
+    fn mark_synced(&mut self) {
         self.last_sync = Some(Instant::now());
     }
 }
@@ -132,6 +133,7 @@ pub async fn vss_worker_loop(
     let mut ping_failures = 0;
 
     let mut heartbeat = tokio::time::interval(config::VSS_HEARTBEAT_INTERVAL);
+    heartbeat.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
     loop {
         tokio::select! {
@@ -324,10 +326,7 @@ async fn send_pending_visas(
                         // Update our state for the processed visas.
                         // TODO: Need to consider that housekeeping will run frequently, possibly bombarding
                         // nodes that for some reason are not accepting visas. Not sure correct solution yet.
-                        for (i, pushed) in actualized.iter().enumerate() {
-                            if i >= processed {
-                                break;
-                            }
+                        for pushed in actualized.iter().take(processed) {
                             if let Err(e) = asm
                                 .visa_mgr
                                 .visa_installed(pushed.issuer_id, &node_addr)
@@ -395,7 +394,7 @@ async fn send_auth_services(
                 asm.counters.incr(CounterType::VssErrors);
             } else {
                 debug!(target: VSS, "initial auth services list sent to VSS at {}", node_addr);
-                state.mark_services_syncd();
+                state.mark_services_synced();
             }
         }
         Err(e) => {
@@ -418,7 +417,7 @@ async fn send_topology(
         asm.counters.incr(CounterType::VssErrors);
     } else {
         debug!(target: VSS, "initial topology sent to VSS at {}", node_addr);
-        state.mark_topology_syncd();
+        state.mark_topology_synced();
     }
 }
 

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -100,63 +100,17 @@ pub async fn vss_worker_loop(
     // Open connect to VSS.
     info!(target: VSS, "connecting to VSS at {}", node_addr);
 
-    let mut state = VssState::default();
-
-    let sock = match tokio::net::TcpStream::connect(node_addr).await {
-        Ok(sock) => sock,
+    let vss_handle = match vss_connect(node_addr).await {
+        Ok(h) => h,
         Err(e) => {
             error!(target: VSS, "failed to connect to VSS at {}: {}", node_addr, e);
             asm.counters.incr(CounterType::VssErrors);
-            return; // TODO: How to signal manager?
-        }
-    };
-
-    let connector = tls_connect();
-    let tls = connector
-        .connect(node_addr.ip().into(), sock)
-        .await
-        .unwrap();
-    let (reader, writer) = tokio::io::split(tls);
-
-    let network = capnp_rpc::twoparty::VatNetwork::new(
-        tokio::io::BufReader::new(reader).compat(),
-        tokio::io::BufWriter::new(writer).compat_write(),
-        capnp_rpc::rpc_twoparty_capnp::Side::Client,
-        capnp::message::ReaderOptions::new(),
-    );
-
-    let mut rpc_system = capnp_rpc::RpcSystem::new(Box::new(network), None);
-
-    let vss_service: v1::visa_support_service::Client =
-        rpc_system.bootstrap(capnp_rpc::rpc_twoparty_capnp::Side::Server);
-
-    tokio::task::spawn_local(rpc_system);
-
-    let req = vss_service.connect_request();
-
-    let handle_result_rdr =
-        match rpc_with_timeout("connect", DEFAULT_RPC_TIMEOUT, req.send().promise).await {
-            Ok(req_resp) => req_resp,
-            Err(e) => {
-                error!(target: VSS, "VSS connect request failed: {}", e);
-                asm.counters.incr(CounterType::VssErrors);
-                return; // TODO: Signal manager?
-            }
-        };
-
-    let handle_result_ok_or_error = handle_result_rdr.get().unwrap().get_resp().unwrap();
-
-    let vss_handle: v1::v_s_s_handle::Client = match handle_result_ok_or_error.which().unwrap() {
-        v1::result::Which::Ok(vss_handle_obj) => vss_handle_obj.unwrap(),
-        v1::result::Which::Error(err_obj) => {
-            let err_obj = err_obj.unwrap();
-            error!(target: VSS, "VSS connect error: code={:?} msg={:?}", err_obj.get_code(), err_obj.get_message());
-            asm.counters.incr(CounterType::VssErrors);
-            return; // TODO: Signal manager?
+            return;
         }
     };
 
     info!(target: VSS, "now connected to VSS at {}", node_addr);
+    let mut state = VssState::default();
     do_housekeeping(&mut state, &asm, &node_addr.ip(), &vss_handle).await;
 
     let ping_timeout = tokio::time::sleep(config::VSS_PING_INTERVAL);
@@ -256,6 +210,48 @@ pub async fn vss_worker_loop(
                     return;
                 }
             }
+        }
+    }
+}
+
+/// Perform TCP connect, TLS handshake, Cap'n Proto RPC bootstrap, and the initial
+/// connect RPC, returning a ready-to-use VSS handle client.
+async fn vss_connect(node_addr: SocketAddr) -> Result<v1::v_s_s_handle::Client, VssSyncError> {
+    let sock = tokio::net::TcpStream::connect(node_addr)
+        .await
+        .map_err(|e| VssSyncError::Internal(format!("TCP connect: {e}")))?;
+
+    let tls = tls_connect()
+        .connect(node_addr.ip().into(), sock)
+        .await
+        .map_err(|e| VssSyncError::Internal(format!("TLS handshake: {e}")))?;
+
+    let (reader, writer) = tokio::io::split(tls);
+    let network = capnp_rpc::twoparty::VatNetwork::new(
+        tokio::io::BufReader::new(reader).compat(),
+        tokio::io::BufWriter::new(writer).compat_write(),
+        capnp_rpc::rpc_twoparty_capnp::Side::Client,
+        capnp::message::ReaderOptions::new(),
+    );
+    let mut rpc_system = capnp_rpc::RpcSystem::new(Box::new(network), None);
+    let vss_service: v1::visa_support_service::Client =
+        rpc_system.bootstrap(capnp_rpc::rpc_twoparty_capnp::Side::Server);
+    tokio::task::spawn_local(rpc_system);
+
+    let req = vss_service.connect_request();
+    let handle_result_rdr =
+        rpc_with_timeout("connect", DEFAULT_RPC_TIMEOUT, req.send().promise).await?;
+
+    let handle_result_ok_or_error = handle_result_rdr.get()?.get_resp()?;
+    match handle_result_ok_or_error.which().unwrap() {
+        v1::result::Which::Ok(vss_handle_obj) => Ok(vss_handle_obj.unwrap()),
+        v1::result::Which::Error(err_obj) => {
+            let err_obj = err_obj.unwrap();
+            Err(VssSyncError::Internal(format!(
+                "VSS rejected connect: code={:?} msg={:?}",
+                err_obj.get_code(),
+                err_obj.get_message(),
+            )))
         }
     }
 }

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -408,9 +408,7 @@ async fn send_topology(
     node_addr: &IpAddr,
     vss_handle: &v1::v_s_s_handle::Client,
 ) {
-    let cpol = asm.policy_mgr.get_current();
     let links = asm.policy_mgr.resolved_links_for_node(node_addr);
-    drop(cpol);
 
     debug!(target: VSS, "sending initial topology to VSS at {}", node_addr);
     if let Err(e) = vss_do_set_topology(vss_handle, &links).await {

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -43,6 +43,10 @@ struct VssState {
 }
 
 impl VssState {
+    fn needs_configure(&self) -> bool {
+        self.last_configure.is_none()
+    }
+
     /// Indicates that the initial configuration call was performed.
     fn mark_configured(&mut self) {
         self.last_configure = Some(Instant::now());
@@ -139,7 +143,7 @@ pub async fn vss_worker_loop(
                             break;
                         }
                         VssCmd::PushVisas(visas, resp_tx) => {
-                            if let Err(e) = resp_tx.send(vss_do_push_visas(&vss_handle, visas).await) {
+                            if let Err(e) = resp_tx.send(vss_do_push_visas(&vss_handle, &visas).await) {
                                 error!(target: VSS, "failed to send response for push-visas command: {:?}", e);
                                 asm.counters.incr(CounterType::VssErrors);
                             }
@@ -273,7 +277,7 @@ async fn do_housekeeping(
     node_addr: &IpAddr,
     vss_handle: &v1::v_s_s_handle::Client,
 ) {
-    if state.last_configure.is_none() {
+    if state.needs_configure() {
         send_configure(state, asm, node_addr, vss_handle).await;
     }
     if state.needs_set_services() {
@@ -283,7 +287,38 @@ async fn do_housekeeping(
         send_topology(state, asm, node_addr, vss_handle).await;
     }
 
-    // TODO: Check for pending visas and revocations. And if found, send them.
+    // Now we check for any pending visas for this node.
+    match asm.visa_mgr.get_pending_visas_for_node(node_addr).await {
+        Ok(pending_visas) => {
+            let mut actualized = Vec::new();
+
+            for visa in pending_visas {
+                let issuer_id = visa.issuer_id;
+                match asm
+                    .visa_mgr
+                    .actualize_visa_for_target_node(visa, node_addr)
+                    .await
+                {
+                    Ok(a_visa) => actualized.push(a_visa),
+                    Err(e) => {
+                        error!(target: VSS, "failed to actualize pending visa {issuer_id} for node {}: {}", node_addr, e);
+                    }
+                }
+            }
+
+            if let Err(e) = vss_do_push_visas(vss_handle, &actualized).await {
+                error!(target: VSS, "failed to push pending visas to node {}: {}", node_addr, e);
+            } else {
+                debug!(target: VSS, "successfully pushed {} pending visas to node {}", actualized.len(), node_addr);
+            }
+        }
+        Err(e) => {
+            warn!(target: VSS, "failed to get pending visas for node {}: {}", node_addr, e);
+        }
+    }
+
+    // TODO: Check for pending visa revocations.
+    // TODO: Check for pending authentication revocations.
 }
 
 async fn send_configure(
@@ -498,7 +533,7 @@ fn check_ok_or_error(r: v1::ok_or_error::Reader<'_>) -> Result<(), VssSyncError>
 /// Treats zero visas processed as an error.
 async fn vss_do_push_visas(
     vss_handle: &v1::v_s_s_handle::Client,
-    visas: Vec<Visa>,
+    visas: &[Visa],
 ) -> Result<usize, VssSyncError> {
     let mut req = vss_handle.push_visa_op_request();
     let req_builder = req.get();

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -1,0 +1,563 @@
+//! Each node's VSS service is managed by a worker here on the VS side.
+
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{DigitallySignedStruct, SignatureScheme};
+use std::future::Future;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
+use tokio_rustls::TlsConnector;
+use tokio_util::compat::*;
+use tracing::{debug, error, info, trace, warn};
+
+use zpr::policy_types::{NetAddr, NetworkHost};
+use zpr::vsapi::v1;
+use zpr::vsapi_types::{
+    ApiResponseError, Link, LinkRole, Param, ServiceDescriptor, SockAddr, pname,
+};
+use zpr::write_to::WriteTo;
+
+use libeval::policy::Peer;
+
+use crate::assembly::Assembly;
+use crate::config;
+use crate::counters::CounterType;
+use crate::error::{ResolverError, VssSyncError};
+use crate::logging::targets::VSS;
+use crate::net_mgr;
+use crate::vss::VssCmd;
+
+/// Default timeout for a single Cap'n Proto RPC call.
+const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Minimum (and initial) timeout for a ping RPC call.
+const PING_MIN_TIMEOUT: Duration = Duration::from_secs(1);
+
+#[derive(Debug)]
+struct VssState {
+    last_configure: Option<Instant>,
+    last_set_services: Option<Instant>,
+    last_set_topology: Option<Instant>,
+    last_services_update: Instant,
+    last_topology_update: Instant,
+}
+
+impl VssState {
+    fn default() -> Self {
+        VssState {
+            last_configure: None,
+            last_set_services: None,
+            last_set_topology: None,
+            last_services_update: Instant::now(),
+            last_topology_update: Instant::now(),
+        }
+    }
+
+    fn needs_set_services(&self) -> bool {
+        self.last_set_services.is_none()
+            || self.last_services_update > self.last_set_services.unwrap()
+    }
+
+    fn needs_set_topology(&self) -> bool {
+        self.last_set_topology.is_none()
+            || self.last_topology_update > self.last_set_topology.unwrap()
+    }
+}
+
+/// Wrap a Cap'n Proto RPC future with a timeout, mapping errors.
+async fn rpc_with_timeout<F, T>(
+    name: &'static str,
+    duration: Duration,
+    fut: F,
+) -> Result<T, VssSyncError>
+where
+    F: Future<Output = Result<T, capnp::Error>>,
+{
+    match tokio::time::timeout(duration, fut).await {
+        Ok(Ok(result)) => Ok(result),
+        Ok(Err(capnp_err)) => Err(capnp_err.into()),
+        Err(_elapsed) => Err(VssSyncError::Timeout(name.to_string())),
+    }
+}
+
+// Run-loop for a thread that manages a VSS connection to a node.
+pub async fn vss_worker_loop(
+    asm: Arc<Assembly>,
+    node_addr: SocketAddr,
+    mut cmd_rx: mpsc::Receiver<VssCmd>,
+) {
+    // Open connect to VSS.
+    info!(target: VSS, "connecting to VSS at {}", node_addr);
+
+    let mut state = VssState::default();
+
+    let sock = match tokio::net::TcpStream::connect(node_addr).await {
+        Ok(sock) => sock,
+        Err(e) => {
+            error!(target: VSS, "failed to connect to VSS at {}: {}", node_addr, e);
+            asm.counters.incr(CounterType::VssErrors);
+            return; // TODO: How to signal manager?
+        }
+    };
+
+    let connector = tls_connect();
+    let tls = connector
+        .connect(node_addr.ip().into(), sock)
+        .await
+        .unwrap();
+    let (reader, writer) = tokio::io::split(tls);
+
+    let network = capnp_rpc::twoparty::VatNetwork::new(
+        tokio::io::BufReader::new(reader).compat(),
+        tokio::io::BufWriter::new(writer).compat_write(),
+        capnp_rpc::rpc_twoparty_capnp::Side::Client,
+        capnp::message::ReaderOptions::new(),
+    );
+
+    let mut rpc_system = capnp_rpc::RpcSystem::new(Box::new(network), None);
+
+    let vss_service: v1::visa_support_service::Client =
+        rpc_system.bootstrap(capnp_rpc::rpc_twoparty_capnp::Side::Server);
+
+    tokio::task::spawn_local(rpc_system);
+
+    let req = vss_service.connect_request();
+
+    let handle_result_rdr =
+        match rpc_with_timeout("connect", DEFAULT_RPC_TIMEOUT, req.send().promise).await {
+            Ok(req_resp) => req_resp,
+            Err(e) => {
+                error!(target: VSS, "VSS connect request failed: {}", e);
+                asm.counters.incr(CounterType::VssErrors);
+                return; // TODO: Signal manager?
+            }
+        };
+
+    let handle_result_ok_or_error = handle_result_rdr.get().unwrap().get_resp().unwrap();
+
+    let vss_handle: v1::v_s_s_handle::Client = match handle_result_ok_or_error.which().unwrap() {
+        v1::result::Which::Ok(vss_handle_obj) => vss_handle_obj.unwrap(),
+        v1::result::Which::Error(err_obj) => {
+            let err_obj = err_obj.unwrap();
+            error!(target: VSS, "VSS connect error: code={:?} msg={:?}", err_obj.get_code(), err_obj.get_message());
+            asm.counters.incr(CounterType::VssErrors);
+            return; // TODO: Signal manager?
+        }
+    };
+
+    info!(target: VSS, "now connected to VSS at {}", node_addr);
+
+    do_vss_initialization(&mut state, &asm, &node_addr.ip(), &vss_handle).await;
+
+    let ping_timeout = tokio::time::sleep(config::VSS_PING_INTERVAL);
+    tokio::pin!(ping_timeout);
+    let mut ping_failures = 0;
+
+    let mut heartbeat = tokio::time::interval(config::VSS_HEARTBEAT_INTERVAL);
+
+    loop {
+        tokio::select! {
+            cmd_opt = cmd_rx.recv() => {
+                match cmd_opt {
+                    Some(cmd) => match cmd {
+                        VssCmd::Stop() => {
+                            info!(target: VSS, "stop called on VSS worker for {}", node_addr);
+                            break;
+                        }
+                        VssCmd::PushVisas(_visas, resp_tx) => {
+                            if let Err(e) = resp_tx.send(Err(VssSyncError::Internal("push-visas not implemented".to_string()))) {
+                                error!(target: VSS, "failed to send response for push-visas command: {:?}", e);
+                                asm.counters.incr(CounterType::VssErrors);
+                            }
+                        }
+                        VssCmd::RevokeVisasById(_visa_id, resp_tx) => {
+                            if let Err(e) = resp_tx.send(Err(VssSyncError::Internal("revoke-visas not implemented".to_string()))) {
+                                error!(target: VSS, "failed to send response for revoke-visas command: {:?}", e);
+                                asm.counters.incr(CounterType::VssErrors);
+                            }
+                        }
+                        VssCmd::RevokeAuthsByZprAddr(_zpr_addr, resp_tx) => {
+                            if let Err(e) = resp_tx.send(Err(VssSyncError::Internal("revoke-auths not implemented".to_string()))) {
+                                error!(target: VSS, "failed to send response for revoke-auths command: {:?}", e);
+                                asm.counters.incr(CounterType::VssErrors);
+                            }
+                        }
+                        VssCmd::SetServices(services, resp_tx) => {
+                            if let Err(e) = resp_tx.send(do_set_services(&vss_handle, services).await) {
+                                error!(target: VSS, "failed to send response for set-services command: {:?}", e);
+                                asm.counters.incr(CounterType::VssErrors);
+                            }
+                        }
+                        VssCmd::Configure(params, resp_tx) => {
+                            if let Err(e) = resp_tx.send(do_configure(&vss_handle, params).await) {
+                                error!(target: VSS, "failed to send response for configure command: {:?}", e);
+                                asm.counters.incr(CounterType::VssErrors);
+                            }
+                        }
+                    }
+                    None => {
+                        // Uh oh - channel closed.
+                        warn!(target: VSS, "command channel closed for VSS worker for {}", node_addr);
+                        break;
+                    }
+                }
+            }
+
+            _ = heartbeat.tick() => {
+                do_housekeeping(&mut state, &asm, &node_addr.ip(), &vss_handle).await;
+            }
+
+            () = &mut ping_timeout => {
+                let ping_dur = PING_MIN_TIMEOUT + Duration::from_secs(ping_failures);
+                match rpc_with_timeout("ping", ping_dur, vss_handle.ping_request().send().promise).await {
+                    Ok(ping_response_rdr) => {
+                        match ping_response_rdr.get().unwrap().get_res().unwrap().which().unwrap() {
+                            v1::ok_or_error::Which::Ok(_) => {
+                                trace!(target: VSS, "ping to VSS at {} succeeded", node_addr);
+                                asm.actor_mgr.update_node_last_seen(&node_addr.ip()).await.ok(); // Ignore errors.
+                                ping_failures = 0;
+                            }
+                            v1::ok_or_error::Which::Error(err_rdr) => {
+                                let err_obj = err_rdr.unwrap();
+                                error!(target: VSS, "VSS ping returns error: code={:?} msg={:?}", err_obj.get_code(), err_obj.get_message());
+                                asm.counters.incr(CounterType::VssErrors);
+                                // TODO: What does this even mean? We got a reply but it is a coded error message? Should we just disconnect from node?
+                                ping_failures += 1;
+                            }
+                        }
+                    }
+                    Err(VssSyncError::Timeout(_)) => {
+                        warn!(target: VSS, "ping to VSS at {} timed out", node_addr);
+                        asm.counters.incr(CounterType::VssErrors);
+                        ping_failures += 1;
+                    }
+                    Err(_) => {
+                        warn!(target: VSS, "ping to VSS at {} failed", node_addr);
+                        asm.counters.incr(CounterType::VssErrors);
+                        ping_failures += 1;
+                    }
+                }
+                if ping_failures == 0 {
+                    ping_timeout.as_mut().reset(tokio::time::Instant::now() + config::VSS_PING_INTERVAL);
+                } else if ping_failures < config::VSS_MAX_PING_FAILURES as u64 {
+                    ping_timeout.as_mut().reset(tokio::time::Instant::now() + Duration::from_secs(1));
+                } else {
+                    error!(target: VSS, "too many VSS ping failures to {}, exiting VSS worker", node_addr);
+                    return;
+                }
+            }
+        }
+    }
+}
+
+async fn do_housekeeping(
+    state: &mut VssState,
+    asm: &Arc<Assembly>,
+    node_addr: &IpAddr,
+    vss_handle: &v1::v_s_s_handle::Client,
+) {
+    if state.last_configure.is_none() {
+        send_configure(state, asm, node_addr, vss_handle).await;
+    }
+    if state.needs_set_services() {
+        send_services(state, asm, node_addr, vss_handle).await;
+    }
+    if state.needs_set_topology() {
+        send_topology(state, asm, node_addr, vss_handle).await;
+    }
+
+    // TODO: Check for pending visas and revocations. And if found, send them.
+}
+
+/// When the vss worker starts up the node expects a couple of calls immediately.
+///
+/// 1. `configure()` to set the params (only AAA prefix for now).
+/// 2. `setServices()` to tell node about the available auth services.
+///
+/// And, if the node is supposed to have peers, we call:
+///
+/// 3. `setTopology()` to tell node about its links.
+///
+async fn do_vss_initialization(
+    state: &mut VssState,
+    asm: &Arc<Assembly>,
+    node_addr: &IpAddr,
+    vss_handle: &v1::v_s_s_handle::Client,
+) {
+    send_configure(state, asm, node_addr, vss_handle).await;
+    send_services(state, asm, node_addr, vss_handle).await;
+    send_topology(state, asm, node_addr, vss_handle).await;
+}
+
+async fn send_configure(
+    state: &mut VssState,
+    asm: &Arc<Assembly>,
+    node_addr: &IpAddr,
+    vss_handle: &v1::v_s_s_handle::Client,
+) {
+    // The AAA net is stored in the actor properties, but it is statically tied to
+    // the node ZPR address so we just recompute it here.
+    let aaa_net = net_mgr::aaa_network_for_node(node_addr);
+    let params = vec![Param::new_str(
+        pname::AAA_PREFIX.into(),
+        aaa_net.to_string(),
+    )];
+    debug!(target: VSS, "sending configure to VSS at {node_addr}");
+    match do_configure(vss_handle, params).await {
+        Ok(_) => {
+            debug!(target: VSS, "{node_addr} configured successfully");
+            state.last_configure = Some(Instant::now());
+        }
+        Err(e) => {
+            warn!(target: VSS, "failed to configure VSS at {node_addr}: {e}");
+            asm.counters.incr(CounterType::VssErrors);
+        }
+    }
+}
+
+async fn send_services(
+    state: &mut VssState,
+    asm: &Arc<Assembly>,
+    node_addr: &IpAddr,
+    vss_handle: &v1::v_s_s_handle::Client,
+) {
+    match asm.actor_mgr.get_auth_services_list(asm.clone()).await {
+        Ok(services) => {
+            debug!(target: VSS, "sending initial auth services list to VSS at {}", node_addr);
+            if let Err(e) = do_set_services(&vss_handle, services).await {
+                error!(target: VSS, "failed to send initial auth services list to VSS at {}: {}", node_addr, e);
+                asm.counters.incr(CounterType::VssErrors);
+            } else {
+                debug!(target: VSS, "initial auth services list sent to VSS at {}", node_addr);
+                state.last_set_services = Some(Instant::now());
+            }
+        }
+        Err(e) => {
+            warn!(target: VSS, "failed to get auth services list for VSS at {}: {}", node_addr, e);
+        }
+    }
+}
+
+async fn send_topology(
+    state: &mut VssState,
+    asm: &Arc<Assembly>,
+    node_addr: &IpAddr,
+    vss_handle: &v1::v_s_s_handle::Client,
+) {
+    let cpol = asm.policy_mgr.get_current();
+    let peers = cpol.get_peers_for_node(node_addr);
+    let links = peers_to_links(peers.unwrap_or(&[])).await;
+    drop(cpol);
+
+    debug!(target: VSS, "sending initial topology to VSS at {}", node_addr);
+    if let Err(e) = do_set_topology(vss_handle, &links).await {
+        error!(target: VSS, "failed to send initial topology to VSS at {}: {}", node_addr, e);
+        asm.counters.incr(CounterType::VssErrors);
+    } else {
+        debug!(target: VSS, "initial topology sent to VSS at {}", node_addr);
+        state.last_set_topology = Some(Instant::now());
+    }
+}
+
+async fn do_set_services(
+    vss_handle: &v1::v_s_s_handle::Client,
+    services: Vec<ServiceDescriptor>,
+) -> Result<(), VssSyncError> {
+    let mut req = vss_handle.set_services_request();
+    let req_builder = req.get();
+
+    let mut svc_list_builder = req_builder.init_svcs(services.len() as u32);
+    for (i, svc) in services.iter().enumerate() {
+        let mut svc_builder = svc_list_builder.reborrow().get(i as u32);
+        svc.write_to(&mut svc_builder);
+    }
+
+    let set_response_rdr =
+        rpc_with_timeout("set-services", DEFAULT_RPC_TIMEOUT, req.send().promise).await?;
+
+    let set_response_ok_or_err = set_response_rdr.get()?;
+
+    match set_response_ok_or_err.get_res().unwrap().which().unwrap() {
+        v1::ok_or_error::Which::Ok(_) => (),
+        v1::ok_or_error::Which::Error(err_rdr) => {
+            let api_err = ApiResponseError::try_from(err_rdr.unwrap())?;
+            return Err(VssSyncError::from(api_err));
+        }
+    }
+
+    Ok(())
+}
+
+async fn do_configure(
+    vss_handle: &v1::v_s_s_handle::Client,
+    params: Vec<Param>,
+) -> Result<(), VssSyncError> {
+    let mut req = vss_handle.configure_request();
+    let req_builder = req.get();
+
+    let mut params_builder = req_builder.init_params(params.len() as u32);
+    for (i, param) in params.iter().enumerate() {
+        let mut param_builder = params_builder.reborrow().get(i as u32);
+        param.write_to(&mut param_builder);
+    }
+
+    let configure_response_rdr =
+        rpc_with_timeout("configure", DEFAULT_RPC_TIMEOUT, req.send().promise).await?;
+
+    let configure_response_ok_or_err = configure_response_rdr.get()?;
+
+    match configure_response_ok_or_err
+        .get_res()
+        .unwrap()
+        .which()
+        .unwrap()
+    {
+        v1::ok_or_error::Which::Ok(_) => Ok(()),
+        v1::ok_or_error::Which::Error(err_rdr) => {
+            let api_err = ApiResponseError::try_from(err_rdr.unwrap())?;
+            Err(VssSyncError::from(api_err))
+        }
+    }
+}
+
+/// Pass an empty slice to indicate no peers.
+///
+async fn do_set_topology(
+    vss_handle: &v1::v_s_s_handle::Client,
+    peers: &[Link],
+) -> Result<(), VssSyncError> {
+    let mut req = vss_handle.set_topology_request();
+    let req_builder = req.get();
+    let mut peer_list_builder = req_builder.init_links(peers.len() as u32);
+
+    for (i, peer) in peers.iter().enumerate() {
+        let mut peer_builder = peer_list_builder.reborrow().get(i as u32);
+        peer.write_to(&mut peer_builder);
+    }
+
+    let set_response_rdr =
+        rpc_with_timeout("set-topology", DEFAULT_RPC_TIMEOUT, req.send().promise).await?;
+
+    let set_response_ok_or_err = set_response_rdr.get()?;
+
+    match set_response_ok_or_err.get_res().unwrap().which().unwrap() {
+        v1::ok_or_error::Which::Ok(_) => Ok(()),
+        v1::ok_or_error::Which::Error(err_rdr) => {
+            let api_err = ApiResponseError::try_from(err_rdr.unwrap())?;
+            Err(VssSyncError::from(api_err))
+        }
+    }
+}
+
+/// Peers from policy may include hostnames. Here we run any hostnames through a
+/// DNS lookup and create concrete `Link` objects with IP addresses. If any hostname fails
+/// to resolve we just skip that peer and log an error.
+async fn peers_to_links(peers: &[Peer]) -> Vec<Link> {
+    let mut links = Vec::new();
+
+    for peer in peers {
+        match resolve_netaddr(&peer.remote_substrate).await {
+            Ok(sock_addr) => {
+                let sa: SockAddr = SockAddr {
+                    addr: sock_addr.ip(),
+                    port: sock_addr.port(),
+                };
+                //resolved.insert(&peer.link_id, sa);
+                let link = Link {
+                    link_id: peer.link_id.clone(),
+                    role: LinkRole::Active, // only "active" support at the moment.
+                    peer: sa,
+                };
+                links.push(link);
+            }
+            Err(e) => {
+                error!(target: VSS, "failed to resolve address for peer {}: {}, skipping peer in topology", peer.link_id, e);
+                continue;
+            }
+        }
+    }
+
+    links
+}
+
+async fn resolve_netaddr(naddr: &NetAddr) -> Result<SocketAddr, ResolverError> {
+    match &naddr.host {
+        NetworkHost::Ip(ip_addr) => Ok(SocketAddr::new(ip_addr.clone(), naddr.port)),
+        NetworkHost::Hostname(hostname) => {
+            let mut addrs = tokio::net::lookup_host((hostname.as_str(), naddr.port)).await?;
+            addrs
+                .next()
+                .ok_or_else(|| ResolverError::NoAddresses(hostname.clone()))
+        }
+    }
+}
+
+#[derive(Debug)]
+struct NoVerification;
+
+// Implement the dangerous trait ServerCertVerifier NoVerification which will
+// just always approve the connection
+impl ServerCertVerifier for NoVerification {
+    fn verify_server_cert(
+        &self,
+        _: &CertificateDer<'_>,
+        _: &[CertificateDer<'_>],
+        _: &ServerName<'_>,
+        _: &[u8],
+        _: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _: &[u8],
+        _: &CertificateDer<'_>,
+        _: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _: &[u8],
+        _: &CertificateDer<'_>,
+        _: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        vec![
+            SignatureScheme::RSA_PKCS1_SHA1,
+            SignatureScheme::ECDSA_SHA1_Legacy,
+            SignatureScheme::RSA_PKCS1_SHA256,
+            SignatureScheme::ECDSA_NISTP256_SHA256,
+            SignatureScheme::RSA_PKCS1_SHA384,
+            SignatureScheme::ECDSA_NISTP384_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA512,
+            SignatureScheme::ECDSA_NISTP521_SHA512,
+            SignatureScheme::RSA_PSS_SHA256,
+            SignatureScheme::RSA_PSS_SHA384,
+            SignatureScheme::RSA_PSS_SHA512,
+            SignatureScheme::ED25519,
+            SignatureScheme::ED448,
+            SignatureScheme::ML_DSA_44,
+            SignatureScheme::ML_DSA_65,
+            SignatureScheme::ML_DSA_87,
+        ]
+    }
+}
+
+// Create a dangerous connector - the verifier will always approve
+// TODO decide if we want to use an actual certificate
+fn tls_connect() -> TlsConnector {
+    let cfg = rustls::ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(NoVerification))
+        .with_no_client_auth();
+
+    TlsConnector::from(Arc::new(cfg))
+}

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -12,19 +12,14 @@ use tokio_rustls::TlsConnector;
 use tokio_util::compat::*;
 use tracing::{debug, error, info, trace, warn};
 
-use zpr::policy_types::{NetAddr, NetworkHost};
 use zpr::vsapi::v1;
-use zpr::vsapi_types::{
-    ApiResponseError, Link, LinkRole, Param, ServiceDescriptor, SockAddr, Visa, pname,
-};
+use zpr::vsapi_types::{ApiResponseError, Link, Param, ServiceDescriptor, Visa, pname};
 use zpr::write_to::WriteTo;
-
-use libeval::policy::Peer;
 
 use crate::assembly::Assembly;
 use crate::config;
 use crate::counters::CounterType;
-use crate::error::{ResolverError, VssSyncError};
+use crate::error::VssSyncError;
 use crate::logging::targets::VSS;
 use crate::net_mgr;
 use crate::vss::VssCmd;
@@ -414,8 +409,7 @@ async fn send_topology(
     vss_handle: &v1::v_s_s_handle::Client,
 ) {
     let cpol = asm.policy_mgr.get_current();
-    let peers = cpol.get_peers_for_node(node_addr);
-    let links = peers_to_links(peers.unwrap_or(&[])).await;
+    let links = asm.policy_mgr.resolved_links_for_node(node_addr);
     drop(cpol);
 
     debug!(target: VSS, "sending initial topology to VSS at {}", node_addr);
@@ -425,49 +419,6 @@ async fn send_topology(
     } else {
         debug!(target: VSS, "initial topology sent to VSS at {}", node_addr);
         state.mark_topology_syncd();
-    }
-}
-
-/// Peers from policy may include hostnames. Here we run any hostnames through a
-/// DNS lookup and create concrete `Link` objects with IP addresses. If any hostname fails
-/// to resolve we just skip that peer and log an error.
-async fn peers_to_links(peers: &[Peer]) -> Vec<Link> {
-    // Attempt to parallelize the DNS lookups.
-    let futs = peers
-        .iter()
-        .map(|peer| async move { (peer, resolve_netaddr(&peer.remote_substrate).await) });
-
-    futures::future::join_all(futs)
-        .await
-        .into_iter()
-        .filter_map(|(peer, result)| match result {
-            Ok(sock_addr) => Some(Link {
-                link_id: peer.link_id.clone(),
-                role: LinkRole::Active, // only "active" support at the moment.
-                peer: SockAddr {
-                    addr: sock_addr.ip(),
-                    port: sock_addr.port(),
-                },
-            }),
-            Err(e) => {
-                error!(target: VSS, "failed to resolve address for peer {}: {}, skipping peer in topology", peer.link_id, e);
-                None
-            }
-        })
-        .collect()
-}
-
-/// If the passed `NetAddr` contains a hostname, perform a DNS lookup to resolve it to an IP address.
-/// Otherwise this quickly just returns a SocketAddr.
-async fn resolve_netaddr(naddr: &NetAddr) -> Result<SocketAddr, ResolverError> {
-    match &naddr.host {
-        NetworkHost::Ip(ip_addr) => Ok(SocketAddr::new(ip_addr.clone(), naddr.port)),
-        NetworkHost::Hostname(hostname) => {
-            let mut addrs = tokio::net::lookup_host((hostname.as_str(), naddr.port)).await?;
-            addrs
-                .next()
-                .ok_or_else(|| ResolverError::NoAddresses(hostname.clone()))
-        }
     }
 }
 
@@ -659,82 +610,4 @@ async fn vss_do_set_topology(
         rpc_with_timeout("set-topology", DEFAULT_RPC_TIMEOUT, req.send().promise).await?;
     let set_response_ok_or_err = set_response_rdr.get()?;
     check_ok_or_error(set_response_ok_or_err.get_res().unwrap())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use libeval::policy::Peer;
-    use std::net::IpAddr;
-    use zpr::policy_types::{NetAddr, NetworkHost};
-    use zpr::vsapi_types::LinkRole;
-
-    fn ip_peer(link_id: &str, ip: IpAddr, port: u16) -> Peer {
-        Peer {
-            link_id: link_id.to_string(),
-            remote_zpr_addr: "fd5a:5052::1".parse().unwrap(),
-            remote_substrate: NetAddr {
-                host: NetworkHost::Ip(ip),
-                port,
-            },
-        }
-    }
-
-    /// Empty peer slice produces an empty link list.
-    #[tokio::test]
-    async fn test_peers_to_links_empty() {
-        let links = peers_to_links(&[]).await;
-        assert!(links.is_empty());
-    }
-
-    /// A single IP peer maps to a single Link with the correct fields.
-    #[tokio::test]
-    async fn test_peers_to_links_single_ip() {
-        let ip: IpAddr = "192.0.2.1".parse().unwrap();
-        let peer = ip_peer("link-a", ip, 4000);
-
-        let links = peers_to_links(&[peer]).await;
-
-        assert_eq!(links.len(), 1);
-        assert_eq!(links[0].link_id, "link-a");
-        assert_eq!(links[0].role, LinkRole::Active);
-        assert_eq!(links[0].peer.addr, ip);
-        assert_eq!(links[0].peer.port, 4000);
-    }
-
-    /// Multiple IP peers produce one Link each, in the same order.
-    #[tokio::test]
-    async fn test_peers_to_links_multiple_ips() {
-        let ip_a: IpAddr = "192.0.2.1".parse().unwrap();
-        let ip_b: IpAddr = "192.0.2.2".parse().unwrap();
-        let peers = [ip_peer("link-a", ip_a, 4000), ip_peer("link-b", ip_b, 5000)];
-
-        let links = peers_to_links(&peers).await;
-
-        assert_eq!(links.len(), 2);
-        assert_eq!(links[0].link_id, "link-a");
-        assert_eq!(links[0].peer.addr, ip_a);
-        assert_eq!(links[1].link_id, "link-b");
-        assert_eq!(links[1].peer.addr, ip_b);
-    }
-
-    /// A peer with an unresolvable hostname is silently dropped; valid IP peers survive.
-    #[tokio::test]
-    async fn test_peers_to_links_bad_hostname_skipped() {
-        let ip: IpAddr = "192.0.2.1".parse().unwrap();
-        let good = ip_peer("link-good", ip, 4000);
-        let bad = Peer {
-            link_id: "link-bad".to_string(),
-            remote_zpr_addr: "fd5a:5052::2".parse().unwrap(),
-            remote_substrate: NetAddr {
-                host: NetworkHost::Hostname("this.hostname.does.not.exist.invalid".to_string()),
-                port: 4000,
-            },
-        };
-
-        let links = peers_to_links(&[good, bad]).await;
-
-        assert_eq!(links.len(), 1);
-        assert_eq!(links[0].link_id, "link-good");
-    }
 }

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -79,16 +79,16 @@ impl VssState {
 #[derive(Debug)]
 struct AgedState {
     last_update: Instant,
-    last_sync: Instant,
+    last_sync: Option<Instant>,
 }
 
 impl AgedState {
     fn needs_sync(&self) -> bool {
-        self.last_sync < self.last_update
+        self.last_sync.is_none() || self.last_sync.as_ref().unwrap() < &self.last_update
     }
 
     fn mark_syncd(&mut self) {
-        self.last_sync = Instant::now();
+        self.last_sync = Some(Instant::now());
     }
 }
 
@@ -96,7 +96,7 @@ impl Default for AgedState {
     fn default() -> Self {
         Self {
             last_update: Instant::now(),
-            last_sync: Instant::now(),
+            last_sync: None,
         }
     }
 }

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -65,11 +65,14 @@ impl VssState {
         self.services_state.mark_syncd();
     }
 
+    /// TODO: This is not yet tracking policy changes. So only returns TRUE first time it is created.
     fn needs_set_topology(&self) -> bool {
         self.topology_state.needs_sync()
     }
 
     /// If topology effecting this node has been updated, indicate that here.
+    /// TODO: Not used yet.
+    #[allow(dead_code)]
     fn mark_topology_updated(&mut self) {
         self.topology_state.last_update = Instant::now();
     }
@@ -277,21 +280,34 @@ async fn do_housekeeping(
     node_addr: &IpAddr,
     vss_handle: &v1::v_s_s_handle::Client,
 ) {
+    // Currently these three items are all onoly part of intiial VSS connection.
+    // Once they are sent, they are not sent again.
     if state.needs_configure() {
         send_configure(state, asm, node_addr, vss_handle).await;
     }
     if state.needs_set_services() {
-        send_services(state, asm, node_addr, vss_handle).await;
+        send_auth_services(state, asm, node_addr, vss_handle).await;
     }
     if state.needs_set_topology() {
         send_topology(state, asm, node_addr, vss_handle).await;
     }
 
-    // Now we check for any pending visas for this node.
+    send_pending_visas(asm, node_addr, vss_handle).await;
+
+    // TODO: Check for pending visa revocations.
+    // TODO: Check for pending authentication revocations.
+}
+
+/// If there are pending visas for this node, use VSS api to send them over.
+/// Update DB state if we are successful.
+async fn send_pending_visas(
+    asm: &Assembly,
+    node_addr: &IpAddr,
+    vss_handle: &v1::v_s_s_handle::Client,
+) {
     match asm.visa_mgr.get_pending_visas_for_node(node_addr).await {
         Ok(pending_visas) => {
             let mut actualized = Vec::new();
-
             for visa in pending_visas {
                 let issuer_id = visa.issuer_id;
                 match asm
@@ -305,20 +321,41 @@ async fn do_housekeeping(
                     }
                 }
             }
+            if !actualized.is_empty() {
+                match vss_do_push_visas(vss_handle, &actualized).await {
+                    Ok(processed) => {
+                        // Update our state for the processed visas.
+                        // TODO: Need to consider that housekeeping will run frequently, possibly bombarding
+                        // nodes that for some reason are not accepting visas. Not sure correct solution yet.
+                        for (i, pushed) in actualized.iter().enumerate() {
+                            if i >= processed {
+                                break;
+                            }
+                            if let Err(e) = asm
+                                .visa_mgr
+                                .visa_installed(pushed.issuer_id, &node_addr)
+                                .await
+                            {
+                                // TODO: Means it will be attempt to be installed next housekeeping run.
+                                warn!(target: VSS,
+                                    "error marking visa {} as installed for node {node_addr}: {e}", pushed.issuer_id
+                                );
+                            }
+                        }
 
-            if let Err(e) = vss_do_push_visas(vss_handle, &actualized).await {
-                error!(target: VSS, "failed to push pending visas to node {}: {}", node_addr, e);
-            } else {
-                debug!(target: VSS, "successfully pushed {} pending visas to node {}", actualized.len(), node_addr);
+                        debug!(target: VSS, "successfully pushed {} pending visas to node {}", actualized.len(), node_addr);
+                    }
+                    Err(e) => {
+                        error!(target: VSS, "failed to push {} pending visas to node {}: {}", actualized.len(), node_addr, e);
+                        return;
+                    }
+                }
             }
         }
         Err(e) => {
             warn!(target: VSS, "failed to get pending visas for node {}: {}", node_addr, e);
         }
     }
-
-    // TODO: Check for pending visa revocations.
-    // TODO: Check for pending authentication revocations.
 }
 
 async fn send_configure(
@@ -347,7 +384,7 @@ async fn send_configure(
     }
 }
 
-async fn send_services(
+async fn send_auth_services(
     state: &mut VssState,
     asm: &Arc<Assembly>,
     node_addr: &IpAddr,

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -15,7 +15,7 @@ use tracing::{debug, error, info, trace, warn};
 use zpr::policy_types::{NetAddr, NetworkHost};
 use zpr::vsapi::v1;
 use zpr::vsapi_types::{
-    ApiResponseError, Link, LinkRole, Param, ServiceDescriptor, SockAddr, pname,
+    ApiResponseError, Link, LinkRole, Param, ServiceDescriptor, SockAddr, Visa, pname,
 };
 use zpr::write_to::WriteTo;
 
@@ -138,8 +138,8 @@ pub async fn vss_worker_loop(
                             info!(target: VSS, "stop called on VSS worker for {}", node_addr);
                             break;
                         }
-                        VssCmd::PushVisas(_visas, resp_tx) => {
-                            if let Err(e) = resp_tx.send(Err(VssSyncError::Internal("push-visas not implemented".to_string()))) {
+                        VssCmd::PushVisas(visas, resp_tx) => {
+                            if let Err(e) = resp_tx.send(vss_do_push_visas(&vss_handle, visas).await) {
                                 error!(target: VSS, "failed to send response for push-visas command: {:?}", e);
                                 asm.counters.incr(CounterType::VssErrors);
                             }
@@ -491,6 +491,47 @@ fn check_ok_or_error(r: v1::ok_or_error::Reader<'_>) -> Result<(), VssSyncError>
             let api_err = ApiResponseError::try_from(err_rdr.unwrap())?;
             Err(VssSyncError::from(api_err))
         }
+    }
+}
+
+/// Performt he VSS push_visas call, returns the number of visas positively ack'd by node.
+/// Treats zero visas processed as an error.
+async fn vss_do_push_visas(
+    vss_handle: &v1::v_s_s_handle::Client,
+    visas: Vec<Visa>,
+) -> Result<usize, VssSyncError> {
+    let mut req = vss_handle.push_visa_op_request();
+    let req_builder = req.get();
+    let mut ops_list_builder = req_builder.init_ops(visas.len() as u32);
+
+    // A VisaOp is either a Grant or a Revoke; these are all GRANTs here.
+    for (i, visa) in visas.iter().enumerate() {
+        let op_builder = ops_list_builder.reborrow().get(i as u32);
+        let mut grant_builder = op_builder.init_grant();
+        visa.write_to(&mut grant_builder);
+    }
+
+    let push_response_rdr =
+        rpc_with_timeout("push-visas", DEFAULT_RPC_TIMEOUT, req.send().promise).await?;
+
+    // Response is an Ack struct (TODO: Add this to the vsapi types in zpr-common)
+    let ack_response = push_response_rdr.get()?.get_ack()?;
+    if ack_response.get_ok() {
+        // At least one visa was processed. In this case we return the number processed and
+        // log the error (if any).
+        let processed = ack_response.get_processed() as usize;
+        if processed < visas.len() {
+            let err_rdr = ack_response.get_error()?;
+            let err_obj = ApiResponseError::try_from(err_rdr)?;
+            error!(target: VSS, "push-visas partially succeeded: {} of {} processed, error code={:?} msg={}",
+            processed, visas.len(), err_obj.code, err_obj.message);
+        }
+        return Ok(processed);
+    } else {
+        // No visas were processed.  Return error or zero ?? Not sure.
+        let err_rdr = ack_response.get_error()?;
+        let err_obj = ApiResponseError::try_from(err_rdr)?;
+        return Err(err_obj.into());
     }
 }
 


### PR DESCRIPTION
# Branch Changes: mk/178-peers vs main

## VSS Worker Extraction (`vss_worker.rs`, `vss_mgr.rs`)

The per-node VSS connection logic was extracted from `vss_mgr.rs` into a new dedicated `vss_worker.rs`. `vss_mgr.rs` is now a thin dispatcher; the worker handles TLS connection management, ping/keepalive, configure, set_services, and set_topology RPCs against each peer VSS. State tracking (what has been synced, what needs refreshing) lives in `VssState` inside the worker.

## Topology Push to Peer Nodes (`vss_worker.rs`, `policy_mgr.rs`)

VS now pushes link topology to each node's VSS via `send_topology`. The worker reads the resolved link list for a node from `PolicyMgr` and calls the VSS `set_topology` RPC, so each node knows its forwarding graph without a separate discovery step.

## Visa Push to Path Nodes (`visareq_worker.rs`, `visa_mgr.rs`, `vss_worker.rs`)

When a visa is issued, actualized copies are pushed to every intermediate node on the multihop path (not just returned to the requester). `visa_from_allow` now spawns a background task that calls `push_visas` for each peer VSS on the path. `visa_mgr.rs` gained `VisaWithMetadata` and a simplified `actualize_visa` that infers ingress/egress context from the requesting-node address rather than a caller-supplied direction enum.

## DNS

Policy manager does any required DNS resolution on the peer info in policy binary up-front.  Vss worker can just send the ip addresses over.

## VSS Actualize on Pending-Visa Check (`visa_mgr.rs`)

`actualize_visa` is now called during VSS state reconciliation to check for pending visas that need to be pushed to a node, ensuring nodes receive visas that were issued while they were offline.