### PR TITLE
Mk/148 update policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,12 +12,17 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 name = "admin-api-types"
 version = "0.13.0"
 dependencies = [
+ "base64",
+ "bytes",
+ "capnp",
  "chrono",
  "colored",
+ "flate2",
  "reqwest",
  "serde",
  "serde_json",
  "serde_with",
+ "zpr",
 ]
 
 [[package]]
@@ -4401,6 +4406,7 @@ dependencies = [
  "clap",
  "dashmap",
  "enum-map",
+ "flate2",
  "futures",
  "futures-util",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ capnp-rpc = "0.25.0"
 chrono = "0.4.42"
 clap = { version = "4.5.50", features = ["derive"] }
 colored = "3.0.0"
+flate2 = "1.0.34"
 openssl = "0.10.80"
 rand = "0.9.2"
 reqwest = "0.13.1"

--- a/admin-api-types/Cargo.toml
+++ b/admin-api-types/Cargo.toml
@@ -5,9 +5,14 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+base64.workspace = true
+bytes.workspace = true
+capnp.workspace = true
 chrono.workspace = true
 colored.workspace = true
+flate2.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
+zpr.workspace = true

--- a/admin-api-types/src/admin_api_types.rs
+++ b/admin-api-types/src/admin_api_types.rs
@@ -31,23 +31,6 @@ impl fmt::Display for NamedListEntry {
     }
 }
 
-#[derive(Serialize, Deserialize)]
-pub struct PolicyBundle {
-    pub config_id: u64,  // ignored when installing
-    pub version: String, // use empty string if you don't care
-    pub format: String,
-    pub container: String,
-}
-
-impl fmt::Display for PolicyBundle {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} {}  ", "id:".dimmed(), self.config_id)?;
-        write!(f, "{} {}  ", "version:".dimmed(), self.version)?;
-        write!(f, "{} {}  ", "format:".dimmed(), self.format)?;
-        write!(f, "{} {}\n", "container:".dimmed(), self.container)
-    }
-}
-
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum VisaMatchDirection {

--- a/admin-api-types/src/lib.rs
+++ b/admin-api-types/src/lib.rs
@@ -1,2 +1,5 @@
 mod admin_api_types;
+mod policy_bundle;
+
 pub use admin_api_types::*;
+pub use policy_bundle::PolicyBundle;

--- a/admin-api-types/src/policy_bundle.rs
+++ b/admin-api-types/src/policy_bundle.rs
@@ -1,0 +1,202 @@
+use std::fmt;
+use std::io::prelude::*;
+
+use zpr::policy::v1;
+
+use base64::prelude::*;
+use bytes::Buf;
+use colored::Colorize;
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct PolicyBundle {
+    pub config_id: u64,  // ignored when installing
+    pub version: String, // use empty string if you don't care
+    pub format: String,
+    pub container: String,
+}
+
+impl fmt::Display for PolicyBundle {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} {}  ", "id:".dimmed(), self.config_id)?;
+        write!(f, "{} {}  ", "version:".dimmed(), self.version)?;
+        write!(f, "{} {}  ", "format:".dimmed(), self.format)?;
+        write!(f, "{} {}\n", "container:".dimmed(), self.container)
+    }
+}
+
+impl PolicyBundle {
+    /// Create the [PolicyBundle] from the Cap'n Proto encoded bytes of a `PolicyContainer`.
+    ///
+    /// ### Errors
+    /// - Capn Proto errors related to deserialization.
+    /// - GZIP errors related to compression. (unlikely)
+    pub fn new_from_policy_container(
+        config_id: u64,
+        container_bytes: &[u8],
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let container_reader = capnp::serialize::read_message(
+            container_bytes.reader(),
+            capnp::message::ReaderOptions::new(),
+        )?;
+        let container = container_reader.get_root::<v1::policy_container::Reader>()?;
+        let zplc_maj = container.get_zplc_ver_major();
+        let zplc_min = container.get_zplc_ver_minor();
+        let zplc_patch = container.get_zplc_ver_patch();
+        let compiler_version = format!("{}.{}.{}", zplc_maj, zplc_min, zplc_patch);
+
+        // compress policy data with gzip
+        let mut gz_w = GzEncoder::new(Vec::new(), Compression::default());
+        gz_w.write_all(container_bytes)?;
+        let gz_bytes = gz_w.finish()?;
+
+        // encode the compressed data as base64
+        let container_b64 = BASE64_STANDARD.encode(&gz_bytes);
+
+        Ok(PolicyBundle {
+            config_id,
+            version: String::new(),
+            format: format!("base64;zip;{}", compiler_version),
+            container: container_b64,
+        })
+    }
+
+    /// Decode the `container` field of the [PolicyBundle] back into the original Cap'n Proto encoded
+    /// bytes of a `PolicyContainer` struct.
+    pub fn decode(&self) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        // check format:
+        let mut format_parts = self.format.split(';');
+        let encoding = format_parts
+            .next()
+            .ok_or("invalid format: missing encoding")?;
+        if encoding != "base64" {
+            return Err(format!("unsupported encoding: {encoding}").into());
+        }
+        let compression = format_parts
+            .next()
+            .ok_or("invalid format: missing compression")?;
+        if compression != "zip" {
+            return Err(format!("unsupported compression: {compression}").into());
+        }
+
+        // Don't care about compiler version (TODO: remove?) It is already in the container.
+
+        // decode base64
+        let gz_bytes = BASE64_STANDARD.decode(&self.container)?;
+
+        // decompress gzip
+        let mut gz_d = flate2::read::GzDecoder::new(&gz_bytes[..]);
+        let mut container_bytes = Vec::new();
+        gz_d.read_to_end(&mut container_bytes)?;
+
+        Ok(container_bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build the Cap'n Proto encoded bytes of a `PolicyContainer` with the given
+    /// compiler version and (arbitrary) policy payload, for use as test input.
+    fn make_container_bytes(maj: u32, min: u32, patch: u32, policy: &[u8]) -> Vec<u8> {
+        let mut msg = capnp::message::Builder::new_default();
+        {
+            let mut container = msg.init_root::<v1::policy_container::Builder>();
+            container.set_zplc_ver_major(maj);
+            container.set_zplc_ver_minor(min);
+            container.set_zplc_ver_patch(patch);
+            container.set_policy(policy);
+            container.set_signature(&[]);
+        }
+        let mut buf = Vec::new();
+        capnp::serialize::write_message(&mut buf, &msg).unwrap();
+        buf
+    }
+
+    /// new_from_policy_container should record the config id, an empty version,
+    /// and a format string carrying the compiler version parsed from the container.
+    #[test]
+    fn new_from_policy_container_sets_fields() {
+        let container = make_container_bytes(1, 2, 3, b"some-policy");
+        let bundle = PolicyBundle::new_from_policy_container(42, &container).unwrap();
+
+        assert_eq!(bundle.config_id, 42);
+        assert_eq!(bundle.version, "");
+        assert_eq!(bundle.format, "base64;zip;1.2.3");
+        assert!(!bundle.container.is_empty());
+    }
+
+    /// Encoding a container and decoding it back should reproduce the original bytes.
+    #[test]
+    fn encode_decode_round_trips() {
+        let container = make_container_bytes(0, 9, 17, b"round-trip-policy");
+        let bundle = PolicyBundle::new_from_policy_container(7, &container).unwrap();
+        let decoded = bundle.decode().unwrap();
+
+        assert_eq!(decoded, container);
+    }
+
+    /// new_from_policy_container should error on bytes that aren't a valid Cap'n Proto message.
+    #[test]
+    fn new_from_policy_container_rejects_garbage() {
+        let result = PolicyBundle::new_from_policy_container(0, b"not capnp");
+        assert!(result.is_err());
+    }
+
+    /// decode should reject a format whose encoding segment isn't "base64".
+    #[test]
+    fn decode_rejects_unsupported_encoding() {
+        let bundle = PolicyBundle {
+            config_id: 0,
+            version: String::new(),
+            format: "hex;zip;1.0.0".to_string(),
+            container: String::new(),
+        };
+        let err = bundle.decode().unwrap_err();
+        assert!(err.to_string().contains("unsupported encoding"));
+    }
+
+    /// decode should reject a format whose compression segment isn't "zip".
+    #[test]
+    fn decode_rejects_unsupported_compression() {
+        let bundle = PolicyBundle {
+            config_id: 0,
+            version: String::new(),
+            format: "base64;lz4;1.0.0".to_string(),
+            container: String::new(),
+        };
+        let err = bundle.decode().unwrap_err();
+        assert!(err.to_string().contains("unsupported compression"));
+    }
+
+    /// decode should fail when the container field isn't valid base64.
+    #[test]
+    fn decode_rejects_invalid_base64() {
+        let bundle = PolicyBundle {
+            config_id: 0,
+            version: String::new(),
+            format: "base64;zip;1.0.0".to_string(),
+            container: "!!!not base64!!!".to_string(),
+        };
+        assert!(bundle.decode().is_err());
+    }
+
+    /// Display should render all four fields with their labels.
+    #[test]
+    fn display_includes_all_fields() {
+        let bundle = PolicyBundle {
+            config_id: 99,
+            version: "v1".to_string(),
+            format: "base64;zip;1.2.3".to_string(),
+            container: "abc".to_string(),
+        };
+        let rendered = format!("{bundle}");
+        assert!(rendered.contains("99"));
+        assert!(rendered.contains("v1"));
+        assert!(rendered.contains("base64;zip;1.2.3"));
+        assert!(rendered.contains("abc"));
+    }
+}

--- a/libeval/src/attribute.rs
+++ b/libeval/src/attribute.rs
@@ -40,6 +40,9 @@ pub mod key {
 
     /// Policy install version when actor last authenticated/permitted.
     pub const VINST: &str = "zpr.vinst";
+
+    /// Link cost
+    pub const LINK_COST: &str = "link.zpr.cost";
 }
 
 #[derive(Debug, Error)]

--- a/libeval/src/pio.rs
+++ b/libeval/src/pio.rs
@@ -17,6 +17,10 @@ impl fmt::Display for Version {
     }
 }
 
+/// Returns the contained policy from the Cap'n Proto `PolicyContainer` struct.
+///
+/// `policy_container_bytes` - bytes of the Cap'n Proto `PolicyContainer` struct.
+/// `min_version` - minimum compiler version accepted. Note that the container includes the compiler version used to create it.
 pub fn load_policy_from_container(
     policy_container_bytes: &[u8],
     min_version: &Version,
@@ -53,37 +57,12 @@ pub fn load_policy_from_container(
 /// Load policy from file. Checks the version of the compiler against the passed
 /// minimum version.  This will not allow loading policies if the major version
 /// is not the same as specified in the minimum version.
+///
+/// `fpath` - path to policy container (bin2) file.
 pub fn load_policy(fpath: &Path, min_version: &Version) -> Result<Policy, PolicyError> {
     let encoded = std::fs::read(fpath)?;
     let encoded_container_bytes = Bytes::from(encoded);
-
-    let container_reader = capnp::serialize::read_message(
-        encoded_container_bytes.reader(),
-        capnp::message::ReaderOptions::new(),
-    )?;
-
-    let container = container_reader.get_root::<policy_capnp::policy_container::Reader>()?;
-
-    // Version check: container compiler major version must be >= min_version.major
-
-    let comp_version = Version(
-        container.get_zplc_ver_major(),
-        container.get_zplc_ver_minor(),
-        container.get_zplc_ver_patch(),
-    );
-
-    check_version(&comp_version, min_version)?;
-
-    if !container.has_policy() {
-        return Err(PolicyError::PolicyFileError(
-            "policy container missing policy data".to_string(),
-        ));
-    }
-
-    let policy_bytes = container.get_policy().unwrap();
-    let p = Policy::new_from_policy_bytes(Bytes::copy_from_slice(policy_bytes))?;
-    info!(target: PIO, "loaded policy created by compiler version {comp_version}");
-    Ok(p)
+    load_policy_from_container(&encoded_container_bytes, min_version)
 }
 
 /// Returns an error if the `found_version` is not compatible with the `min_version`.

--- a/libeval/src/pio.rs
+++ b/libeval/src/pio.rs
@@ -17,10 +17,43 @@ impl fmt::Display for Version {
     }
 }
 
+pub fn load_policy_from_container(
+    policy_container_bytes: &[u8],
+    min_version: &Version,
+) -> Result<Policy, PolicyError> {
+    let container_reader = capnp::serialize::read_message(
+        policy_container_bytes.reader(),
+        capnp::message::ReaderOptions::new(),
+    )?;
+
+    let container = container_reader.get_root::<policy_capnp::policy_container::Reader>()?;
+
+    // Version check: container compiler major version must be >= min_version.major
+
+    let comp_version = Version(
+        container.get_zplc_ver_major(),
+        container.get_zplc_ver_minor(),
+        container.get_zplc_ver_patch(),
+    );
+
+    check_version(&comp_version, &min_version)?;
+
+    if !container.has_policy() {
+        return Err(PolicyError::PolicyFileError(
+            "policy container missing policy data".to_string(),
+        ));
+    }
+
+    let policy_bytes = container.get_policy().unwrap();
+    let p = Policy::new_from_policy_bytes(Bytes::copy_from_slice(policy_bytes))?;
+    info!(target: PIO, "loaded policy created by compiler version {comp_version}");
+    Ok(p)
+}
+
 /// Load policy from file. Checks the version of the compiler against the passed
 /// minimum version.  This will not allow loading policies if the major version
 /// is not the same as specified in the minimum version.
-pub fn load_policy(fpath: &Path, min_version: Version) -> Result<Policy, PolicyError> {
+pub fn load_policy(fpath: &Path, min_version: &Version) -> Result<Policy, PolicyError> {
     let encoded = std::fs::read(fpath)?;
     let encoded_container_bytes = Bytes::from(encoded);
 
@@ -39,7 +72,7 @@ pub fn load_policy(fpath: &Path, min_version: Version) -> Result<Policy, PolicyE
         container.get_zplc_ver_patch(),
     );
 
-    check_version(&comp_version, &min_version)?;
+    check_version(&comp_version, min_version)?;
 
     if !container.has_policy() {
         return Err(PolicyError::PolicyFileError(

--- a/libeval/src/policy.rs
+++ b/libeval/src/policy.rs
@@ -161,6 +161,7 @@ impl Policy {
         self.policy_rdr.clone()
     }
 
+    /// Returns the serialized Cap'n Proto `Policy` struct that created this [Policy].
     pub fn get_serialized(&self) -> &Bytes {
         &self.serialized
     }
@@ -380,7 +381,7 @@ mod test {
     fn read_policy_from_test_file(filename: &str) -> Policy {
         let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
         let fpath = PathBuf::from(manifest_dir).join("test-data").join(filename);
-        load_policy(&fpath, MIN_COMPILER_VERSION).unwrap()
+        load_policy(&fpath, &MIN_COMPILER_VERSION).unwrap()
     }
 
     /// Build a Policy from a list of ZPL source strings by constructing a capnp

--- a/vs-admin/Cargo.toml
+++ b/vs-admin/Cargo.toml
@@ -12,7 +12,7 @@ clap.workspace = true
 clap_complete = { version = "4.5.57", optional = true}
 colored.workspace = true
 crossterm = "0.29.0"
-flate2 = "1.0.34"
+flate2.workspace = true
 futures-io = "0.3.31"
 reqwest = { workspace = true, features = ["json", "blocking"] }
 ratatui = "0.30.0"

--- a/vs-admin/src/executor.rs
+++ b/vs-admin/src/executor.rs
@@ -1,12 +1,8 @@
 //! "Executes" all the commands kicked off in main (except gui).
 
-use base64::prelude::*;
 use colored::Colorize;
-use flate2::Compression;
-use flate2::write::GzEncoder;
 use std::fs::File;
 use std::io::Read;
-use std::io::prelude::*;
 use std::path::Path;
 
 use admin_api_types::{ListEntry, PolicyBundle};
@@ -27,7 +23,6 @@ impl Executor {
     pub fn do_cmd_policies(
         &self,
         id: Option<u64>,
-        version: Option<String>,
         path: Option<String>,
         curr: bool,
     ) -> Result<(), Box<dyn std::error::Error>> {
@@ -35,10 +30,8 @@ impl Executor {
             Some(id) => self.get_policy(id)?,
             None => match curr {
                 true => self.get_curr_policy()?,
-                false => match (version, path) {
-                    (Some(version), Some(path)) => {
-                        self.install_policy(version.as_str(), Path::new(&path))?
-                    }
+                false => match path {
+                    Some(path) => self.install_policy(Path::new(&path))?,
                     _ => self.get_policies()?,
                 },
             },
@@ -143,47 +136,22 @@ impl Executor {
     // passed here through the API is only used to catch potential problems early. The
     // visa service will open the policy file and check the actual version itself.
     //
-    fn install_policy(
-        &self,
-        compiler_version: &str,
-        policy: &Path,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    fn install_policy(&self, policy: &Path) -> Result<(), Box<dyn std::error::Error>> {
         let mut policy_buf = Vec::new();
         File::open(policy)?.read_to_end(&mut policy_buf)?;
 
-        let raw_len = policy_buf.len();
-
-        // compress policy data with gzip
-        let mut gz_w = GzEncoder::new(Vec::new(), Compression::default());
-        gz_w.write_all(&policy_buf)?;
-        let gz_bytes = gz_w.finish()?;
-
-        let gz_len = gz_bytes.len();
-
-        // encode the compressed data as base64
-        let container = BASE64_STANDARD.encode(&gz_bytes);
-
-        println!(
-            "{}",
-            format!(
-                "sending policy: container size {} bytes (raw {} / {} compressed)",
-                container.len(),
-                raw_len,
-                gz_len
-            )
-            .magenta()
-        );
-
-        let bundle = PolicyBundle {
-            config_id: 0,
-            version: "".to_string(),
-            format: format!("base64;zip;{}", compiler_version),
-            container,
-        };
-
-        let entry: ListEntry = self.vs_cli.install_policy(&bundle)?;
-        println!("{entry}");
-        Ok(())
+        match PolicyBundle::new_from_policy_container(0, &policy_buf) {
+            Ok(pb) => {
+                println!("{}", "sending policy container".magenta());
+                let entry: ListEntry = self.vs_cli.install_policy(&pb)?;
+                println!("{entry}");
+                Ok(())
+            }
+            Err(e) => {
+                eprintln!("{} {}", "Error creating policy bundle:".red(), e);
+                return Err(e.into());
+            }
+        }
     }
 
     fn get_visas(&self) -> Result<(), Box<dyn std::error::Error>> {

--- a/vs-admin/src/main.rs
+++ b/vs-admin/src/main.rs
@@ -63,12 +63,7 @@ fn main() {
     let exec = Executor::new(args.svc_url.clone(), ca_cert.clone(), api_key.clone());
 
     match args.command {
-        Some(SubCmd::Policies {
-            id,
-            version,
-            path,
-            curr,
-        }) => exec.do_cmd_policies(id, version, path, curr),
+        Some(SubCmd::Policies { id, path, curr }) => exec.do_cmd_policies(id, path, curr),
 
         Some(SubCmd::Visas { id, revoke }) => exec.do_cmd_visas(id, revoke),
 

--- a/vs-admin/src/main_args.rs
+++ b/vs-admin/src/main_args.rs
@@ -32,9 +32,6 @@ pub enum SubCmd {
         /// See more information on a specific policy
         #[arg(long, short = 'i', conflicts_with_all = ["version", "path", "curr"])]
         id: Option<u64>,
-        /// Version number of compiled policy when installing a new policy. If version is provided, path must be as well
-        #[arg(long, short = 'v', requires = "path", conflicts_with_all = ["id", "curr"])]
-        version: Option<String>,
         /// Path to compiled policy when installing a new policy. If path is provided, version must be as well
         #[arg(long, short = 'p', requires = "version", conflicts_with_all = ["id", "curr"])]
         path: Option<String>,

--- a/vs-admin/src/main_args.rs
+++ b/vs-admin/src/main_args.rs
@@ -30,13 +30,13 @@ pub enum SubCmd {
     #[command()]
     Policies {
         /// See more information on a specific policy
-        #[arg(long, short = 'i', conflicts_with_all = ["version", "path", "curr"])]
+        #[arg(long, short = 'i', conflicts_with_all = ["path", "curr"])]
         id: Option<u64>,
         /// Path to compiled policy when installing a new policy. If path is provided, version must be as well
-        #[arg(long, short = 'p', requires = "version", conflicts_with_all = ["id", "curr"])]
+        #[arg(long, short = 'p', conflicts_with_all = ["id", "curr"])]
         path: Option<String>,
         /// See the current policy in the VS
-        #[arg(long, short = 'c', conflicts_with_all = ["version", "path", "id"])]
+        #[arg(long, short = 'c', conflicts_with_all = ["path", "id"])]
         curr: bool,
     },
 

--- a/vs/Cargo.toml
+++ b/vs/Cargo.toml
@@ -21,6 +21,7 @@ chrono.workspace = true
 clap.workspace = true
 dashmap = "6.1.0"
 enum-map = "2.7.3"
+flate2.workspace = true
 futures = "0.3.31"
 futures-util = "0.3.31"
 hex = "0.4.3"

--- a/vs/src/actor_mgr.rs
+++ b/vs/src/actor_mgr.rs
@@ -602,7 +602,7 @@ mod test {
     use crate::db::{ActorRepo, FakeDb, NodeRepo};
     use crate::test_helpers::{
         make_actor_defexp, make_actor_with_services_defexp, make_adapter_actor_defexp,
-        make_node_actor_defexp,
+        make_container_bytes, make_node_actor_defexp,
     };
 
     use bytes::Bytes;
@@ -610,6 +610,7 @@ mod test {
     use libeval::policy::Policy;
     use std::net::{IpAddr, SocketAddr};
     use std::sync::Arc;
+    use zpr::policy::v1 as capnp_policy;
     use zpr::policy_types::{JoinPolicy, PFlags, Service};
     use zpr::write_to::WriteTo;
 
@@ -620,10 +621,11 @@ mod test {
         ActorMgr::new(actor_repo, node_repo, Arc::new(Counters::default()))
     }
 
-    fn make_policy_with_services(services: Vec<Service>) -> Policy {
+    /// Returns `(Policy, container_bytes)`
+    fn make_policy_with_services(services: Vec<Service>) -> (Policy, Vec<u8>) {
         let mut msg = capnp::message::Builder::new_default();
         {
-            let mut policy_bldr = msg.init_root::<zpr::policy::v1::policy::Builder>();
+            let mut policy_bldr = msg.init_root::<capnp_policy::policy::Builder>();
             policy_bldr.set_created("2024-01-01T00:00:00Z");
             policy_bldr.set_version(1);
             policy_bldr.set_metadata("");
@@ -639,7 +641,18 @@ mod test {
         }
         let mut bytes = Vec::new();
         capnp::serialize::write_message(&mut bytes, &msg).unwrap();
-        Policy::new_from_policy_bytes(Bytes::copy_from_slice(&bytes)).unwrap()
+
+        let container = make_container_bytes(
+            config::POLICY_MIN_COMPILER_MAJOR,
+            config::POLICY_MIN_COMPILER_MINOR,
+            config::POLICY_MIN_COMPILER_PATCH,
+            &bytes,
+        );
+
+        (
+            Policy::new_from_policy_bytes(Bytes::copy_from_slice(&bytes)).unwrap(),
+            container,
+        )
     }
 
     #[tokio::test]
@@ -815,10 +828,14 @@ mod test {
             }],
             kind: ServiceType::Regular,
         };
-        let policy = make_policy_with_services(vec![auth_service, regular_service]);
+        let (_policy, container_bytes) =
+            make_policy_with_services(vec![auth_service, regular_service]);
 
         let asm = new_assembly_for_tests(None).await;
-        asm.policy_mgr.update_policy(policy).await.unwrap();
+        asm.policy_mgr
+            .update_policy_from_container_bytes(container_bytes)
+            .await
+            .unwrap();
         let asm = Arc::new(asm);
 
         let mut services = mgr.get_auth_services_list(asm).await.unwrap();
@@ -855,10 +872,13 @@ mod test {
             }],
             kind: ServiceType::Regular, // NOT an auth service
         };
-        let policy = make_policy_with_services(vec![regular_service]);
+        let (_policy, container_bytes) = make_policy_with_services(vec![regular_service]);
 
         let asm = new_assembly_for_tests(None).await;
-        asm.policy_mgr.update_policy(policy).await.unwrap();
+        asm.policy_mgr
+            .update_policy_from_container_bytes(container_bytes)
+            .await
+            .unwrap();
         let asm = Arc::new(asm);
 
         let services = mgr.get_auth_services_list(asm).await.unwrap();

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -1,11 +1,7 @@
 //! HTTPS admin service implementation.
-
 use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::Arc;
-
-use libeval::attribute::{Attribute, ROLE_NODE, key};
-use tracing::{debug, error, info, warn};
 
 use axum::{
     Extension,
@@ -27,12 +23,14 @@ use tower_service::Service;
 
 use zpr::vsapi_types::{DockPepType, KeyFormat, KeySet, Visa};
 
+use libeval::attribute::{Attribute, ROLE_NODE, key};
 use rustls::ServerConfig;
 use rustls::pki_types::PrivateKeyDer;
 use serde::Deserialize;
 use std::time::SystemTime;
 use tokio::net::TcpListener;
 use tokio_rustls::TlsAcceptor;
+use tracing::{debug, error, info, warn};
 
 use crate::admin_apikeys::Permission;
 use crate::apikey::ApiKey;
@@ -40,6 +38,7 @@ use crate::assembly::Assembly;
 use crate::counters::CounterType;
 use crate::db::Role;
 use crate::logging::targets::ADMIN;
+use crate::policy_mgr::DEFAULT_POLICY_ID;
 
 use admin_api_types::{
     ActorDescriptor, ApiAttribute, ApiKeyFormat, ApiKeySet, AuthRevokeDescriptor, CnEntry,
@@ -223,44 +222,110 @@ fn two_elem_list() -> impl IntoResponse {
     (StatusCode::OK, Json(vec![le0, le1])).into_response()
 }
 
-async fn get_policies() -> impl IntoResponse {
+/// TODO: Placeholder - Only returnd ID(0) which is for the current policy.
+async fn get_policies(
+    Extension(perm): Extension<Permission>,
+) -> Result<Json<ListEntry>, StatusCode> {
+    if !perm.can_read() {
+        return Err(StatusCode::FORBIDDEN);
+    }
     debug!(target: ADMIN, "GET /admin/policies");
-    two_elem_list()
-}
-
-async fn get_policy(EPath(id): EPath<String>) -> impl IntoResponse {
-    debug!(target: ADMIN, "GET /admin/policies/{}", id);
-    let pb = PolicyBundle {
-        config_id: 0,
-        version: "v".to_string(),
-        format: "f".to_string(),
-        container: "c".to_string(),
+    let le = ListEntry {
+        id: DEFAULT_POLICY_ID,
     };
-
-    (StatusCode::OK, Json(pb)).into_response()
+    Ok(Json(le))
 }
 
-async fn get_curr_policy() -> impl IntoResponse {
+/// TODO: Handle multiple policis. Right now only accepts ID(0).
+async fn get_policy(
+    Extension(perm): Extension<Permission>,
+    State(state): State<SharedState>,
+    EPath(id): EPath<u64>,
+) -> Result<Json<PolicyBundle>, StatusCode> {
+    if !perm.can_read() {
+        return Err(StatusCode::FORBIDDEN);
+    }
+    debug!(target: ADMIN, "GET /admin/policies/{id}");
+    get_policy_by_id(&state.read().await.asm, id).await
+}
+
+async fn get_curr_policy(
+    Extension(perm): Extension<Permission>,
+    State(state): State<SharedState>,
+) -> Result<Json<PolicyBundle>, StatusCode> {
+    if !perm.can_read() {
+        return Err(StatusCode::FORBIDDEN);
+    }
     debug!(target: ADMIN, "GET /admin/policies/curr");
-    let pb = PolicyBundle {
-        config_id: 0,
-        version: "v".to_string(),
-        format: "f".to_string(),
-        container: "c".to_string(),
-    };
-
-    (StatusCode::OK, Json(pb)).into_response()
+    get_policy_by_id(&state.read().await.asm, DEFAULT_POLICY_ID).await
 }
 
-async fn install_policy(EJson(_body): EJson<PolicyBundle>) -> impl IntoResponse {
+/// Helper function used by [get_policy] and [get_curr_policy].
+async fn get_policy_by_id(asm: &Assembly, id: u64) -> Result<Json<PolicyBundle>, StatusCode> {
+    if id != DEFAULT_POLICY_ID {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    let bundle = {
+        let pmgr = &asm.policy_mgr;
+        let current = pmgr.get_current();
+        if let Some(container_bytes) = pmgr.get_container_for_policy(current.vinst()) {
+            match PolicyBundle::new_from_policy_container(0, &container_bytes) {
+                Ok(pb) => pb,
+                Err(e) => {
+                    error!(target: ADMIN, "error creating policy bundle for policy {id}: {}", e);
+                    return Err(StatusCode::INTERNAL_SERVER_ERROR);
+                }
+            }
+        } else {
+            error!(target: ADMIN, "policy container not found for policy {id}");
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    };
+    Ok(Json(bundle))
+}
+
+async fn install_policy(
+    Extension(perm): Extension<Permission>,
+    State(state): State<SharedState>,
+    EJson(body): EJson<PolicyBundle>,
+) -> Result<Json<ListEntry>, StatusCode> {
+    if !perm.can_write() {
+        return Err(StatusCode::FORBIDDEN);
+    }
     debug!(target: ADMIN, "POST /admin/policies");
-    let le = ListEntry { id: 0 };
-    (StatusCode::OK, Json(le)).into_response()
+
+    let container_bytes = body.decode().map_err(|e| {
+        error!(target: ADMIN, "error decoding policy bundle: {}", e);
+        StatusCode::BAD_REQUEST
+    })?;
+
+    let rstate = state.read().await;
+    match rstate
+        .asm
+        .policy_mgr
+        .update_policy_from_container_bytes(container_bytes)
+        .await
+    {
+        Ok(vinst) => debug!(target: ADMIN, "policy updated successfully, new vinst={vinst}"),
+        Err(e) => {
+            error!(target: ADMIN, "failed to update policy: {}", e);
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    };
+    drop(rstate);
+
+    // what do we use as the policy identifier?
+    // In the future maybe it will be possible to add policies to system without activating them.
+    // In delegating model we mave have several policies installed for different domains.
+    // For now we punt on this and just use identifier 0.
+    let le = ListEntry {
+        id: DEFAULT_POLICY_ID,
+    };
+    Ok(Json(le))
 }
 
 /// Returns a list of visa IDs in ListEntry structs or empty list.
-#[axum::debug_handler]
-//async fn get_visas(State(state): State<SharedState>) -> impl IntoResponse {
 async fn get_visas(
     Extension(perm): Extension<Permission>,
     State(state): State<SharedState>,

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -846,11 +846,17 @@ mod tests {
     /// Insert a readwrite test key into the assembly's key store and return the
     /// key string to use in the X-API-Key header.
     fn setup_test_api_key(asm: &Arc<Assembly>) -> String {
+        setup_test_api_key_with_perm(asm, Permission::ReadWrite)
+    }
+
+    /// Insert a test key with the given permission into the assembly's key store
+    /// and return the key string to use in the X-API-Key header.
+    fn setup_test_api_key_with_perm(asm: &Arc<Assembly>, permission: Permission) -> String {
         let secret_bytes: [u8; 32] = (0u8..32).collect::<Vec<_>>().try_into().unwrap();
         let apikey = ApiKey::new(0xaabbccdd, secret_bytes);
         let record = ApiKeyRecord {
             owner: "test".to_string(),
-            permission: Permission::ReadWrite,
+            permission,
             status: KeyStatus::Active,
             created: "2026-01-01".to_string(),
             secret_hash: apikey.secret_hash().unwrap(),
@@ -859,6 +865,233 @@ mod tests {
         asm.admin_api_keys
             .insert_for_test(apikey.key_id_hex(), record);
         apikey.to_key_string()
+    }
+
+    /// Build a valid `PolicyBundle` carrying a minimal policy (no topology, so the
+    /// FakeResolver in the test assembly resolves it cleanly) at the minimum
+    /// supported compiler version, for use as `install_policy` request input.
+    fn make_valid_policy_bundle() -> PolicyBundle {
+        let mut msg = capnp::message::Builder::new_default();
+        {
+            let mut policy = msg.init_root::<zpr::policy::v1::policy::Builder>();
+            policy.set_created("2026-01-01T00:00:00Z");
+            policy.set_version(1);
+            policy.set_metadata("");
+        }
+        let mut inner = Vec::new();
+        capnp::serialize::write_message(&mut inner, &msg).unwrap();
+        let container = crate::test_helpers::make_container_bytes(
+            crate::config::POLICY_MIN_COMPILER_MAJOR,
+            crate::config::POLICY_MIN_COMPILER_MINOR,
+            crate::config::POLICY_MIN_COMPILER_PATCH,
+            &inner,
+        );
+        PolicyBundle::new_from_policy_container(0, &container).unwrap()
+    }
+
+    /// GET /admin/policies returns the single current policy id (0) with a read key.
+    #[tokio::test]
+    async fn test_get_policies_ok() {
+        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let api_key = setup_test_api_key(&asm);
+        let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
+        let app = admin_app(shared_state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/admin/policies")
+                    .header("X-API-Key", &api_key)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let entry: ListEntry = serde_json::from_slice(&body).unwrap();
+        assert_eq!(entry.id, DEFAULT_POLICY_ID);
+    }
+
+    /// GET /admin/policies/curr returns the current policy as a base64;zip PolicyBundle.
+    #[tokio::test]
+    async fn test_get_curr_policy_ok() {
+        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let api_key = setup_test_api_key(&asm);
+        let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
+        let app = admin_app(shared_state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/admin/policies/curr")
+                    .header("X-API-Key", &api_key)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let bundle: PolicyBundle = serde_json::from_slice(&body).unwrap();
+        assert_eq!(bundle.config_id, DEFAULT_POLICY_ID);
+        assert!(bundle.format.starts_with("base64;zip;"));
+        assert!(!bundle.container.is_empty());
+    }
+
+    /// GET /admin/policies/0 returns the current policy bundle (id 0 is the default).
+    #[tokio::test]
+    async fn test_get_policy_by_id_zero_ok() {
+        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let api_key = setup_test_api_key(&asm);
+        let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
+        let app = admin_app(shared_state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/admin/policies/0")
+                    .header("X-API-Key", &api_key)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let bundle: PolicyBundle = serde_json::from_slice(&body).unwrap();
+        assert!(bundle.format.starts_with("base64;zip;"));
+    }
+
+    /// GET /admin/policies/<non-zero> is rejected because only id 0 currently exists.
+    #[tokio::test]
+    async fn test_get_policy_not_found() {
+        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let api_key = setup_test_api_key(&asm);
+        let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
+        let app = admin_app(shared_state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/admin/policies/1")
+                    .header("X-API-Key", &api_key)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// POST /admin/policies installs a valid bundle and the new policy is then
+    /// served by GET /admin/policies/curr.
+    #[tokio::test]
+    async fn test_install_policy_ok() {
+        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let api_key = setup_test_api_key(&asm);
+        let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
+
+        let bundle = make_valid_policy_bundle();
+        let body = serde_json::to_vec(&bundle).unwrap();
+
+        let app = admin_app(shared_state.clone());
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/admin/policies")
+                    .header("X-API-Key", &api_key)
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let entry: ListEntry = serde_json::from_slice(&body).unwrap();
+        assert_eq!(entry.id, DEFAULT_POLICY_ID);
+
+        // The installed policy should now be the current one.
+        let app = admin_app(shared_state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/admin/policies/curr")
+                    .header("X-API-Key", &api_key)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let curr: PolicyBundle = serde_json::from_slice(&body).unwrap();
+        assert_eq!(curr.decode().unwrap(), bundle.decode().unwrap());
+    }
+
+    /// POST /admin/policies rejects a bundle whose container can't be decoded.
+    #[tokio::test]
+    async fn test_install_policy_bad_bundle() {
+        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let api_key = setup_test_api_key(&asm);
+        let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
+
+        // Valid JSON shape, but an unsupported format makes decode() fail.
+        let bad = PolicyBundle {
+            config_id: 0,
+            version: String::new(),
+            format: "hex;zip;0.11.1".to_string(),
+            container: String::new(),
+        };
+        let body = serde_json::to_vec(&bad).unwrap();
+
+        let app = admin_app(shared_state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/admin/policies")
+                    .header("X-API-Key", &api_key)
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    /// POST /admin/policies is forbidden for a read-only key (no write permission).
+    #[tokio::test]
+    async fn test_install_policy_forbidden_without_write() {
+        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let api_key = setup_test_api_key_with_perm(&asm, Permission::Read);
+        let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
+
+        let bundle = make_valid_policy_bundle();
+        let body = serde_json::to_vec(&bundle).unwrap();
+
+        let app = admin_app(shared_state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/admin/policies")
+                    .header("X-API-Key", &api_key)
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
 
     #[tokio::test]

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -845,8 +845,12 @@ mod tests {
 
     /// Insert a readwrite test key into the assembly's key store and return the
     /// key string to use in the X-API-Key header.
-    fn setup_test_api_key(asm: &Arc<Assembly>) -> String {
+    fn setup_test_api_rw_key(asm: &Arc<Assembly>) -> String {
         setup_test_api_key_with_perm(asm, Permission::ReadWrite)
+    }
+
+    fn setup_test_api_r_key(asm: &Arc<Assembly>) -> String {
+        setup_test_api_key_with_perm(asm, Permission::Read)
     }
 
     /// Insert a test key with the given permission into the assembly's key store
@@ -893,7 +897,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_policies_ok() {
         let asm = Arc::new(new_assembly_for_tests(None).await);
-        let api_key = setup_test_api_key(&asm);
+        let api_key = setup_test_api_r_key(&asm);
         let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
         let app = admin_app(shared_state);
         let response = app
@@ -918,7 +922,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_curr_policy_ok() {
         let asm = Arc::new(new_assembly_for_tests(None).await);
-        let api_key = setup_test_api_key(&asm);
+        let api_key = setup_test_api_r_key(&asm);
         let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
         let app = admin_app(shared_state);
         let response = app
@@ -945,7 +949,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_policy_by_id_zero_ok() {
         let asm = Arc::new(new_assembly_for_tests(None).await);
-        let api_key = setup_test_api_key(&asm);
+        let api_key = setup_test_api_r_key(&asm);
         let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
         let app = admin_app(shared_state);
         let response = app
@@ -970,7 +974,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_policy_not_found() {
         let asm = Arc::new(new_assembly_for_tests(None).await);
-        let api_key = setup_test_api_key(&asm);
+        let api_key = setup_test_api_r_key(&asm);
         let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
         let app = admin_app(shared_state);
         let response = app
@@ -992,7 +996,7 @@ mod tests {
     #[tokio::test]
     async fn test_install_policy_ok() {
         let asm = Arc::new(new_assembly_for_tests(None).await);
-        let api_key = setup_test_api_key(&asm);
+        let api_key = setup_test_api_rw_key(&asm);
         let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
 
         let bundle = make_valid_policy_bundle();
@@ -1040,7 +1044,7 @@ mod tests {
     #[tokio::test]
     async fn test_install_policy_bad_bundle() {
         let asm = Arc::new(new_assembly_for_tests(None).await);
-        let api_key = setup_test_api_key(&asm);
+        let api_key = setup_test_api_rw_key(&asm);
         let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
 
         // Valid JSON shape, but an unsupported format makes decode() fail.
@@ -1072,7 +1076,7 @@ mod tests {
     #[tokio::test]
     async fn test_install_policy_forbidden_without_write() {
         let asm = Arc::new(new_assembly_for_tests(None).await);
-        let api_key = setup_test_api_key_with_perm(&asm, Permission::Read);
+        let api_key = setup_test_api_r_key(&asm);
         let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
 
         let bundle = make_valid_policy_bundle();
@@ -1097,7 +1101,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_visas_no_visas() {
         let asm = Arc::new(new_assembly_for_tests(None).await);
-        let api_key = setup_test_api_key(&asm);
+        let api_key = setup_test_api_r_key(&asm);
         let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
         let app = admin_app(shared_state);
         let response = app
@@ -1122,7 +1126,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_visas_one_visa() {
         let asm = Arc::new(new_assembly_for_tests(None).await);
-        let api_key = setup_test_api_key(&asm);
+        let api_key = setup_test_api_r_key(&asm);
 
         let node_addr: IpAddr = "fd5a:5052:90de::1".parse().unwrap();
         let pdesc =
@@ -1166,7 +1170,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_visas_three_visas() {
         let asm = Arc::new(new_assembly_for_tests(None).await);
-        let api_key = setup_test_api_key(&asm);
+        let api_key = setup_test_api_r_key(&asm);
 
         let node_addr: IpAddr = "fd5a:5052:90de::1".parse().unwrap();
         let hit = Hit::new_no_signal(0, Direction::Forward);
@@ -1228,7 +1232,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_actors_no_actors() {
         let asm = Arc::new(new_assembly_for_tests(None).await);
-        let api_key = setup_test_api_key(&asm);
+        let api_key = setup_test_api_r_key(&asm);
         let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
         let app = admin_app(shared_state);
         let response = app
@@ -1253,7 +1257,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_actors_one_actor() {
         let asm = Arc::new(new_assembly_for_tests(None).await);
-        let api_key = setup_test_api_key(&asm);
+        let api_key = setup_test_api_r_key(&asm);
         let actor = make_node_actor_defexp("fd5a:5052::10", "node-1", "[fd5a:5052::100]:1234");
         asm.actor_mgr.add_node(&actor, false).await.unwrap();
 
@@ -1282,7 +1286,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_actors_multiple_actors() {
         let asm = Arc::new(new_assembly_for_tests(None).await);
-        let api_key = setup_test_api_key(&asm);
+        let api_key = setup_test_api_r_key(&asm);
         let actor0 = make_node_actor_defexp("fd5a:5052::11", "node-1", "[fd5a:5052::101]:1234");
         let actor1 = make_node_actor_defexp("fd5a:5052::12", "node-2", "[fd5a:5052::102]:1234");
         let actor2 = make_node_actor_defexp("fd5a:5052::13", "node-3", "[fd5a:5052::103]:1234");
@@ -1325,7 +1329,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_actors_role_filter() {
         let asm = Arc::new(new_assembly_for_tests(None).await);
-        let api_key = setup_test_api_key(&asm);
+        let api_key = setup_test_api_r_key(&asm);
         let node_actor = make_node_actor_defexp("fd5a:5052::20", "node-1", "[fd5a:5052::120]:1234");
         let adapter_actor = make_adapter_actor_defexp("fd5a:5052::21", "adapter-1");
 
@@ -1389,7 +1393,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_visa_not_found() {
         let asm = Arc::new(new_assembly_for_tests(None).await);
-        let api_key = setup_test_api_key(&asm);
+        let api_key = setup_test_api_r_key(&asm);
         let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
         let app = admin_app(shared_state);
         let response = app
@@ -1409,7 +1413,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_visa_fields_forward_no_signal() {
         let asm = Arc::new(new_assembly_for_tests(None).await);
-        let api_key = setup_test_api_key(&asm);
+        let api_key = setup_test_api_r_key(&asm);
 
         let node_addr: IpAddr = "fd5a:5052:90de::1".parse().unwrap();
         let pdesc =
@@ -1465,7 +1469,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_visa_direction_reverse() {
         let asm = Arc::new(new_assembly_for_tests(None).await);
-        let api_key = setup_test_api_key(&asm);
+        let api_key = setup_test_api_r_key(&asm);
 
         let node_addr: IpAddr = "fd5a:5052:90de::1".parse().unwrap();
         let pdesc =
@@ -1505,7 +1509,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_visa_with_signal() {
         let asm = Arc::new(new_assembly_for_tests(None).await);
-        let api_key = setup_test_api_key(&asm);
+        let api_key = setup_test_api_r_key(&asm);
 
         let node_addr: IpAddr = "fd5a:5052:90de::1".parse().unwrap();
         let pdesc =
@@ -1546,7 +1550,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_actors_invalid_role_filter() {
         let asm = Arc::new(new_assembly_for_tests(None).await);
-        let api_key = setup_test_api_key(&asm);
+        let api_key = setup_test_api_r_key(&asm);
         let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
         let app = admin_app(shared_state);
 
@@ -1568,7 +1572,7 @@ mod tests {
     async fn test_get_network_empty() {
         // No nodes
         let asm = Arc::new(new_assembly_for_tests(None).await);
-        let api_key = setup_test_api_key(&asm);
+        let api_key = setup_test_api_r_key(&asm);
         let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
         let app = admin_app(shared_state);
 
@@ -1594,7 +1598,7 @@ mod tests {
     async fn test_get_network_one_node_no_peers() {
         // One node with no links
         let asm = Arc::new(new_assembly_for_tests(None).await);
-        let api_key = setup_test_api_key(&asm);
+        let api_key = setup_test_api_r_key(&asm);
 
         let addr: IpAddr = "fd5a:5052::10".parse().unwrap();
         let actor = make_node_actor_defexp("fd5a:5052::10", "node-a", "[fd5a:5052::100]:1234");
@@ -1630,7 +1634,7 @@ mod tests {
         use libeval::route::LinkId;
 
         let asm = Arc::new(new_assembly_for_tests(None).await);
-        let api_key = setup_test_api_key(&asm);
+        let api_key = setup_test_api_r_key(&asm);
 
         let addr_a: IpAddr = "fd5a:5052::10".parse().unwrap();
         let addr_b: IpAddr = "fd5a:5052::11".parse().unwrap();

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -268,18 +268,13 @@ async fn get_policy_by_id(asm: &Assembly, id: u64) -> Result<Json<PolicyBundle>,
 
     let bundle = {
         let pmgr = &asm.policy_mgr;
-        let current = pmgr.get_current();
-        if let Some(container_bytes) = pmgr.get_container_for_policy(current.vinst()) {
-            match PolicyBundle::new_from_policy_container(0, &container_bytes) {
-                Ok(pb) => pb,
-                Err(e) => {
-                    error!(target: ADMIN, "error creating policy bundle for policy {id}: {}", e);
-                    return Err(StatusCode::INTERNAL_SERVER_ERROR);
-                }
+        let container = pmgr.get_current_container();
+        match PolicyBundle::new_from_policy_container(0, container.as_bytes()) {
+            Ok(pb) => pb,
+            Err(e) => {
+                error!(target: ADMIN, "error creating policy bundle for policy {id}: {}", e);
+                return Err(StatusCode::INTERNAL_SERVER_ERROR);
             }
-        } else {
-            error!(target: ADMIN, "policy container not found for policy {id}");
-            return Err(StatusCode::INTERNAL_SERVER_ERROR);
         }
     };
     Ok(Json(bundle))

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -223,7 +223,7 @@ fn two_elem_list() -> impl IntoResponse {
     (StatusCode::OK, Json(vec![le0, le1])).into_response()
 }
 
-/// TODO: Placeholder - Only returnd ID(0) which is for the current policy.
+/// TODO: Placeholder - Only returns ID(0) which is for the current policy.
 async fn get_policies(
     Extension(perm): Extension<Permission>,
 ) -> Result<Json<ListEntry>, StatusCode> {
@@ -237,7 +237,7 @@ async fn get_policies(
     Ok(Json(le))
 }
 
-/// TODO: Handle multiple policis. Right now only accepts ID(0).
+/// TODO: Handle multiple policies. Right now only accepts ID(0).
 async fn get_policy(
     Extension(perm): Extension<Permission>,
     State(state): State<SharedState>,

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -37,6 +37,7 @@ use crate::apikey::ApiKey;
 use crate::assembly::Assembly;
 use crate::counters::CounterType;
 use crate::db::Role;
+use crate::event_mgr::VsEvent;
 use crate::logging::targets::ADMIN;
 use crate::policy_mgr::DEFAULT_POLICY_ID;
 
@@ -302,7 +303,14 @@ async fn install_policy(
         .update_policy_from_container_bytes(container_bytes)
         .await
     {
-        Ok(vinst) => debug!(target: ADMIN, "policy updated successfully, new vinst={vinst}"),
+        Ok(vinst) => {
+            info!(target: ADMIN, "policy updated successfully, new vinst={vinst}");
+            // fire event!
+            let evt = VsEvent::PolicyUpdated(vinst);
+            if let Err(e) = rstate.asm.event_mgr.record_event(evt).await {
+                warn!(target: ADMIN, "failed to record policy updated event: {}", e);
+            }
+        }
         Err(e) => {
             error!(target: ADMIN, "failed to update policy: {}", e);
             return Err(StatusCode::INTERNAL_SERVER_ERROR);

--- a/vs/src/assembly.rs
+++ b/vs/src/assembly.rs
@@ -53,20 +53,20 @@ pub mod tests {
     use super::*;
 
     use crate::actor_mgr::ActorMgr;
+    use crate::config;
     use crate::connection_control::ConnectionControl;
     use crate::db::FakeDb;
     use crate::db::{ActorRepo, NodeRepo, PolicyRepo, VisaRepo};
     use crate::policy_mgr::PolicyMgr;
     use crate::test_helpers::FakeResolver;
+    use crate::test_helpers::make_container_bytes;
     use crate::visa_mgr::VisaMgr;
     use crate::visareq_worker::VisaRequestJob;
     use crate::vss_mgr::VssMgr;
 
-    use bytes::Bytes;
-    use libeval::policy::Policy;
     use zpr::policy::v1;
 
-    fn make_policy(created: &str, version: u64, metadata: Option<&str>) -> Policy {
+    fn make_policy(created: &str, version: u64, metadata: Option<&str>) -> Vec<u8> {
         let mut msg = capnp::message::Builder::new_default();
         {
             let mut policy_bldr = msg.init_root::<v1::policy::Builder>();
@@ -80,7 +80,12 @@ pub mod tests {
         }
         let mut bytes = Vec::new();
         capnp::serialize::write_message(&mut bytes, &msg).unwrap();
-        Policy::new_from_policy_bytes(Bytes::copy_from_slice(&bytes)).unwrap()
+        make_container_bytes(
+            config::POLICY_MIN_COMPILER_MAJOR,
+            config::POLICY_MIN_COMPILER_MINOR,
+            config::POLICY_MIN_COMPILER_PATCH,
+            &bytes,
+        )
     }
 
     pub async fn new_assembly_for_tests(
@@ -96,7 +101,7 @@ pub mod tests {
         let db_handle = Arc::new(FakeDb::new());
 
         let policy_repo = PolicyRepo::new(db_handle.clone());
-        let initial_policy = make_policy("2024-01-01T00:00:00Z", 1, Some("meta"));
+        let policy_container_bytes = make_policy("2024-01-01T00:00:00Z", 1, Some("meta"));
 
         let actor_repo = ActorRepo::new(db_handle.clone());
         let node_repo = NodeRepo::new(db_handle.clone());
@@ -113,7 +118,7 @@ pub mod tests {
             system_start_time: std::time::Instant::now(),
             cc: ConnectionControl::new("vs_ident".to_string()),
             policy_mgr: PolicyMgr::new_with_initial_policy(
-                initial_policy,
+                policy_container_bytes,
                 policy_repo,
                 Arc::new(FakeResolver::ip_only()),
             )

--- a/vs/src/config.rs
+++ b/vs/src/config.rs
@@ -31,13 +31,12 @@ pub const POLICY_MIN_COMPILER_MINOR: u32 = 11;
 pub const POLICY_MIN_COMPILER_PATCH: u32 = 1;
 
 /// Minimum policy compiler version this build will load.
-pub fn policy_min_version() -> libeval::pio::Version {
-    libeval::pio::Version(
-        POLICY_MIN_COMPILER_MAJOR,
-        POLICY_MIN_COMPILER_MINOR,
-        POLICY_MIN_COMPILER_PATCH,
-    )
-}
+
+pub const POLICY_MIN_VERSION: libeval::pio::Version = libeval::pio::Version(
+    POLICY_MIN_COMPILER_MAJOR,
+    POLICY_MIN_COMPILER_MINOR,
+    POLICY_MIN_COMPILER_PATCH,
+);
 
 /// Default VSAPI port - must be in sync with compiler since it adds policy for that.
 pub const VSAPI_PORT: u16 = 5002;
@@ -169,24 +168,6 @@ impl VSConfig {
     }
 }
 
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_override_one_field_deserialize() {
-        let cfg: VSConfig = toml::from_str(
-            r#"
-        [core]
-        vsapi_port = 9999
-        "#,
-        )
-        .unwrap();
-        assert_eq!(cfg.core.vk_uri, Some(VALKEY_URI.to_string()));
-        assert_eq!(cfg.core.vsapi_port, Some(9999));
-    }
-}
-
 // Return the path to the data home directory.
 pub fn get_data_home() -> PathBuf {
     let mut dh = match env::var("XDG_DATA_HOME") {
@@ -207,4 +188,22 @@ pub fn get_data_home() -> PathBuf {
     };
     dh.push("zpr");
     dh
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_override_one_field_deserialize() {
+        let cfg: VSConfig = toml::from_str(
+            r#"
+        [core]
+        vsapi_port = 9999
+        "#,
+        )
+        .unwrap();
+        assert_eq!(cfg.core.vk_uri, Some(VALKEY_URI.to_string()));
+        assert_eq!(cfg.core.vsapi_port, Some(9999));
+    }
 }

--- a/vs/src/config.rs
+++ b/vs/src/config.rs
@@ -30,6 +30,15 @@ pub const POLICY_MIN_COMPILER_MAJOR: u32 = 0;
 pub const POLICY_MIN_COMPILER_MINOR: u32 = 11;
 pub const POLICY_MIN_COMPILER_PATCH: u32 = 1;
 
+/// Minimum policy compiler version this build will load.
+pub fn policy_min_version() -> libeval::pio::Version {
+    libeval::pio::Version(
+        POLICY_MIN_COMPILER_MAJOR,
+        POLICY_MIN_COMPILER_MINOR,
+        POLICY_MIN_COMPILER_PATCH,
+    )
+}
+
 /// Default VSAPI port - must be in sync with compiler since it adds policy for that.
 pub const VSAPI_PORT: u16 = 5002;
 

--- a/vs/src/connection_control.rs
+++ b/vs/src/connection_control.rs
@@ -734,7 +734,7 @@ mod tests {
         let (_privkey, pubkey_der) = gen_rsa_test_keypair();
         let container_bytes = make_policy_with_bootstrap_key(cn, &pubkey_der);
 
-        pio::load_policy_from_container(&container_bytes, &config::policy_min_version())
+        pio::load_policy_from_container(&container_bytes, &config::POLICY_MIN_VERSION)
             .expect("should load policy from container bytes");
     }
 

--- a/vs/src/connection_control.rs
+++ b/vs/src/connection_control.rs
@@ -572,7 +572,8 @@ fn scrub_adapter_claims(claims: Vec<Claim>) -> Result<Vec<Attribute>, ServiceErr
 mod tests {
     use super::*;
 
-    use bytes::Bytes;
+    use crate::test_helpers::make_container_bytes;
+    use libeval::pio;
     use openssl::hash::MessageDigest;
     use openssl::pkey::{PKey, Private};
     use openssl::rsa::Rsa;
@@ -694,7 +695,8 @@ mod tests {
         signer.sign_to_vec().unwrap()
     }
 
-    fn make_policy_with_bootstrap_key(cn: &str, pubkey_der: &[u8]) -> libeval::policy::Policy {
+    /// Returns container bytes for Capn Proto `PolicyContainer`
+    fn make_policy_with_bootstrap_key(cn: &str, pubkey_der: &[u8]) -> Vec<u8> {
         let mut msg = capnp::message::Builder::new_default();
         {
             let mut policy_bldr = msg.init_root::<v1::policy::Builder>();
@@ -714,10 +716,27 @@ mod tests {
         }
         let mut bytes: Vec<u8> = Vec::new();
         capnp::serialize::write_message(&mut bytes, &msg).unwrap();
-        libeval::policy::Policy::new_from_policy_bytes(Bytes::copy_from_slice(&bytes)).unwrap()
+        let container = make_container_bytes(
+            config::POLICY_MIN_COMPILER_MAJOR,
+            config::POLICY_MIN_COMPILER_MINOR,
+            config::POLICY_MIN_COMPILER_PATCH,
+            &bytes,
+        );
+        container
     }
 
     // --- authenticate_node tests ---
+
+    #[tokio::test]
+    async fn test_make_policy_with_bootstrap_key() {
+        // Make sure our helper serializes Capn Proto properly.
+        let cn = "test-node.zpr";
+        let (_privkey, pubkey_der) = gen_rsa_test_keypair();
+        let container_bytes = make_policy_with_bootstrap_key(cn, &pubkey_der);
+
+        pio::load_policy_from_container(&container_bytes, &config::policy_min_version())
+            .expect("should load policy from container bytes");
+    }
 
     #[tokio::test]
     async fn authenticate_node_unknown_cn() {
@@ -742,10 +761,15 @@ mod tests {
         let asm = Arc::new(crate::assembly::tests::new_assembly_for_tests(None).await);
         let cn = "test-node.zpr";
         let (_, pubkey_der) = gen_rsa_test_keypair();
-        asm.policy_mgr
-            .update_policy(make_policy_with_bootstrap_key(cn, &pubkey_der))
+        match asm
+            .policy_mgr
+            .update_policy_from_container_bytes(make_policy_with_bootstrap_key(cn, &pubkey_der))
             .await
-            .unwrap();
+        {
+            Ok(_vinst) => (),
+            Err(e) => panic!("failed to update policy for test: {}", e),
+        }
+
         let cc = make_cc("test-vs");
         let result = cc
             .authenticate_node(
@@ -767,7 +791,7 @@ mod tests {
         let cn = "test-node.zpr";
         let (privkey, pubkey_der) = gen_rsa_test_keypair();
         asm.policy_mgr
-            .update_policy(make_policy_with_bootstrap_key(cn, &pubkey_der))
+            .update_policy_from_container_bytes(make_policy_with_bootstrap_key(cn, &pubkey_der))
             .await
             .unwrap();
         let cc = make_cc("test-vs");
@@ -788,7 +812,7 @@ mod tests {
         assert!(matches!(result, Err(ServiceError::AuthenticationFailed(_))));
     }
 
-    fn make_policy_with_node_join_policy(cn: &str, pubkey_der: &[u8]) -> libeval::policy::Policy {
+    fn make_policy_with_node_join_policy(cn: &str, pubkey_der: &[u8]) -> Vec<u8> {
         let mut msg = capnp::message::Builder::new_default();
         {
             let mut policy_bldr = msg.init_root::<v1::policy::Builder>();
@@ -818,7 +842,12 @@ mod tests {
         }
         let mut bytes: Vec<u8> = Vec::new();
         capnp::serialize::write_message(&mut bytes, &msg).unwrap();
-        libeval::policy::Policy::new_from_policy_bytes(Bytes::copy_from_slice(&bytes)).unwrap()
+        make_container_bytes(
+            config::POLICY_MIN_COMPILER_MAJOR,
+            config::POLICY_MIN_COMPILER_MINOR,
+            config::POLICY_MIN_COMPILER_PATCH,
+            &bytes,
+        )
     }
 
     #[tokio::test]
@@ -827,7 +856,7 @@ mod tests {
         let cn = "test-node.zpr";
         let (privkey, pubkey_der) = gen_rsa_test_keypair();
         asm.policy_mgr
-            .update_policy(make_policy_with_bootstrap_key(cn, &pubkey_der))
+            .update_policy_from_container_bytes(make_policy_with_bootstrap_key(cn, &pubkey_der))
             .await
             .unwrap();
         let cc = make_cc("test-vs");
@@ -854,7 +883,7 @@ mod tests {
         let cn = "test-node.zpr";
         let (privkey, pubkey_der) = gen_rsa_test_keypair();
         asm.policy_mgr
-            .update_policy(make_policy_with_node_join_policy(cn, &pubkey_der))
+            .update_policy_from_container_bytes(make_policy_with_node_join_policy(cn, &pubkey_der))
             .await
             .unwrap();
         let cc = make_cc("test-vs");

--- a/vs/src/db/db_fake.rs
+++ b/vs/src/db/db_fake.rs
@@ -77,6 +77,15 @@ impl FakeDb {
         Ok(())
     }
 
+    /// Set a binary value without taking the outer lock (caller holds it).
+    async fn set_bin_with_lock(&self, key: &str, value: &[u8]) -> DbResult<()> {
+        self.store.insert(
+            key.to_string(),
+            Entry::new(FakeDbValue::Bin(value.to_vec())),
+        );
+        Ok(())
+    }
+
     async fn hset_with_lock(&self, key: &str, field: &str, value: &str) -> DbResult<()> {
         let entry = self
             .store
@@ -198,11 +207,7 @@ impl DbConnection for FakeDb {
     /// Set a binary value.
     async fn set_bin(&self, key: &str, value: &[u8]) -> DbResult<()> {
         let _rlock = self.lock.read().await;
-        self.store.insert(
-            key.to_string(),
-            Entry::new(FakeDbValue::Bin(value.to_vec())),
-        );
-        Ok(())
+        self.set_bin_with_lock(key, value).await
     }
 
     /// Set a binary value with expiration.
@@ -430,6 +435,9 @@ impl DbConnection for FakeDb {
             match op {
                 DbOp::Del(key) => {
                     self.del_with_lock(key).await?;
+                }
+                DbOp::SetBin { key, value } => {
+                    self.set_bin_with_lock(key, value).await?;
                 }
                 DbOp::SRem { set_key, member } => {
                     self.srem_with_lock(set_key, member).await?;

--- a/vs/src/db/db_redis.rs
+++ b/vs/src/db/db_redis.rs
@@ -161,6 +161,9 @@ impl DbConnection for RedisDb {
                 DbOp::Del(key) => {
                     piper.del(key);
                 }
+                DbOp::SetBin { key, value } => {
+                    piper.set(key, value.as_slice());
+                }
                 DbOp::SRem { set_key, member } => {
                     piper.srem(set_key, member);
                 }

--- a/vs/src/db/mod.rs
+++ b/vs/src/db/mod.rs
@@ -42,6 +42,9 @@ pub trait DbConnection: Send + Sync {
     async fn set(&self, key: &str, value: &str) -> DbResult<()>;
     async fn get(&self, key: &str) -> DbResult<Option<String>>;
 
+    /// Set a binary value directly. For atomic writes alongside other ops, use
+    /// `DbOp::SetBin` in an `atomic_pipeline` instead.
+    #[allow(dead_code)]
     async fn set_bin(&self, key: &str, value: &[u8]) -> DbResult<()>;
     async fn set_bin_ex(&self, key: &str, value: &[u8], seconds: u64) -> DbResult<()>;
     async fn get_bin(&self, key: &str) -> DbResult<Vec<u8>>;
@@ -118,6 +121,11 @@ impl Eq for LockDescriptor {}
 
 pub enum DbOp {
     Del(String),
+    /// Set a binary value at `key`. Lets binary blobs join an atomic pipeline.
+    SetBin {
+        key: String,
+        value: Vec<u8>,
+    },
     SRem {
         set_key: String,
         member: String,

--- a/vs/src/db/policy.rs
+++ b/vs/src/db/policy.rs
@@ -1,20 +1,23 @@
 //! Redis/ValKey operations related to policy.
 //!
-//! PHASH is a hash of the policy. Should change if the policy changes or is recompiled.
+//! PHASH is a true content hash of the policy *container* artifact: the SHA-256
+//! of the exact container bytes we received. It changes whenever the container
+//! bytes change (recompiles, compiler metadata, signatures, or policy body).
 //!
-//! This updates:
-//! - policies:<PHASH>:blob maps to a raw string value which is capn proto encoded bytes of the policy.
+//! The container is the single source of truth; the inner decoded policy is
+//! always re-derived from it. This updates:
+//! - policies:<PHASH>:container maps to the raw Cap'n Proto `PolicyContainer` bytes.
 //! - policy:current a hash which includes key 'phash' with the current policy PHASH.
 //!
 
-use libeval::policy::Policy;
-use openssl::hash::{Hasher, MessageDigest};
+use libeval::pio;
 use std::sync::Arc;
 use tracing::debug;
 
 use crate::db;
 use crate::db::{DbConnection, DbOp};
 use crate::error::StoreError;
+use crate::loaded_policy::{LoadedPolicy, PolicyContainerBytes};
 use crate::logging::targets::DB;
 
 const KEY_POLICIES: &str = "policies";
@@ -33,47 +36,52 @@ impl PolicyRepo {
     /// Unless `force_overwrite` is true, only updates the database if the current
     /// policy is different (by its phash) from the one already stored.
     ///
+    /// Only the container half of `loaded` is persisted; the decoded policy is
+    /// always re-derived from it on load. Taking `&LoadedPolicy` makes it
+    /// impossible to persist bytes that never decoded into a valid artifact.
+    ///
     /// Return TRUE only if database was written to.
     pub async fn set_current_policy(
         &self,
-        policy: &Policy,
+        loaded: &LoadedPolicy,
         force_overwrite: bool,
     ) -> Result<bool, StoreError> {
-        let phash = hash_for_policy(policy)?;
+        let container_bytes = loaded.container().as_bytes();
+        let phash = loaded.hash_container_bytes()?;
         let maybe_curhash: Option<String> = self.db.hget("policy:current", "phash").await?;
         let curhash = maybe_curhash.unwrap_or_default();
-        let exists: bool = (curhash == phash)
-            && self
-                .db
-                .exists(&format!("{KEY_POLICIES}:{phash}:blob"))
-                .await?;
+        let container_key = format!("{KEY_POLICIES}:{phash}:container");
+
+        // Require the container blob to exist, so a half-written state (current
+        // pointer present, container missing) still forces a rewrite.
+        let exists: bool = (curhash == phash) && self.db.exists(&container_key).await?;
         let mut updated = false;
         if !exists || force_overwrite {
             debug!(target: DB, "updating current policy in DB to phash {phash}");
-            let pbuf = policy.get_serialized(); // get capn proto bytes
-
-            //
-            // policies:<PHASH>:blob -> <capn proto bytes>
-            //
-            self.db
-                .set_bin(&format!("{KEY_POLICIES}:{phash}:blob"), pbuf.as_ref())
-                .await?;
 
             let key_current = format!("{KEY_POLICY}:current");
 
             //
+            // policies:<PHASH>:container -> <capn proto container bytes>
             // policy:current
             //          |- phash -> the string <PHASH> value
             //          |- ctime -> string
             //
+            // All written in one atomic pipeline so the current pointer never
+            // points at a missing container.
+            //
             let ops = vec![
+                DbOp::SetBin {
+                    key: container_key,
+                    value: container_bytes.to_vec(),
+                },
                 DbOp::HSet {
                     hash_key: key_current.clone(),
                     field: "phash".to_string(),
                     value: phash.clone(),
                 },
                 DbOp::HSet {
-                    hash_key: key_current.clone(),
+                    hash_key: key_current,
                     field: "ctime".to_string(),
                     value: db::gen_timestamp(),
                 },
@@ -88,137 +96,179 @@ impl PolicyRepo {
         Ok(updated)
     }
 
-    /// Load the current policy stored in the database. This will return an error if there is no current policy set, or if the
-    /// current policy blob cannot be deserialized into a Policy struct.
-    pub async fn get_current_policy(&self) -> Result<Policy, StoreError> {
+    /// Load the current policy artifact and decode it into a [LoadedPolicy].
+    ///
+    /// Returns an error if there is no current policy set, or if the stored
+    /// container bytes cannot be decoded into a valid policy.
+    pub async fn get_current_loaded_policy(
+        &self,
+        min_version: &pio::Version,
+    ) -> Result<LoadedPolicy, StoreError> {
         let maybe_curhash: Option<String> = self.db.hget("policy:current", "phash").await?;
         let curhash =
             maybe_curhash.ok_or_else(|| StoreError::NotFound("no current policy set".into()))?;
-        let blob_key = format!("{KEY_POLICIES}:{curhash}:blob");
-        let pbytes = self.db.get_bin(&blob_key).await?;
-        match Policy::new_from_policy_bytes(pbytes.into()) {
-            Ok(p) => Ok(p),
-            Err(e) => Err(StoreError::InvalidData(format!(
-                "failed to de-serialize policy: {e}"
-            ))),
-        }
+        let container_key = format!("{KEY_POLICIES}:{curhash}:container");
+        let cbytes = self.db.get_bin(&container_key).await?;
+        LoadedPolicy::from_container(PolicyContainerBytes::from(cbytes), min_version)
+            .map_err(|e| StoreError::InvalidData(format!("failed to decode policy container: {e}")))
     }
-}
-
-fn hash_for_policy(policy: &Policy) -> Result<String, StoreError> {
-    let mut hasher = Hasher::new(MessageDigest::sha256())?;
-    if let Some(ctimestr) = policy.get_created() {
-        hasher.update(ctimestr.as_bytes())?;
-    } else {
-        return Err(StoreError::MissingRequired("created timestamp".to_string()));
-    }
-    if let Some(version) = policy.get_version() {
-        hasher.update(&version.to_be_bytes())?;
-    } else {
-        return Err(StoreError::MissingRequired("version".to_string()));
-    }
-    if let Some(md) = policy.get_metadata() {
-        hasher.update(md.as_bytes())?;
-    }
-    let dig = hasher.finish()?;
-
-    let phash = hex::encode(dig);
-    Ok(phash)
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::config;
     use crate::db::db_fake::FakeDb;
-    use bytes::Bytes;
     use std::time::Duration;
     use zpr::policy::v1 as policy_capnp;
 
-    fn make_policy(created: &str, version: u64, metadata: Option<&str>) -> Policy {
+    /// Build a [LoadedPolicy] by encoding a minimal policy, wrapping it in a
+    /// container at the minimum supported compiler version, and decoding it.
+    fn make_loaded(created: &str, version: u64, metadata: Option<&str>) -> LoadedPolicy {
         let mut msg = capnp::message::Builder::new_default();
         {
             let mut policy_bldr = msg.init_root::<policy_capnp::policy::Builder>();
             policy_bldr.set_created(created);
             policy_bldr.set_version(version);
-            if let Some(md) = metadata {
-                policy_bldr.set_metadata(md);
-            } else {
-                policy_bldr.set_metadata("");
-            }
+            policy_bldr.set_metadata(metadata.unwrap_or(""));
         }
-        let mut bytes = Vec::new();
-        capnp::serialize::write_message(&mut bytes, &msg).unwrap();
-        Policy::new_from_policy_bytes(Bytes::copy_from_slice(&bytes)).unwrap()
+        let mut inner = Vec::new();
+        capnp::serialize::write_message(&mut inner, &msg).unwrap();
+        let container = crate::test_helpers::make_container_bytes(
+            config::POLICY_MIN_COMPILER_MAJOR,
+            config::POLICY_MIN_COMPILER_MINOR,
+            config::POLICY_MIN_COMPILER_PATCH,
+            &inner,
+        );
+        LoadedPolicy::from_container(
+            PolicyContainerBytes::from(container),
+            &config::POLICY_MIN_VERSION,
+        )
+        .unwrap()
     }
 
     #[tokio::test]
+    /// An initial write stores the container blob and points policy:current at it.
     async fn test_set_current_policy_initial_write() {
         let db = Arc::new(FakeDb::new());
         let repo = PolicyRepo::new(db.clone());
-        let policy = make_policy("2024-01-01T00:00:00Z", 1, Some("meta"));
+        let loaded = make_loaded("2024-01-01T00:00:00Z", 1, Some("meta"));
 
-        let updated = repo.set_current_policy(&policy, false).await.unwrap();
+        let updated = repo.set_current_policy(&loaded, false).await.unwrap();
         assert!(updated);
 
         let phash = db.hget("policy:current", "phash").await.unwrap().unwrap();
-        let blob_key = format!("{KEY_POLICIES}:{phash}:blob");
-        let stored = db.get_bin(&blob_key).await.unwrap();
-        assert_eq!(stored, policy.get_serialized().as_ref());
+        let container_key = format!("{KEY_POLICIES}:{phash}:container");
+        let stored = db.get_bin(&container_key).await.unwrap();
+        assert_eq!(stored, loaded.container().as_bytes());
     }
 
     #[tokio::test]
+    /// Re-writing the same artifact is a no-op (no DB write).
     async fn test_set_current_policy_no_change() {
         let db = Arc::new(FakeDb::new());
         let repo = PolicyRepo::new(db);
-        let policy = make_policy("2024-01-01T00:00:00Z", 2, Some("meta"));
+        let loaded = make_loaded("2024-01-01T00:00:00Z", 2, Some("meta"));
 
-        let updated = repo.set_current_policy(&policy, false).await.unwrap();
+        let updated = repo.set_current_policy(&loaded, false).await.unwrap();
         assert!(updated);
-        let updated = repo.set_current_policy(&policy, false).await.unwrap();
+        let updated = repo.set_current_policy(&loaded, false).await.unwrap();
         assert!(!updated);
     }
 
     #[tokio::test]
+    /// force_overwrite rewrites even when the artifact is unchanged.
     async fn test_set_current_policy_force_overwrite() {
         let db = Arc::new(FakeDb::new());
         let repo = PolicyRepo::new(db);
-        let policy = make_policy("2024-01-01T00:00:00Z", 3, Some("meta"));
+        let loaded = make_loaded("2024-01-01T00:00:00Z", 3, Some("meta"));
 
-        let updated = repo.set_current_policy(&policy, false).await.unwrap();
+        let updated = repo.set_current_policy(&loaded, false).await.unwrap();
         assert!(updated);
         tokio::time::sleep(Duration::from_millis(10)).await;
-        let updated = repo.set_current_policy(&policy, true).await.unwrap();
+        let updated = repo.set_current_policy(&loaded, true).await.unwrap();
         assert!(updated);
     }
 
     #[tokio::test]
-    async fn test_set_current_policy_missing_fields() {
-        let db = Arc::new(FakeDb::new());
-        let repo = PolicyRepo::new(db);
-        let policy = Policy::new_empty();
-
-        let err = repo.set_current_policy(&policy, false).await.unwrap_err();
-        match err {
-            StoreError::MissingRequired(_) => {}
-            other => panic!("unexpected error: {:?}", other),
-        }
-    }
-
-    #[tokio::test]
-    async fn test_set_current_policy_rewrites_when_blob_missing() {
+    /// A missing container blob forces a rewrite even though the current pointer
+    /// still matches the phash.
+    async fn test_set_current_policy_rewrites_when_container_missing() {
         let db = Arc::new(FakeDb::new());
         let repo = PolicyRepo::new(db.clone());
-        let policy = make_policy("2024-01-01T00:00:00Z", 4, Some("meta"));
+        let loaded = make_loaded("2024-01-01T00:00:00Z", 4, Some("meta"));
 
-        let updated = repo.set_current_policy(&policy, false).await.unwrap();
+        let updated = repo.set_current_policy(&loaded, false).await.unwrap();
         assert!(updated);
 
         let phash = db.hget("policy:current", "phash").await.unwrap().unwrap();
-        db.del(&format!("{KEY_POLICIES}:{phash}:blob"))
+        db.del(&format!("{KEY_POLICIES}:{phash}:container"))
             .await
             .unwrap();
 
-        let updated = repo.set_current_policy(&policy, false).await.unwrap();
+        let updated = repo.set_current_policy(&loaded, false).await.unwrap();
         assert!(updated);
+    }
+
+    #[tokio::test]
+    /// Changing only the container bytes changes the PHASH and stores a distinct
+    /// artifact under a new key.
+    async fn test_set_current_policy_distinct_phash_per_container() {
+        let db = Arc::new(FakeDb::new());
+        let repo = PolicyRepo::new(db.clone());
+
+        let loaded_a = make_loaded("2024-01-01T00:00:00Z", 1, Some("meta-a"));
+        let loaded_b = make_loaded("2024-01-01T00:00:00Z", 1, Some("meta-b"));
+
+        let phash_a = loaded_a.hash_container_bytes().unwrap();
+        let phash_b = loaded_b.hash_container_bytes().unwrap();
+        assert_ne!(phash_a, phash_b);
+
+        repo.set_current_policy(&loaded_a, false).await.unwrap();
+        repo.set_current_policy(&loaded_b, false).await.unwrap();
+
+        // Both artifacts are stored under their own keys.
+        assert!(
+            db.exists(&format!("{KEY_POLICIES}:{phash_a}:container"))
+                .await
+                .unwrap()
+        );
+        assert!(
+            db.exists(&format!("{KEY_POLICIES}:{phash_b}:container"))
+                .await
+                .unwrap()
+        );
+        // Current points at the most recent write.
+        let cur = db.hget("policy:current", "phash").await.unwrap().unwrap();
+        assert_eq!(cur, phash_b);
+    }
+
+    #[tokio::test]
+    /// set_current_policy followed by get_current_loaded_policy round-trips
+    /// through LoadedPolicy: same container bytes, same decoded policy version.
+    async fn test_round_trip_through_loaded_policy() {
+        let db = Arc::new(FakeDb::new());
+        let repo = PolicyRepo::new(db);
+        let loaded = make_loaded("2024-01-01T00:00:00Z", 7, Some("meta"));
+
+        repo.set_current_policy(&loaded, false).await.unwrap();
+
+        let got = repo
+            .get_current_loaded_policy(&config::POLICY_MIN_VERSION)
+            .await
+            .unwrap();
+        assert_eq!(got.container().as_bytes(), loaded.container().as_bytes());
+        assert_eq!(got.policy().get_version(), Some(7));
+    }
+
+    #[tokio::test]
+    /// get_current_loaded_policy errors when no current policy is set.
+    async fn test_get_current_loaded_policy_not_found() {
+        let db = Arc::new(FakeDb::new());
+        let repo = PolicyRepo::new(db);
+        let res = repo
+            .get_current_loaded_policy(&config::POLICY_MIN_VERSION)
+            .await;
+        assert!(matches!(res, Err(StoreError::NotFound(_))));
     }
 }

--- a/vs/src/error.rs
+++ b/vs/src/error.rs
@@ -105,6 +105,9 @@ pub enum StoreError {
 
     #[error("vsapi error: {0}")]
     VsapiType(#[from] VsapiTypeError),
+
+    #[error("crypto error: {0}")]
+    Crypto(#[from] CryptoError),
 }
 
 #[derive(Debug, Error)]

--- a/vs/src/event_mgr.rs
+++ b/vs/src/event_mgr.rs
@@ -7,7 +7,7 @@ use std::collections::HashSet;
 use std::net::IpAddr;
 use std::sync::Arc;
 use tokio::sync::mpsc;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use zpr::vsapi::v1::DisconnectReason;
 use zpr::vsapi_types::ServiceDescriptor;
@@ -23,6 +23,9 @@ pub enum VsEvent {
     /// Use when we get a signal from remote that actor is disconnected/disconnecting.
     /// EventManager takes care of state updates.
     ActorLeaves(IpAddr, DisconnectReason),
+
+    /// Indicates that policy has been successfully updated. Pass the new `vinst`.
+    PolicyUpdated(u64),
 }
 
 pub struct EventMgr {
@@ -56,6 +59,11 @@ pub async fn launch(asm: Arc<Assembly>, mut event_rx: mpsc::Receiver<VsEvent>) {
             VsEvent::ActorLeaves(actor, reason) => {
                 if let Err(e) = handle_actor_leaves(&asm, actor, reason).await {
                     error!(target: EVENT, "failed to handle actor leave event: {}", e);
+                }
+            }
+            VsEvent::PolicyUpdated(vinst) => {
+                if let Err(e) = handle_policy_updated(&asm, vinst).await {
+                    error!(target: EVENT, "failed to handle policy updated event: {}", e);
                 }
             }
         }
@@ -157,5 +165,36 @@ async fn set_services_all_nodes(
             }
         })
         .await;
+    Ok(())
+}
+
+async fn handle_policy_updated(_asm: &Arc<Assembly>, vinst: u64) -> Result<(), ServiceError> {
+    /*
+
+    https://github.com/org-zpr/zpr-visaservice/issues/219
+
+
+    When we get here we have already updated policy.
+
+    - are there any existing visas that need to be revoked.
+       - do we have the 5-tuple or whatever so that we can check them? NO, this is a TODO.
+
+    - check our existing topology.
+       - Are all the nodes and links still valid?
+
+    - request re-auth all nodes.
+
+    - services -> ensure all services being offered are still allowed by policy.
+       - What if an already connected adapter has a new service -> will need to re-connect?
+       - We can do a basic check to see that all the services we have do exist in policy.
+          - But that won't detect if a service has altered its provider.
+          - TO BE SAFE: expire auth from all services - force re-auth of all existing services (after removing non-existing ones)
+
+    - all connected adapters.  Are they still allowed?
+       - Well we could expire all the auth, but that seems drastic.
+       - Instead we will have already killed visas. Probably ok to let them be connected but unable to do anything.
+
+     */
+    warn!(target: EVENT, "policy updated event vinst={vinst} (not implemented)");
     Ok(())
 }

--- a/vs/src/loaded_policy.rs
+++ b/vs/src/loaded_policy.rs
@@ -1,0 +1,107 @@
+//! Policy is kept together with its container. This does that.
+//!
+//! - [PolicyContainerBytes]: encoded Cap'n Proto `PolicyContainer` bytes.
+//! - [LoadedPolicy]: a decoded [Policy] paired with the exact container bytes it
+//!   was decoded from, so the two can never drift apart.
+//!
+//! These live in their own module (rather than in `policy_mgr`) so the DB layer
+//! (`db::policy`) can use them in its public API without `db` having to depend on
+//! the policy manager.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+
+use libeval::pio;
+use libeval::policy::{Policy, PolicyError};
+use openssl::hash::{Hasher, MessageDigest};
+
+use crate::error::CryptoError;
+
+/// Encoded Cap'n Proto `PolicyContainer` bytes.
+///
+/// A cheap-to-clone newtype over [bytes::Bytes] that documents, at the type
+/// level, that the wrapped bytes are a policy *container* (compiler version
+/// metadata, signature, and the inner policy) rather than raw policy bytes or
+/// unrelated binary data.
+#[derive(Clone, Debug)]
+pub struct PolicyContainerBytes(Bytes);
+
+impl PolicyContainerBytes {
+    /// Borrow the raw container bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<Vec<u8>> for PolicyContainerBytes {
+    /// Take ownership of `Vec<u8>` container bytes (zero-copy via `Bytes::from`).
+    fn from(v: Vec<u8>) -> Self {
+        PolicyContainerBytes(Bytes::from(v))
+    }
+}
+
+impl From<Bytes> for PolicyContainerBytes {
+    /// Wrap already-shared `Bytes` container bytes.
+    fn from(b: Bytes) -> Self {
+        PolicyContainerBytes(b)
+    }
+}
+
+/// A decoded [Policy] paired with the exact container bytes it came from.
+///
+/// Constructing a `LoadedPolicy` guarantees the policy and container agree *at
+/// decode time*. The service-assigned `vinst` is mutated after decode (see
+/// [LoadedPolicy::set_vinst]); that does not affect the container artifact, which
+/// is what the admin API round-trips.
+pub struct LoadedPolicy {
+    policy: Arc<Policy>,
+    container: PolicyContainerBytes,
+}
+
+impl LoadedPolicy {
+    /// Decode a policy from encoded policy container bytes, retaining the source
+    /// container for later round-tripping.
+    pub fn from_container(
+        container: PolicyContainerBytes,
+        min_version: &pio::Version,
+    ) -> Result<Self, PolicyError> {
+        let policy = pio::load_policy_from_container(container.as_bytes(), min_version)?;
+        Ok(Self {
+            policy: Arc::new(policy),
+            container,
+        })
+    }
+
+    /// The decoded policy as a cheap-to-clone `Arc`.
+    pub fn policy(&self) -> Arc<Policy> {
+        self.policy.clone()
+    }
+
+    /// The source container bytes.
+    pub fn container(&self) -> &PolicyContainerBytes {
+        &self.container
+    }
+
+    /// Assign the service's version instance number to the decoded policy.
+    ///
+    /// `vinst` is service state, not part of the container artifact, so this
+    /// mutates only the decoded policy and leaves the container bytes untouched.
+    /// It mutates through the `Arc` and therefore must be called while the `Arc`
+    /// is still uniquely held — i.e. right after [LoadedPolicy::from_container]
+    /// and before the policy is cloned into shared state.
+    pub fn set_vinst(&mut self, vinst: u64) {
+        Arc::get_mut(&mut self.policy)
+            .expect("set_vinst called after the policy Arc was shared")
+            .set_vinst(vinst);
+    }
+
+    /// Compute the policy artifact hash: the SHA-256 of the container bytes as-is.
+    /// We use this in the database to key policies.
+    pub fn hash_container_bytes(&self) -> Result<String, CryptoError> {
+        let mut hasher = Hasher::new(MessageDigest::sha256())?;
+        hasher.update(self.container.as_bytes())?;
+        let dig = hasher.finish()?;
+        Ok(hex::encode(dig))
+    }
+}

--- a/vs/src/main.rs
+++ b/vs/src/main.rs
@@ -8,7 +8,6 @@ use tokio::task::JoinSet;
 use tracing::{debug, error, info, warn};
 
 use libeval::attribute::{ROLE_ADAPTER, key};
-use libeval::pio;
 
 mod actor_mgr;
 mod admin_apikeys;
@@ -140,25 +139,21 @@ async fn main() -> std::process::ExitCode {
 
     // If a policy path was provided, attempt to load it here. If not provided, we set this None
     // and then later the policy_mgr will attempt to load the current policy from the database.
-    let initial_policy = {
-        if let Some(ref policy_path) = cli.policy {
-            match pio::load_policy(
-                policy_path,
-                pio::Version(
-                    config::POLICY_MIN_COMPILER_MAJOR,
-                    config::POLICY_MIN_COMPILER_MINOR,
-                    config::POLICY_MIN_COMPILER_PATCH,
-                ),
-            ) {
-                Ok(p) => Some(p),
-                Err(e) => {
-                    error!(target: MAIN, "failed to load initial policy from {}: {}", policy_path.display(), e);
-                    return std::process::ExitCode::FAILURE;
-                }
+    let initial_policy_bytes = if let Some(policy_path) = &cli.policy {
+        match std::fs::read(policy_path) {
+            Ok(bytes) => Some(bytes),
+            Err(e) => {
+                error!(
+                    target: MAIN,
+                    "failed to load initial policy from {}: {}",
+                    policy_path.display(),
+                    e
+                );
+                return std::process::ExitCode::FAILURE;
             }
-        } else {
-            None
         }
+    } else {
+        None
     };
 
     let local_set = tokio::task::LocalSet::new();
@@ -221,21 +216,31 @@ async fn main() -> std::process::ExitCode {
         }
     };
 
-    let policy_mgr_res = match initial_policy {
-        Some(p) => {
-            PolicyMgr::new_with_initial_policy(
-                p,
-                db::PolicyRepo::new(db_handle.clone()),
-                Arc::new(SystemResolver),
-            )
-            .await
-        }
-        None => {
-            PolicyMgr::new_from_state(
-                db::PolicyRepo::new(db_handle.clone()),
-                Arc::new(SystemResolver),
-            )
-            .await
+    // Initialize the policy manager either from provided policy-container or from database.
+    let policy_mgr = {
+        let policy_mgr_res = match initial_policy_bytes {
+            Some(p) => {
+                PolicyMgr::new_with_initial_policy(
+                    p,
+                    db::PolicyRepo::new(db_handle.clone()),
+                    Arc::new(SystemResolver),
+                )
+                .await
+            }
+            None => {
+                PolicyMgr::new_from_state(
+                    db::PolicyRepo::new(db_handle.clone()),
+                    Arc::new(SystemResolver),
+                )
+                .await
+            }
+        };
+        match policy_mgr_res {
+            Ok(pm) => pm,
+            Err(e) => {
+                error!(target: MAIN, "failed to instantiate policy manager: {}", e);
+                return std::process::ExitCode::FAILURE;
+            }
         }
     };
 
@@ -248,14 +253,6 @@ async fn main() -> std::process::ExitCode {
             return std::process::ExitCode::FAILURE;
         }
     }
-
-    let policy_mgr = match policy_mgr_res {
-        Ok(pm) => pm,
-        Err(e) => {
-            error!(target: MAIN, "failed to instantiate policy manager: {}", e);
-            return std::process::ExitCode::FAILURE;
-        }
-    };
 
     let visa_repo = match db::VisaRepo::new(db_handle.clone(), config::INITIAL_VISA_ID).await {
         Ok(vr) => vr,

--- a/vs/src/main.rs
+++ b/vs/src/main.rs
@@ -22,6 +22,7 @@ mod db;
 mod db_worker;
 mod error;
 mod event_mgr;
+mod loaded_policy;
 mod logging;
 mod net_mgr;
 mod packet;

--- a/vs/src/policy_mgr.rs
+++ b/vs/src/policy_mgr.rs
@@ -1,4 +1,4 @@
-//! The policy manage is conceived as the one true place where the running visa service
+//! The policy manager is conceived as the one true place where the running visa service
 //! can obtain the current policy.  Policy can be updated asynchronously by administrators.
 //! A policy update can have many ripple effects on the running visa serivce: visas may no
 //! longer be valid, connected actors may be forced to disconnect, services may be taken
@@ -13,14 +13,13 @@
 
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
-use dashmap::DashMap;
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use tracing::{debug, info};
 
 use libeval::attribute::Attribute;
-use libeval::pio;
+use libeval::attribute::key;
 use libeval::policy::{Peer, Policy};
 
 use zpr::policy_types::{NetAddr, NetworkHost};
@@ -29,6 +28,7 @@ use zpr::vsapi_types::{Link, LinkRole, SockAddr};
 use crate::config;
 use crate::db;
 use crate::error::{ResolverError, ServiceError, TopologyError};
+use crate::loaded_policy::{LoadedPolicy, PolicyContainerBytes};
 use crate::logging::targets::MAIN;
 
 /// Abstracts DNS hostname resolution so it can be swapped out in tests.
@@ -38,20 +38,19 @@ pub trait DnsResolver: Send + Sync {
     async fn resolve(&self, host: &str, port: u16) -> Result<SocketAddr, ResolverError>;
 }
 
-/// The identifier shared over the admin API of the current policy.
+/// The identifier of the "current policy" shared over the admin API.
 /// This will be reworked in the future where we may have multiple policies, not all
 /// active, including policies for different domains.
 pub const DEFAULT_POLICY_ID: u64 = 0;
 
-// TODO: move to libeval::attribute::key
-const LINK_COST_ATTR_KEY: &str = "link.zpr.cost";
-
 /// The default and the minimum.
 const DEFAULT_LINK_COST: u32 = 1;
 
-/// Combined policy and resolved topology — swapped atomically as a unit.
+/// Combined policy, source container, and resolved topology — swapped atomically
+/// as a unit so the three can never drift apart.
 struct PolicyState {
     policy: Arc<Policy>,
+    container: PolicyContainerBytes,
     links_by_node: HashMap<IpAddr, Vec<Link>>,
 }
 
@@ -62,7 +61,6 @@ pub struct PolicyMgr {
     /// Serializes concurrent policy updates; reads remain lock-free via ArcSwap.
     update_lock: tokio::sync::Mutex<()>,
     resolver: PolicyResolver,
-    containers: DashMap<u64, Arc<[u8]>>, // vinst -> container_bytes, Arc for cheap clone (for admin API)
 }
 
 #[derive(Debug, Clone)]
@@ -102,22 +100,24 @@ impl PolicyMgr {
     ) -> Result<Self, ServiceError> {
         debug!(target: MAIN, "initializing policy manager");
 
-        let mut policy =
-            pio::load_policy_from_container(&container_bytes, &config::policy_min_version())?;
-        policy.set_vinst(1);
+        // Decode and assign the initial vinst while the policy Arc
+        // is still uniquely held (before build_state clones it).
+        let mut loaded = LoadedPolicy::from_container(
+            PolicyContainerBytes::from(container_bytes),
+            &config::POLICY_MIN_VERSION,
+        )?;
+        loaded.set_vinst(1);
 
         let resolver = PolicyResolver::new(resolver);
 
         // Resolve topology before persisting so a policy that cannot initialize is never
-        // stored as the current policy.
-        let state = Self::build_state(&resolver, policy).await?;
-        let _db_updated = repo.set_current_policy(&state.policy, false).await?;
-
-        let containers = DashMap::new();
-        containers.insert(state.policy.vinst(), Arc::from(container_bytes));
+        // stored as the current policy. build_state borrows `loaded`, leaving it
+        // available for the post-resolution persist below.
+        let state = Self::build_state(&resolver, &loaded).await?;
+        let _db_updated = repo.set_current_policy(&loaded, false).await?;
 
         debug!(target: MAIN, "policy manager initialized successfully");
-        Ok(Self::from_state(state, repo, resolver, containers))
+        Ok(Self::from_state(state, repo, resolver))
     }
 
     /// Create a new policy manager, initializing it with the current policy in
@@ -133,87 +133,92 @@ impl PolicyMgr {
         resolver: Arc<dyn DnsResolver>,
     ) -> Result<Self, ServiceError> {
         debug!(target: MAIN, "initializing policy manager from state");
-        let policy = repo.get_current_policy().await?;
-        info!(target: MAIN, "loaded policy from state version:{}, created:{}", policy.get_version().unwrap_or(0),
-            policy.get_created().unwrap_or("unknown").to_string());
-        debug!(target: MAIN, "policy manager initialized successfully");
-
+        let loaded = repo
+            .get_current_loaded_policy(&config::POLICY_MIN_VERSION)
+            .await?;
+        {
+            let policy = loaded.policy();
+            info!(target: MAIN, "loaded policy from state version:{}, created:{}", policy.get_version().unwrap_or(0),
+                policy.get_created().unwrap_or("unknown").to_string());
+        }
         let resolver = PolicyResolver::new(resolver);
+        let state = Self::build_state(&resolver, &loaded).await?;
 
-        let state = Self::build_state(&resolver, policy).await?;
-        // TODO: Where's the container? Need to also check compiler version!
-        Ok(Self::from_state(state, repo, resolver, DashMap::new()))
+        debug!(target: MAIN, "policy manager initialized successfully");
+        Ok(Self::from_state(state, repo, resolver))
     }
 
     /// This is the placeholder "update policy" function. It only replaces the current policy
-    /// with a new current policy.
+    /// with a new current policy. Once the visa service is running this is how policy is
+    /// updated.
     pub async fn update_policy_from_container_bytes(
         &self,
-        policy_continer_bytes: Vec<u8>,
+        policy_container_bytes: Vec<u8>,
     ) -> Result<u64, ServiceError> {
-        let policy =
-            pio::load_policy_from_container(&policy_continer_bytes, &config::policy_min_version())?;
-        self.update_policy_internal(policy, policy_continer_bytes)
-            .await
+        let loaded = LoadedPolicy::from_container(
+            PolicyContainerBytes::from(policy_container_bytes),
+            &config::POLICY_MIN_VERSION,
+        )?;
+        self.update_policy_internal(loaded).await
     }
 
     /// Build the atomically-swapped policy state after resolving all policy topology.
     ///
     /// Intentionally performs only validation/state construction: it does not write the
-    /// DB, update the container cache, or store into `self.state`. This keeps failed
-    /// DNS/topology resolution from leaking partial policy state.
+    /// DB or store into `self.state`. This keeps failed DNS/topology resolution from
+    /// leaking partial policy state. Borrows `loaded` (cloning only the `Arc<Policy>`
+    /// and the `Bytes`-backed container — both refcount bumps) so the caller can still
+    /// persist it after resolution succeeds.
     async fn build_state(
         resolver: &PolicyResolver,
-        policy: Policy,
+        loaded: &LoadedPolicy,
     ) -> Result<PolicyState, ResolverError> {
+        let policy = loaded.policy();
         let links_by_node = resolver.resolve_topology(&policy).await?;
         Ok(PolicyState {
-            policy: Arc::new(policy),
+            policy,
+            container: loaded.container().clone(),
             links_by_node,
         })
     }
 
     /// Assemble a PolicyMgr from already-built state and constructor-owned parts.
-    fn from_state(
-        state: PolicyState,
-        repo: db::PolicyRepo,
-        resolver: PolicyResolver,
-        containers: DashMap<u64, Arc<[u8]>>,
-    ) -> Self {
+    fn from_state(state: PolicyState, repo: db::PolicyRepo, resolver: PolicyResolver) -> Self {
         PolicyMgr {
             state: ArcSwap::from_pointee(state),
             repo,
             update_lock: tokio::sync::Mutex::new(()),
             resolver,
-            containers,
         }
     }
 
-    /// Update the current policy.  The new policy will be assigned a new version instance number (vinst)
-    /// that is one greater than the current policy's vinst.
+    /// Update the current policy in state database and memory.  The new policy
+    /// will be assigned a new version instance number (vinst) that is one
+    /// greater than the current policy's vinst.
     ///
-    /// TODO: There is a lot of housekeeping that needs to happen around a policy update. None of that
-    /// is implemented here. Right now this is just to support unit tests.
+    /// TODO: There is a lot of housekeeping that needs to happen around a
+    /// policy update. None of that is implemented here. Right now this is just
+    /// to support unit tests.
     ///
     /// Returns the new `vinst` value.
-    async fn update_policy_internal(
-        &self,
-        new_policy: Policy,
-        new_policy_container: Vec<u8>,
-    ) -> Result<u64, ServiceError> {
+    ///
+    /// ### Errors
+    /// - `ResolverError` if the new policy's topology contains hostnames that
+    ///   fail to resolve.
+    /// - `StoreError` if there is a problem writing to the database.
+    ///
+    async fn update_policy_internal(&self, mut loaded: LoadedPolicy) -> Result<u64, ServiceError> {
         let _guard = self.update_lock.lock().await;
 
-        let mut new_policy = new_policy;
-        new_policy.set_vinst(self.state.load().policy.vinst() + 1);
+        // Assign the new vinst while the policy Arc is still uniquely held.
+        let vinst = self.state.load().policy.vinst() + 1;
+        loaded.set_vinst(vinst);
 
-        let vinst = new_policy.vinst();
-
-        // Resolve topology before mutating the container cache or current state so a
-        // failed update leaves neither a non-current container nor a swapped-in state.
-        let state = Self::build_state(&self.resolver, new_policy).await?;
-
-        self.containers
-            .insert(vinst, Arc::from(new_policy_container));
+        // Resolve topology before swapping in the new state so a failed update leaves
+        // the current policy, container, and topology untouched. The new policy,
+        // container, and links swap in together as one PolicyState.
+        let state = Self::build_state(&self.resolver, &loaded).await?;
+        let _db_updated = self.repo.set_current_policy(&loaded, false).await?;
 
         self.state.store(Arc::new(state));
         Ok(vinst)
@@ -227,9 +232,9 @@ impl PolicyMgr {
         self.state.load().policy.clone()
     }
 
-    /// When policy is installed we cache the container. Can be retrieved here.
-    pub fn get_container_for_policy(&self, vinst: u64) -> Option<Arc<[u8]>> {
-        self.containers.get(&vinst).map(|v| v.clone())
+    /// Get the source container bytes for the current policy (for the admin API).
+    pub fn get_current_container(&self) -> PolicyContainerBytes {
+        self.state.load().container.clone()
     }
 
     /// When policy is updated, all the peer tables have their DNS names resolved and cached.
@@ -363,7 +368,7 @@ fn get_attributes_for_link(policy: &Policy, link_id: &str) -> Vec<Attribute> {
 /// bin2 representation.
 fn get_link_cost(attrs: &[Attribute], default_cost: u32) -> u32 {
     for attr in attrs {
-        if attr.get_key() == LINK_COST_ATTR_KEY {
+        if attr.get_key() == key::LINK_COST {
             let value = attr
                 .get_single_value()
                 .ok()
@@ -474,17 +479,22 @@ mod tests {
 
         assert!(result.is_err());
         // The DB must remain empty: a policy that cannot resolve is never persisted.
-        assert!(PolicyRepo::new(db).get_current_policy().await.is_err());
+        assert!(
+            PolicyRepo::new(db)
+                .get_current_loaded_policy(&config::POLICY_MIN_VERSION)
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]
-    /// A resolver failure during an update must leave the current state and container
-    /// cache unchanged (no stale container, no swapped-in state).
+    /// A resolver failure during an update must leave the current policy, container,
+    /// and topology unchanged (no swapped-in state).
     async fn test_update_resolver_failure_preserves_state() {
         // Start from a valid no-topology policy (vinst 1).
-        let mgr = make_policy_mgr(policy_no_topology()).await;
+        let initial_container = policy_no_topology();
+        let mgr = make_policy_mgr(initial_container.clone()).await;
         assert_eq!(mgr.get_current().vinst(), 1);
-        assert!(mgr.get_container_for_policy(2).is_none());
 
         // Attempt an update whose topology cannot be resolved.
         let peering = make_peering_bad_host(ip("fd5a:5052::1"), ip("fd5a:5052::2"), "link-1");
@@ -493,9 +503,64 @@ mod tests {
             .await;
 
         assert!(result.is_err());
-        // Current state untouched and the failed vinst-2 container was never cached.
+        // Current state untouched: vinst stays 1 and the container is still the initial one.
         assert_eq!(mgr.get_current().vinst(), 1);
-        assert!(mgr.get_container_for_policy(2).is_none());
+        assert_eq!(
+            mgr.get_current_container().as_bytes(),
+            initial_container.as_slice()
+        );
+    }
+
+    #[tokio::test]
+    /// A successful update swaps the policy, topology, and container together.
+    async fn test_update_swaps_policy_topology_and_container() {
+        // Start from a no-topology policy (vinst 1).
+        let mgr = make_policy_mgr(policy_no_topology()).await;
+        assert_eq!(mgr.get_current().vinst(), 1);
+        assert!(mgr.resolved_links_for_node(&ip("fd5a:5052::1")).is_empty());
+
+        // Update to a policy with topology, all IP-addressed so it resolves.
+        let peering = make_peering(ip("fd5a:5052::1"), ip("fd5a:5052::2"), "link-1", vec![]);
+        let new_container = policy_with_peerings(&[peering]);
+        let vinst = mgr
+            .update_policy_from_container_bytes(new_container.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(vinst, 2);
+        assert_eq!(mgr.get_current().vinst(), 2);
+        // Topology swapped in: node now has a resolved link.
+        assert!(!mgr.resolved_links_for_node(&ip("fd5a:5052::1")).is_empty());
+        // Container swapped in and round-trips.
+        assert_eq!(
+            mgr.get_current_container().as_bytes(),
+            new_container.as_slice()
+        );
+    }
+
+    #[tokio::test]
+    /// PolicyContainerBytes round-trips through as_bytes, and LoadedPolicy decodes
+    /// a valid container while preserving the source bytes.
+    async fn test_policy_artifact_construction() {
+        let container_bytes = policy_no_topology();
+        let pcb = PolicyContainerBytes::from(container_bytes.clone());
+        assert_eq!(pcb.as_bytes(), container_bytes.as_slice());
+
+        let mut loaded = LoadedPolicy::from_container(pcb, &config::POLICY_MIN_VERSION).unwrap();
+        assert_eq!(loaded.container().as_bytes(), container_bytes.as_slice());
+
+        // set_vinst mutates the decoded policy but not the container bytes.
+        loaded.set_vinst(7);
+        assert_eq!(loaded.policy().vinst(), 7);
+        assert_eq!(loaded.container().as_bytes(), container_bytes.as_slice());
+    }
+
+    #[tokio::test]
+    /// LoadedPolicy::from_container rejects bytes that are not a valid container.
+    async fn test_loaded_policy_rejects_garbage() {
+        let pcb = PolicyContainerBytes::from(b"not a capnp container".to_vec());
+        let result = LoadedPolicy::from_container(pcb, &config::POLICY_MIN_VERSION);
+        assert!(result.is_err());
     }
 
     #[tokio::test]
@@ -566,7 +631,7 @@ mod tests {
             ip("fd5a:5052::2"),
             "link-1",
             vec![AttrExp {
-                key: LINK_COST_ATTR_KEY.to_string(),
+                key: key::LINK_COST.to_string(),
                 op: AttrOp::Eq,
                 value: vec!["5".to_string()],
             }],
@@ -586,7 +651,7 @@ mod tests {
             ip("fd5a:5052::2"),
             "link-1",
             vec![AttrExp {
-                key: LINK_COST_ATTR_KEY.to_string(),
+                key: key::LINK_COST.to_string(),
                 op: AttrOp::Eq,
                 value: vec!["not-a-number".to_string()],
             }],

--- a/vs/src/policy_mgr.rs
+++ b/vs/src/policy_mgr.rs
@@ -13,17 +13,20 @@
 
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
+use dashmap::DashMap;
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use tracing::{debug, info};
 
 use libeval::attribute::Attribute;
+use libeval::pio;
 use libeval::policy::{Peer, Policy};
 
 use zpr::policy_types::{NetAddr, NetworkHost};
 use zpr::vsapi_types::{Link, LinkRole, SockAddr};
 
+use crate::config;
 use crate::db;
 use crate::error::{ResolverError, ServiceError, TopologyError};
 use crate::logging::targets::MAIN;
@@ -34,6 +37,11 @@ pub trait DnsResolver: Send + Sync {
     /// Resolve `host` to a `SocketAddr` on the given `port`.
     async fn resolve(&self, host: &str, port: u16) -> Result<SocketAddr, ResolverError>;
 }
+
+/// The identifier shared over the admin API of the current policy.
+/// This will be reworked in the future where we may have multiple policies, not all
+/// active, including policies for different domains.
+pub const DEFAULT_POLICY_ID: u64 = 0;
 
 // TODO: move to libeval::attribute::key
 const LINK_COST_ATTR_KEY: &str = "link.zpr.cost";
@@ -54,6 +62,7 @@ pub struct PolicyMgr {
     /// Serializes concurrent policy updates; reads remain lock-free via ArcSwap.
     update_lock: tokio::sync::Mutex<()>,
     resolver: PolicyResolver,
+    containers: DashMap<u64, Arc<[u8]>>, // vinst -> container_bytes, Arc for cheap clone (for admin API)
 }
 
 #[derive(Debug, Clone)]
@@ -87,28 +96,28 @@ impl PolicyMgr {
     /// [ResolverError] if any of the peerings fail to resolve.  We may revisit this
     /// later if we decide to eventually pass DNS names down to nodes.
     pub async fn new_with_initial_policy(
-        mut policy: Policy,
+        container_bytes: Vec<u8>,
         repo: db::PolicyRepo,
         resolver: Arc<dyn DnsResolver>,
     ) -> Result<Self, ServiceError> {
         debug!(target: MAIN, "initializing policy manager");
+
+        let mut policy =
+            pio::load_policy_from_container(&container_bytes, &config::policy_min_version())?;
         policy.set_vinst(1);
 
-        let presolver = PolicyResolver::new(resolver);
+        let resolver = PolicyResolver::new(resolver);
 
-        let links_by_node = presolver.resolve_topology(&policy).await?;
-        let _db_updated = repo.set_current_policy(&policy, false).await?;
+        // Resolve topology before persisting so a policy that cannot initialize is never
+        // stored as the current policy.
+        let state = Self::build_state(&resolver, policy).await?;
+        let _db_updated = repo.set_current_policy(&state.policy, false).await?;
+
+        let containers = DashMap::new();
+        containers.insert(state.policy.vinst(), Arc::from(container_bytes));
 
         debug!(target: MAIN, "policy manager initialized successfully");
-        Ok(PolicyMgr {
-            state: ArcSwap::from_pointee(PolicyState {
-                policy: Arc::new(policy),
-                links_by_node,
-            }),
-            repo,
-            update_lock: tokio::sync::Mutex::new(()),
-            resolver: presolver,
-        })
+        Ok(Self::from_state(state, repo, resolver, containers))
     }
 
     /// Create a new policy manager, initializing it with the current policy in
@@ -129,18 +138,55 @@ impl PolicyMgr {
             policy.get_created().unwrap_or("unknown").to_string());
         debug!(target: MAIN, "policy manager initialized successfully");
 
-        let presolver = PolicyResolver::new(resolver);
+        let resolver = PolicyResolver::new(resolver);
 
-        let links_by_node = presolver.resolve_topology(&policy).await?;
-        Ok(PolicyMgr {
-            state: ArcSwap::from_pointee(PolicyState {
-                policy: Arc::new(policy),
-                links_by_node,
-            }),
+        let state = Self::build_state(&resolver, policy).await?;
+        // TODO: Where's the container? Need to also check compiler version!
+        Ok(Self::from_state(state, repo, resolver, DashMap::new()))
+    }
+
+    /// This is the placeholder "update policy" function. It only replaces the current policy
+    /// with a new current policy.
+    pub async fn update_policy_from_container_bytes(
+        &self,
+        policy_continer_bytes: Vec<u8>,
+    ) -> Result<u64, ServiceError> {
+        let policy =
+            pio::load_policy_from_container(&policy_continer_bytes, &config::policy_min_version())?;
+        self.update_policy_internal(policy, policy_continer_bytes)
+            .await
+    }
+
+    /// Build the atomically-swapped policy state after resolving all policy topology.
+    ///
+    /// Intentionally performs only validation/state construction: it does not write the
+    /// DB, update the container cache, or store into `self.state`. This keeps failed
+    /// DNS/topology resolution from leaking partial policy state.
+    async fn build_state(
+        resolver: &PolicyResolver,
+        policy: Policy,
+    ) -> Result<PolicyState, ResolverError> {
+        let links_by_node = resolver.resolve_topology(&policy).await?;
+        Ok(PolicyState {
+            policy: Arc::new(policy),
+            links_by_node,
+        })
+    }
+
+    /// Assemble a PolicyMgr from already-built state and constructor-owned parts.
+    fn from_state(
+        state: PolicyState,
+        repo: db::PolicyRepo,
+        resolver: PolicyResolver,
+        containers: DashMap<u64, Arc<[u8]>>,
+    ) -> Self {
+        PolicyMgr {
+            state: ArcSwap::from_pointee(state),
             repo,
             update_lock: tokio::sync::Mutex::new(()),
-            resolver: presolver,
-        })
+            resolver,
+            containers,
+        }
     }
 
     /// Update the current policy.  The new policy will be assigned a new version instance number (vinst)
@@ -148,20 +194,29 @@ impl PolicyMgr {
     ///
     /// TODO: There is a lot of housekeeping that needs to happen around a policy update. None of that
     /// is implemented here. Right now this is just to support unit tests.
-    #[allow(dead_code)]
-    pub async fn update_policy(&self, new_policy: Policy) -> Result<(), ServiceError> {
+    ///
+    /// Returns the new `vinst` value.
+    async fn update_policy_internal(
+        &self,
+        new_policy: Policy,
+        new_policy_container: Vec<u8>,
+    ) -> Result<u64, ServiceError> {
         let _guard = self.update_lock.lock().await;
 
         let mut new_policy = new_policy;
         new_policy.set_vinst(self.state.load().policy.vinst() + 1);
 
-        let links_by_node = self.resolver.resolve_topology(&new_policy).await?;
+        let vinst = new_policy.vinst();
 
-        self.state.store(Arc::new(PolicyState {
-            policy: Arc::new(new_policy),
-            links_by_node,
-        }));
-        Ok(())
+        // Resolve topology before mutating the container cache or current state so a
+        // failed update leaves neither a non-current container nor a swapped-in state.
+        let state = Self::build_state(&self.resolver, new_policy).await?;
+
+        self.containers
+            .insert(vinst, Arc::from(new_policy_container));
+
+        self.state.store(Arc::new(state));
+        Ok(vinst)
     }
 
     /// Callers should drop the policy as quickly as possible to avoid missing a policy update.
@@ -170,6 +225,11 @@ impl PolicyMgr {
     /// If we find we need that we can add a snapshot mechanism.
     pub fn get_current(&self) -> Arc<Policy> {
         self.state.load().policy.clone()
+    }
+
+    /// When policy is installed we cache the container. Can be retrieved here.
+    pub fn get_container_for_policy(&self, vinst: u64) -> Option<Arc<[u8]>> {
+        self.containers.get(&vinst).map(|v| v.clone())
     }
 
     /// When policy is updated, all the peer tables have their DNS names resolved and cached.
@@ -324,7 +384,7 @@ fn get_link_cost(attrs: &[Attribute], default_cost: u32) -> u32 {
 mod tests {
     use super::*;
 
-    use bytes::Bytes;
+    use crate::test_helpers::make_container_bytes;
     use std::sync::Arc;
     use zpr::policy::v1 as policy_capnp;
     use zpr::policy_types::{AttrExp, AttrOp, NetAddr, Peering};
@@ -338,12 +398,12 @@ mod tests {
     }
 
     /// Build a minimal valid Policy with no topology.
-    fn policy_no_topology() -> Policy {
+    fn policy_no_topology() -> Vec<u8> {
         policy_with_peerings(&[])
     }
 
     /// Build a Policy containing the given peerings by encoding a capnp message in memory.
-    fn policy_with_peerings(peerings: &[Peering]) -> Policy {
+    fn policy_with_peerings(peerings: &[Peering]) -> Vec<u8> {
         let mut msg = capnp::message::Builder::new_default();
         {
             let mut policy = msg.init_root::<policy_capnp::policy::Builder>();
@@ -357,14 +417,19 @@ mod tests {
         }
         let mut bytes = Vec::new();
         capnp::serialize::write_message(&mut bytes, &msg).unwrap();
-        Policy::new_from_policy_bytes(Bytes::from(bytes)).unwrap()
+        make_container_bytes(
+            config::POLICY_MIN_COMPILER_MAJOR,
+            config::POLICY_MIN_COMPILER_MINOR,
+            config::POLICY_MIN_COMPILER_PATCH,
+            &bytes,
+        )
     }
 
     /// Create a PolicyMgr backed by a FakeDb with the given policy loaded.
-    async fn make_policy_mgr(policy: Policy) -> PolicyMgr {
+    async fn make_policy_mgr(container_bytes: Vec<u8>) -> PolicyMgr {
         let db = Arc::new(FakeDb::new());
         let repo = PolicyRepo::new(db);
-        PolicyMgr::new_with_initial_policy(policy, repo, Arc::new(FakeResolver::ip_only()))
+        PolicyMgr::new_with_initial_policy(container_bytes, repo, Arc::new(FakeResolver::ip_only()))
             .await
             .unwrap()
     }
@@ -379,6 +444,58 @@ mod tests {
             substrate_b: NetAddr::new_for_ip_or_host(&node_b.to_string(), 0),
             attributes: attrs,
         }
+    }
+
+    /// Build a Peering whose node_b substrate is an unresolvable hostname, so that
+    /// resolving topology with a no-entry FakeResolver fails.
+    fn make_peering_bad_host(node_a: IpAddr, node_b: IpAddr, link_id: &str) -> Peering {
+        Peering {
+            link_id: link_id.to_string(),
+            node_a,
+            substrate_a: NetAddr::new_for_ip_or_host(&node_a.to_string(), 0),
+            node_b,
+            substrate_b: NetAddr::new_for_ip_or_host("unresolvable.invalid", 5000),
+            attributes: vec![],
+        }
+    }
+
+    #[tokio::test]
+    /// A resolver failure during initial policy load must not persist the policy to the DB.
+    async fn test_initial_policy_resolver_failure_does_not_write_db() {
+        let db = Arc::new(FakeDb::new());
+        let peering = make_peering_bad_host(ip("fd5a:5052::1"), ip("fd5a:5052::2"), "link-1");
+
+        let result = PolicyMgr::new_with_initial_policy(
+            policy_with_peerings(&[peering]),
+            PolicyRepo::new(db.clone()),
+            Arc::new(FakeResolver::ip_only()),
+        )
+        .await;
+
+        assert!(result.is_err());
+        // The DB must remain empty: a policy that cannot resolve is never persisted.
+        assert!(PolicyRepo::new(db).get_current_policy().await.is_err());
+    }
+
+    #[tokio::test]
+    /// A resolver failure during an update must leave the current state and container
+    /// cache unchanged (no stale container, no swapped-in state).
+    async fn test_update_resolver_failure_preserves_state() {
+        // Start from a valid no-topology policy (vinst 1).
+        let mgr = make_policy_mgr(policy_no_topology()).await;
+        assert_eq!(mgr.get_current().vinst(), 1);
+        assert!(mgr.get_container_for_policy(2).is_none());
+
+        // Attempt an update whose topology cannot be resolved.
+        let peering = make_peering_bad_host(ip("fd5a:5052::1"), ip("fd5a:5052::2"), "link-1");
+        let result = mgr
+            .update_policy_from_container_bytes(policy_with_peerings(&[peering]))
+            .await;
+
+        assert!(result.is_err());
+        // Current state untouched and the failed vinst-2 container was never cached.
+        assert_eq!(mgr.get_current().vinst(), 1);
+        assert!(mgr.get_container_for_policy(2).is_none());
     }
 
     #[tokio::test]

--- a/vs/src/test_helpers.rs
+++ b/vs/src/test_helpers.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::time::Duration;
 use std::time::SystemTime;
+use zpr::policy::v1 as capnp_policy;
 use zpr::vsapi_types::{DockPepType, EndpointT, KeySet, TcpUdpPep, Visa};
 
 use crate::error::ResolverError;
@@ -153,4 +154,21 @@ pub fn make_visa(visa_id: u64, expires_in: Duration) -> Visa {
         KeySet::new(b"ingress", b"egress"),
         None,
     )
+}
+
+/// Build the Cap'n Proto encoded bytes of a `PolicyContainer` with the given
+/// compiler version and (arbitrary) policy payload, for use as test input.
+pub fn make_container_bytes(maj: u32, min: u32, patch: u32, policy: &[u8]) -> Vec<u8> {
+    let mut msg = capnp::message::Builder::new_default();
+    {
+        let mut container = msg.init_root::<capnp_policy::policy_container::Builder>();
+        container.set_zplc_ver_major(maj);
+        container.set_zplc_ver_minor(min);
+        container.set_zplc_ver_patch(patch);
+        container.set_policy(policy);
+        container.set_signature(&[]);
+    }
+    let mut buf = Vec::new();
+    capnp::serialize::write_message(&mut buf, &msg).unwrap();
+    buf
 }

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -639,8 +639,9 @@ mod tests {
 
     use crate::assembly::Assembly;
     use crate::assembly::tests::new_assembly_for_tests;
-    use crate::test_helpers::{make_actor_with_services_defexp, make_node_actor_defexp};
-    use bytes::Bytes;
+    use crate::test_helpers::{
+        make_actor_with_services_defexp, make_container_bytes, make_node_actor_defexp,
+    };
     use libeval::attribute::ROLE_ADAPTER;
     use libeval::eval_result::Direction;
     use libeval::policy::Policy;
@@ -650,7 +651,7 @@ mod tests {
     use zpr::write_to::WriteTo;
 
     /// Builds a Policy that declares one Authentication service with the given id.
-    fn make_policy_with_auth_service(service_id: &str) -> Policy {
+    fn make_policy_with_auth_service(service_id: &str) -> Vec<u8> {
         let mut msg = capnp::message::Builder::new_default();
         {
             let mut policy_bldr = msg.init_root::<zpr::policy::v1::policy::Builder>();
@@ -678,7 +679,12 @@ mod tests {
         }
         let mut bytes = Vec::new();
         capnp::serialize::write_message(&mut bytes, &msg).unwrap();
-        Policy::new_from_policy_bytes(Bytes::copy_from_slice(&bytes)).unwrap()
+        make_container_bytes(
+            config::POLICY_MIN_COMPILER_MAJOR,
+            config::POLICY_MIN_COMPILER_MINOR,
+            config::POLICY_MIN_COMPILER_PATCH,
+            &bytes,
+        )
     }
 
     // This test just runs a request through the pipeline. There is no real policy here
@@ -827,7 +833,7 @@ mod tests {
             .unwrap();
         asm_inner
             .policy_mgr
-            .update_policy(make_policy_with_auth_service("svc:auth"))
+            .update_policy_from_container_bytes(make_policy_with_auth_service("svc:auth"))
             .await
             .unwrap();
 
@@ -890,7 +896,7 @@ mod tests {
             .unwrap();
         asm_inner
             .policy_mgr
-            .update_policy(make_policy_with_auth_service("svc:auth"))
+            .update_policy_from_container_bytes(make_policy_with_auth_service("svc:auth"))
             .await
             .unwrap();
 
@@ -964,7 +970,7 @@ mod tests {
             .unwrap();
 
         asm.policy_mgr
-            .update_policy(make_policy_with_auth_service("svc:auth"))
+            .update_policy_from_container_bytes(make_policy_with_auth_service("svc:auth"))
             .await
             .unwrap();
 


### PR DESCRIPTION
# Branch `mk/148-update-policy` — High-Level Changes vs `main`

This branch reworks how the visa service handles **policy loading, updating, and
persistence**, moving from loose `Vec<u8>` / `Policy` plumbing to strongly-typed
"policy container" vocabulary types, and wiring the policy-update path end-to-end
through the admin API. 

## Themes

### 1. Strongly-typed policy artifacts
A policy is now always kept together with the exact container bytes it was decoded
from, so the decoded `Policy` and its on-the-wire artifact can never drift apart.

- **New module `vs/src/loaded_policy.rs`** introduces two vocabulary types:
  - `PolicyContainerBytes` — a newtype wrapping the encoded Cap'n Proto
    `PolicyContainer` bytes (backed by `Bytes` for cheap sharing).
  - `LoadedPolicy` — a decoded `Arc<Policy>` paired with its source
    `PolicyContainerBytes`. Constructed via `from_container(..)`, which guarantees
    policy/container agreement at decode time. Provides `set_vinst`,
    `hash_container_bytes` (SHA-256 over the container, used as the DB key), and
    accessors. It lives in its own module so the DB layer can use it without
    depending on the policy manager.

### 2. Policy manager rework (`vs/src/policy_mgr.rs`)
- `PolicyState` (the single atomically-swapped state) now carries the source
  `container` alongside `policy` and resolved `links_by_node`, so all three swap as
  a unit.
- Constructors changed to take **container bytes** rather than a pre-decoded
  `Policy`:
  - `new_with_initial_policy(container_bytes, ..)` decodes, assigns the initial
    `vinst`, resolves topology *before* persisting (so a policy that can't
    initialize is never stored as current), then builds state.
  - Construction de-duplicated via shared `build_state` / `from_state` helpers.
- New `update_policy_from_container_bytes(..)` replaces the old `update_policy(Policy)`
  as the update entry point.
- `get_current_container` / `get_current_loaded_policy` expose the container for the
  admin API to round-trip.


### 3. Database layer stores full container bytes (`vs/src/db/policy.rs`, `vs/src/db/*`)
- `set_current_policy` now takes `&LoadedPolicy`; `get_current_policy` →
  `get_current_loaded_policy` returns a `LoadedPolicy`. The DB now stores the full
  **container** bytes (keyed by container hash), fixing the case where only inner
  policy bytes were stored — which broke the admin API after a service restart.
- New `DbOp::SetBin { key, value }` variant lets binary blobs participate in an
  atomic pipeline; `DbConnection::set_bin` documented and marked test-only.
  `FakeDb` and `RedisDb` updated to handle `SetBin`.

### 4. Admin API policy endpoints (`vs/src/admin_service.rs`)
Implemented/reworked the policy HTTP handlers:
- `GET /admin/policies` — list (currently the single id 0)
- `GET /admin/policies/{id}` and `GET /admin/policies/curr` — return a
  `PolicyBundle` (via shared `get_policy_by_id` helper, now keyed by `u64`)
- `POST /admin/policies` — `install_policy`, decodes the bundle and activates it
- Read vs. write permission enforced on install.

### 5. `PolicyBundle` moved & centralized (`admin-api-types/src/policy_bundle.rs`)
- `PolicyBundle` extracted from `admin_api_types.rs` into its own module with the
  encode/decode logic centralized:
  - `new_from_policy_container(config_id, bytes)` — gzip + base64 encode, deriving
    the `format` string (`base64;zip;<compiler-version>`) from the container.
  - `decode()` — validates format, base64-decodes, gunzips back to container bytes.
- `vs-admin` executor (`install_policy`) simplified to delegate to these helpers
  instead of doing its own gzip/base64.

### 6. Version-handling centralization (`vs/src/config.rs`, `libeval/src/pio.rs`)
- New `config::POLICY_MIN_VERSION` constant built from the existing
  `POLICY_MIN_COMPILER_{MAJOR,MINOR,PATCH}` parts, replacing ~10 repeated
  inline `Version(..)` constructions across the codebase.
- `pio::load_policy(path, ..)` replaced by `pio::load_policy_from_container(bytes, min_version)`,
  decoupling decoding from filesystem access. `vs/src/main.rs` now just reads the
  policy file into bytes and hands them to the policy manager.

