### PR TITLE
add network request to admin

### DIFF
--- a/admin-api-types/src/admin_api_types.rs
+++ b/admin-api-types/src/admin_api_types.rs
@@ -627,6 +627,36 @@ impl fmt::Display for CnEntry {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+pub struct NetworkDetails {
+    pub network: Vec<NodeConnections>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct NodeConnections {
+    pub node: String,
+    pub connections: Vec<String>,
+}
+
+impl fmt::Display for NetworkDetails {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.network.is_empty() {
+            println!("No network")
+        }
+        for node in &self.network {
+            writeln!(
+                f,
+                "{} {}  {} {:?}",
+                "actor:".dimmed(),
+                node.node.yellow(),
+                "connected to:".dimmed(),
+                node.connections
+            )?;
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/admin-api-types/src/admin_api_types.rs
+++ b/admin-api-types/src/admin_api_types.rs
@@ -641,7 +641,7 @@ pub struct NodeConnections {
 impl fmt::Display for NetworkDetails {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.network.is_empty() {
-            println!("No network")
+            writeln!(f, "No network")?;
         }
         for node in &self.network {
             writeln!(

--- a/vs-admin/src/executor.rs
+++ b/vs-admin/src/executor.rs
@@ -112,6 +112,11 @@ impl Executor {
         Ok(())
     }
 
+    pub fn do_cmd_network(&self) -> Result<(), Box<dyn std::error::Error>> {
+        self.get_network()?;
+        Ok(())
+    }
+
     fn get_policies(&self) -> Result<(), Box<dyn std::error::Error>> {
         let entries = self.vs_cli.get_policies()?;
         for (i, entry) in entries.iter().enumerate() {
@@ -284,6 +289,13 @@ impl Executor {
     fn add_revoke(&self, id: &str) -> Result<(), Box<dyn std::error::Error>> {
         let entry = self.vs_cli.add_revoke(id)?;
         println!("{entry}");
+        Ok(())
+    }
+
+    fn get_network(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let network = self.vs_cli.get_network()?;
+
+        println!("{network}");
         Ok(())
     }
 }

--- a/vs-admin/src/main.rs
+++ b/vs-admin/src/main.rs
@@ -95,6 +95,8 @@ fn main() {
 
         Some(SubCmd::Gui) => gui::enter_gui(&args.svc_url, ca_cert, api_key),
 
+        Some(SubCmd::Network) => exec.do_cmd_network(),
+
         None => Err("no command specified".into()),
     }
     .unwrap_or_else(|e| {

--- a/vs-admin/src/main_args.rs
+++ b/vs-admin/src/main_args.rs
@@ -98,6 +98,9 @@ pub enum SubCmd {
         remove: bool,
     },
 
+    #[command()]
+    Network,
+
     /// Enter GUI mode
     #[command()]
     Gui,

--- a/vs-admin/src/vsclient.rs
+++ b/vs-admin/src/vsclient.rs
@@ -5,8 +5,8 @@ use reqwest;
 use reqwest::tls::Certificate;
 
 use admin_api_types::{
-    ActorDescriptor, AuthRevokeDescriptor, CnEntry, ListEntry, NamedListEntry, PolicyBundle,
-    Revokes, ServiceDescriptor, VisaDescriptor, reason_for,
+    ActorDescriptor, AuthRevokeDescriptor, CnEntry, ListEntry, NamedListEntry, NetworkDetails,
+    PolicyBundle, Revokes, ServiceDescriptor, VisaDescriptor, reason_for,
 };
 
 use crate::error::VsaError;
@@ -323,6 +323,14 @@ impl VsClient {
         requrl.path_segments_mut().unwrap().push(id);
         let resp = self.ht_post(requrl.as_str())?;
         let entry: ListEntry = resp.json()?;
+        Ok(entry)
+    }
+
+    /// `GET <api_url>/admin/network`
+    pub fn get_network(&self) -> Result<NetworkDetails, VsaError> {
+        let req = reqwest::Url::parse(&format!("{}/admin/network", self.api_url))?;
+        let resp = self.ht_get(req.as_str())?;
+        let entry: NetworkDetails = resp.json()?;
         Ok(entry)
     }
 }

--- a/vs/src/actor_mgr.rs
+++ b/vs/src/actor_mgr.rs
@@ -271,6 +271,14 @@ impl ActorMgr {
         }
     }
 
+    /// Returns only the CN for the actor at the given ZPR address, without loading the full actor.
+    pub async fn get_cn_by_zpr_addr(&self, zpra: &IpAddr) -> Result<String, ServiceError> {
+        match self.actor_db.get_cn_by_zpr_addr(zpra).await {
+            Ok(cn) => Ok(cn),
+            Err(e) => Err(ServiceError::from(e)),
+        }
+    }
+
     pub async fn get_actor_by_cn(&self, cn: &str) -> Result<Option<Actor>, ServiceError> {
         match self.actor_db.get_actor_by_cn(cn).await {
             Ok(actor) => Ok(Some(actor)),

--- a/vs/src/actor_mgr.rs
+++ b/vs/src/actor_mgr.rs
@@ -178,6 +178,13 @@ impl ActorMgr {
         Ok(())
     }
 
+    pub async fn get_node_last_seen(
+        &self,
+        node_addr: &IpAddr,
+    ) -> Result<Option<SystemTime>, ServiceError> {
+        Ok(self.node_db.get_last_seen_time(node_addr).await?)
+    }
+
     /// Update vss socket for given node in the DB.
     pub async fn set_node_vss(
         &self,

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -43,8 +43,8 @@ use crate::logging::targets::ADMIN;
 
 use admin_api_types::{
     ActorDescriptor, ApiAttribute, ApiKeyFormat, ApiKeySet, AuthRevokeDescriptor, CnEntry,
-    ListEntry, NamedListEntry, NodeRecordBrief, PolicyBundle, Revokes, ServiceDescriptor,
-    VisaDescriptor,
+    ListEntry, NamedListEntry, NetworkDetails, NodeConnections, NodeRecordBrief, PolicyBundle,
+    Revokes, ServiceDescriptor, VisaDescriptor,
 };
 
 // Must use tokio RwLock here becuase we need state to be Send.
@@ -172,6 +172,7 @@ fn admin_app(state: SharedState) -> Router {
         .route("/admin/authrevoke/{capture}", post(add_revoke))
         .route("/admin/authrevoke/clear", post(clear_revokes))
         .route("/admin/authrevoke/{capture}", delete(remove_revoke))
+        .route("/admin/network", get(get_network))
         .layer(middleware::from_fn_with_state(
             state.clone(),
             require_api_key,
@@ -671,6 +672,52 @@ async fn add_revoke(EPath(id): EPath<String>) -> impl IntoResponse {
 
     let le = ListEntry { id: 0 };
     (StatusCode::OK, Json(le)).into_response()
+}
+
+async fn get_network(
+    Extension(perm): Extension<Permission>,
+    State(state): State<SharedState>,
+) -> Result<Json<NetworkDetails>, StatusCode> {
+    if !perm.can_read() {
+        return Err(StatusCode::FORBIDDEN);
+    }
+    info!(target: ADMIN, "GET /admin/network");
+    let rstate = state.read().await;
+
+    let node_addrs = match rstate.asm.actor_mgr.list_node_addrs().await {
+        Ok(addrs) => addrs,
+        Err(e) => {
+            error!(target: ADMIN, "Error {} getting node list", e);
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    };
+
+    let mut network: Vec<NodeConnections> = Vec::new();
+
+    for node_addr in node_addrs {
+        let node = match rstate.asm.actor_mgr.get_cn_by_zpr_addr(&node_addr).await {
+            Ok(cn) => cn,
+            Err(e) => {
+                error!(target: ADMIN, "error {} getting CN for node with addr {}", e, node_addr);
+                return Err(StatusCode::INTERNAL_SERVER_ERROR);
+            }
+        };
+
+        let mut connections: Vec<String> = Vec::new();
+        for peer_addr in rstate.asm.topo_mgr.get_peers(&node_addr) {
+            match rstate.asm.actor_mgr.get_cn_by_zpr_addr(&peer_addr).await {
+                Ok(cn) => connections.push(cn),
+                Err(e) => {
+                    error!(target: ADMIN, "error {} getting CN for peer with addr {}", e, peer_addr);
+                    return Err(StatusCode::INTERNAL_SERVER_ERROR);
+                }
+            }
+        }
+
+        network.push(NodeConnections { node, connections });
+    }
+
+    Ok(Json(NetworkDetails { network }))
 }
 
 fn to_api_attribute(attr: &Attribute) -> ApiAttribute {

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -532,6 +532,7 @@ async fn build_node_record_brief(
             Ok(cn) => links.push(cn),
             Err(e) => {
                 warn!(target: ADMIN, "error {} getting CN for peer with addr {}", e, peer_addr);
+                links.push(format!("cn_missing:{}", peer_addr))
             }
         }
     }
@@ -722,6 +723,7 @@ async fn get_network(
                 Ok(cn) => connections.push(cn),
                 Err(e) => {
                     warn!(target: ADMIN, "error {} getting CN for peer with addr {}", e, peer_addr);
+                    connections.push(format!("cn_missing:{}", peer_addr))
                 }
             }
         }
@@ -1259,5 +1261,114 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_get_network_empty() {
+        // No nodes
+        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let api_key = setup_test_api_key(&asm);
+        let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
+        let app = admin_app(shared_state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/admin/network")
+                    .header("X-API-Key", &api_key)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let details: NetworkDetails = serde_json::from_slice(&body).unwrap();
+        assert!(details.network.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_network_one_node_no_peers() {
+        // One node with no links
+        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let api_key = setup_test_api_key(&asm);
+
+        let addr: IpAddr = "fd5a:5052::10".parse().unwrap();
+        let actor = make_node_actor_defexp("fd5a:5052::10", "node-a", "[fd5a:5052::100]:1234");
+        asm.actor_mgr.add_node(&actor, false).await.unwrap();
+        asm.topo_mgr.add_node(addr).unwrap();
+
+        let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
+        let app = admin_app(shared_state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/admin/network")
+                    .header("X-API-Key", &api_key)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let details: NetworkDetails = serde_json::from_slice(&body).unwrap();
+        assert_eq!(details.network.len(), 1);
+        assert_eq!(details.network[0].node, "node-a");
+        assert!(details.network[0].connections.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_network_two_nodes_linked() {
+        // Two nodes linked to each other
+        use libeval::route::LinkId;
+
+        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let api_key = setup_test_api_key(&asm);
+
+        let addr_a: IpAddr = "fd5a:5052::10".parse().unwrap();
+        let addr_b: IpAddr = "fd5a:5052::11".parse().unwrap();
+        let actor_a = make_node_actor_defexp("fd5a:5052::10", "node-a", "[fd5a:5052::100]:1234");
+        let actor_b = make_node_actor_defexp("fd5a:5052::11", "node-b", "[fd5a:5052::101]:1234");
+
+        asm.actor_mgr.add_node(&actor_a, false).await.unwrap();
+        asm.actor_mgr.add_node(&actor_b, false).await.unwrap();
+        asm.topo_mgr.add_node(addr_a).unwrap();
+        asm.topo_mgr.add_node(addr_b).unwrap();
+        asm.topo_mgr
+            .add_link(addr_a, addr_b, LinkId("link-ab".into()), vec![], 1)
+            .unwrap();
+
+        let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
+        let app = admin_app(shared_state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/admin/network")
+                    .header("X-API-Key", &api_key)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let details: NetworkDetails = serde_json::from_slice(&body).unwrap();
+        assert_eq!(details.network.len(), 2);
+
+        let mut network = details.network;
+        network.sort_by(|a, b| a.node.cmp(&b.node));
+        assert_eq!(network[0].node, "node-a");
+        assert_eq!(network[0].connections, vec!["node-b".to_string()]);
+        assert_eq!(network[1].node, "node-b");
+        assert_eq!(network[1].connections, vec!["node-a".to_string()]);
     }
 }

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -498,6 +498,7 @@ async fn build_node_record_brief(
     let counters = asm.counters.clone();
     let actor_mgr = asm.actor_mgr.clone();
     let visa_mgr = &asm.visa_mgr;
+    let topo_mgr = &asm.topo_mgr;
 
     let zpr_addr = match actor.get_zpr_addr() {
         Some(addr) => addr,
@@ -505,6 +506,10 @@ async fn build_node_record_brief(
     };
     let pending_install = visa_mgr
         .get_num_pending_install_visas(zpr_addr)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let last_contact = actor_mgr
+        .get_node_last_seen(zpr_addr)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     let visa_requests = counters
@@ -521,7 +526,15 @@ async fn build_node_record_brief(
         .get_adapter_cns_connected_to_node(zpr_addr)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    // TODO I don't think we have connected nodes yet, since we don't yet have multi-node
+    let mut links: Vec<String> = Vec::new();
+    for peer_addr in topo_mgr.get_peers(zpr_addr) {
+        match actor_mgr.get_cn_by_zpr_addr(&peer_addr).await {
+            Ok(cn) => links.push(cn),
+            Err(e) => {
+                warn!(target: ADMIN, "error {} getting CN for peer with addr {}", e, peer_addr);
+            }
+        }
+    }
     let visas = visa_mgr
         .get_installed_visa_ids_for_node(zpr_addr)
         .await
@@ -545,7 +558,7 @@ async fn build_node_record_brief(
 
     Ok(NodeRecordBrief {
         pending_install,
-        last_contact: None, // TODO don't think we currently store last contact
+        last_contact,
         visa_requests,
         connect_requests: 0, // TODO blocked on tracking calls to authorize_connect
         in_sync,
@@ -553,7 +566,7 @@ async fn build_node_record_brief(
         denied_vreqs,
         last_vreq,
         adapters,
-        links: Vec::new(), // TODO blocked on multi-node support
+        links,
         visas,
         visas_enqueued,
         pending_revocation,
@@ -708,8 +721,7 @@ async fn get_network(
             match rstate.asm.actor_mgr.get_cn_by_zpr_addr(&peer_addr).await {
                 Ok(cn) => connections.push(cn),
                 Err(e) => {
-                    error!(target: ADMIN, "error {} getting CN for peer with addr {}", e, peer_addr);
-                    return Err(StatusCode::INTERNAL_SERVER_ERROR);
+                    warn!(target: ADMIN, "error {} getting CN for peer with addr {}", e, peer_addr);
                 }
             }
         }

--- a/vs/src/db/actor.rs
+++ b/vs/src/db/actor.rs
@@ -848,4 +848,49 @@ mod test {
 
         assert_eq!(adapter_services, vec!["svc:three".to_string()]);
     }
+
+    #[tokio::test]
+    async fn test_get_cn_by_zpr_addr_returns_cn() {
+        let db = Arc::new(FakeDb::new());
+        let repo = ActorRepo::new(db);
+        let actor = make_actor_defexp(&[
+            (key::ROLE, ROLE_NODE),
+            (key::CN, "my-node"),
+            (key::ZPR_ADDR, "fd5a:5052::10"),
+        ]);
+        repo.add_actor(&actor).await.unwrap();
+
+        let addr: IpAddr = "fd5a:5052::10".parse().unwrap();
+        let cn = repo.get_cn_by_zpr_addr(&addr).await.unwrap();
+        assert_eq!(cn, "my-node");
+    }
+
+    #[tokio::test]
+    async fn test_get_cn_by_zpr_addr_not_found() {
+        let db = Arc::new(FakeDb::new());
+        let repo = ActorRepo::new(db);
+
+        let addr: IpAddr = "fd5a:5052::10".parse().unwrap();
+        let err = repo.get_cn_by_zpr_addr(&addr).await.unwrap_err();
+        assert!(matches!(err, StoreError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn test_get_cn_by_zpr_addr_matches_get_actor_get_cn() {
+        //  Both get_cn_by_zpr_addr and get_actor_by_zpr_addr().get_cn() must return the same CN.
+        let db = Arc::new(FakeDb::new());
+        let repo = ActorRepo::new(db);
+        let actor = make_actor_defexp(&[
+            (key::ROLE, ROLE_NODE),
+            (key::CN, "roundtrip-node"),
+            (key::ZPR_ADDR, "fd5a:5052::10"),
+        ]);
+        repo.add_actor(&actor).await.unwrap();
+
+        let addr: IpAddr = "fd5a:5052::10".parse().unwrap();
+        let cn_direct = repo.get_cn_by_zpr_addr(&addr).await.unwrap();
+        let loaded = repo.get_actor_by_zpr_addr(&addr).await.unwrap();
+        let cn_via_actor = loaded.get_cn().unwrap();
+        assert_eq!(cn_direct, cn_via_actor);
+    }
 }

--- a/vs/src/db/actor.rs
+++ b/vs/src/db/actor.rs
@@ -513,6 +513,26 @@ impl ActorRepo {
         Ok(actor)
     }
 
+    /// Returns only the CN for the actor at the given ZPR address, without loading the full actor.
+    ///
+    /// Returns `StoreError::NotFound` if no actor exists for the address or the actor has no CN attribute.
+    pub async fn get_cn_by_zpr_addr(&self, zpra: &IpAddr) -> Result<String, StoreError> {
+        let base_key = actor_key_for(zpra);
+        let exists: bool = self.db.exists(&base_key).await?;
+        if !exists {
+            return Err(StoreError::NotFound(format!("actor not found: {}", zpra)));
+        }
+        let mut attrs = self.get_actor_attrs(zpra, &[key::CN]).await?;
+        if attrs.is_empty() {
+            return Err(StoreError::NotFound(format!("actor at {} has no CN", zpra)));
+        }
+        let cn_attr = attrs.remove(0);
+        match cn_attr.get_single_value() {
+            Ok(cn_val) => Ok(cn_val.to_string()),
+            Err(_) => Ok(cn_attr.get_value_as_string()),
+        }
+    }
+
     /// Look up actor by CN attribute. Uses our cache.
     ///
     /// ## Errors

--- a/vs/src/db/node.rs
+++ b/vs/src/db/node.rs
@@ -576,4 +576,69 @@ mod test {
             other => panic!("unexpected error: {:?}", other),
         }
     }
+
+    #[tokio::test]
+    async fn test_get_last_seen_time_none_before_update() {
+        // Checks that get_last_seen_time returns None if there is no timestamp
+        let db = Arc::new(FakeDb::new());
+        let repo = NodeRepo::new(db);
+        let node_addr: IpAddr = "fd5a:5052::10".parse().unwrap();
+
+        let result = repo.get_last_seen_time(&node_addr).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_last_seen_time_exact_value() {
+        // Insert a time into the db and ensure get_last_seen time gets correct time
+        let db = Arc::new(FakeDb::new());
+        let repo = NodeRepo::new(db.clone());
+        let node_addr: IpAddr = "fd5a:5052::64".parse().unwrap();
+
+        db.set(
+            &lastseen_key_for_node(&node_addr),
+            "2024-01-15T10:30:00+00:00",
+        )
+        .await
+        .unwrap();
+
+        let expected = SystemTime::from(
+            chrono::DateTime::parse_from_rfc3339("2024-01-15T10:30:00+00:00").unwrap(),
+        );
+        let result = repo.get_last_seen_time(&node_addr).await.unwrap().unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[tokio::test]
+    async fn test_get_last_seen_time_after_update() {
+        // Checks that when we update the db between two known times, last seen time is between those two times
+        let db = Arc::new(FakeDb::new());
+        let repo = NodeRepo::new(db);
+        let node_addr: IpAddr = "fd5a:5052::10".parse().unwrap();
+
+        let before = SystemTime::now();
+        repo.update_last_seen_time(&node_addr).await.unwrap();
+        let after = SystemTime::now();
+
+        let last_seen = repo.get_last_seen_time(&node_addr).await.unwrap().unwrap();
+        assert!(last_seen >= before && last_seen <= after);
+    }
+
+    #[tokio::test]
+    async fn test_get_last_seen_time_invalid_data() {
+        // Returns an error when the stored timestamp is malformed.
+        let db = Arc::new(FakeDb::new());
+        let repo = NodeRepo::new(db.clone());
+        let node_addr: IpAddr = "fd5a:5052::10".parse().unwrap();
+
+        db.set(&lastseen_key_for_node(&node_addr), "not-a-timestamp")
+            .await
+            .unwrap();
+
+        let err = repo.get_last_seen_time(&node_addr).await.unwrap_err();
+        match err {
+            StoreError::InvalidData(_) => {}
+            other => panic!("unexpected error: {:?}", other),
+        }
+    }
 }

--- a/vs/src/db/node.rs
+++ b/vs/src/db/node.rs
@@ -121,6 +121,20 @@ impl NodeRepo {
         Ok(())
     }
 
+    /// Get the last seen time for the node, if recorded.
+    pub async fn get_last_seen_time(
+        &self,
+        node_zpr_addr: &IpAddr,
+    ) -> Result<Option<SystemTime>, StoreError> {
+        let Some(ts_str) = self.db.get(&lastseen_key_for_node(node_zpr_addr)).await? else {
+            return Ok(None);
+        };
+        let dt = chrono::DateTime::parse_from_rfc3339(&ts_str).map_err(|e| {
+            StoreError::InvalidData(format!("failed to parse last-seen timestamp: {}", e))
+        })?;
+        Ok(Some(SystemTime::from(dt)))
+    }
+
     /// Add state that an adapter is connected to a node.
     pub async fn add_connected_adater(
         &self,

--- a/vs/src/topology_mgr.rs
+++ b/vs/src/topology_mgr.rs
@@ -132,6 +132,10 @@ impl TopologyMgr {
     ) -> Result<Vec<NodeId>, TopologyError> {
         self.router.route_to_path(route, starting)
     }
+
+    pub fn get_peers(&self, zpr_addr: &IpAddr) -> Vec<IpAddr> {
+        self.router.get_peers(zpr_addr)
+    }
 }
 
 impl TopologyQueryApi for TopologyMgr {


### PR DESCRIPTION
Adds a command `/admin/network` to vs-admin that requests the network of nodes from the VS. Returns the network in terms of CNs, could be modified to return the `IpAddrs` of the nodes if that would be more helpful. 

  Also filled in the `links` member of the `NodeRecordBrief` with the CNs of the connected nodes, using `get_peers` and filled in the `last_contact` member as well.