### PR TITLE
Mk/219.1 fix topo

### DIFF
--- a/libeval/src/attribute.rs
+++ b/libeval/src/attribute.rs
@@ -209,6 +209,20 @@ impl Attribute {
     }
 }
 
+/// Compare attrs by stable policy content (key + values) only. Regular
+/// [Attribute] equality includes `expires_at`
+pub fn attributes_equivalent(a: &[Attribute], b: &[Attribute]) -> bool {
+    fn normalize(attrs: &[Attribute]) -> Vec<(&str, &[String])> {
+        let mut v: Vec<(&str, &[String])> = attrs
+            .iter()
+            .map(|at| (at.get_key(), at.get_value()))
+            .collect();
+        v.sort();
+        v
+    }
+    normalize(a) == normalize(b)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -253,5 +267,96 @@ mod tests {
         assert_eq!(attr.get_value_as_string(), "");
         let attr = Attribute::builder("key").value("foo");
         assert_eq!(attr.get_value_as_string(), "foo");
+    }
+
+    /// Two empty attribute lists are equivalent.
+    #[test]
+    fn test_attributes_equivalent_both_empty() {
+        assert!(attributes_equivalent(&[], &[]));
+    }
+
+    /// Lists with the same key/value content are equivalent.
+    #[test]
+    fn test_attributes_equivalent_same_content() {
+        let a = vec![Attribute::builder("k").value("v")];
+        let b = vec![Attribute::builder("k").value("v")];
+        assert!(attributes_equivalent(&a, &b));
+    }
+
+    /// Equivalence ignores `expires_at`: same key/value with different
+    /// expirations must still compare equal.
+    #[test]
+    fn test_attributes_equivalent_ignores_expires_at() {
+        let a = vec![
+            Attribute::builder("k")
+                .expires_in(Duration::from_secs(60))
+                .value("v"),
+        ];
+        let b = vec![
+            Attribute::builder("k")
+                .expires_in(Duration::from_secs(99999))
+                .value("v"),
+        ];
+        assert!(attributes_equivalent(&a, &b));
+    }
+
+    /// Equivalence is independent of the order of attributes in the list,
+    /// because the lists are sorted before comparison.
+    #[test]
+    fn test_attributes_equivalent_order_independent() {
+        let a = vec![
+            Attribute::builder("a").value("1"),
+            Attribute::builder("b").value("2"),
+        ];
+        let b = vec![
+            Attribute::builder("b").value("2"),
+            Attribute::builder("a").value("1"),
+        ];
+        assert!(attributes_equivalent(&a, &b));
+    }
+
+    /// Multi-valued attributes with identical values in the same order are
+    /// equivalent.
+    #[test]
+    fn test_attributes_equivalent_multivalue_same() {
+        let a = vec![Attribute::builder("k").values(vec!["x", "y", "z"])];
+        let b = vec![Attribute::builder("k").values(vec!["x", "y", "z"])];
+        assert!(attributes_equivalent(&a, &b));
+    }
+
+    /// A differing key makes the lists non-equivalent.
+    #[test]
+    fn test_attributes_equivalent_different_key() {
+        let a = vec![Attribute::builder("k1").value("v")];
+        let b = vec![Attribute::builder("k2").value("v")];
+        assert!(!attributes_equivalent(&a, &b));
+    }
+
+    /// A differing value makes the lists non-equivalent.
+    #[test]
+    fn test_attributes_equivalent_different_value() {
+        let a = vec![Attribute::builder("k").value("v1")];
+        let b = vec![Attribute::builder("k").value("v2")];
+        assert!(!attributes_equivalent(&a, &b));
+    }
+
+    /// Lists of different lengths are not equivalent.
+    #[test]
+    fn test_attributes_equivalent_different_length() {
+        let a = vec![
+            Attribute::builder("a").value("1"),
+            Attribute::builder("b").value("2"),
+        ];
+        let b = vec![Attribute::builder("a").value("1")];
+        assert!(!attributes_equivalent(&a, &b));
+    }
+
+    /// Value order within a single attribute is significant: the values are
+    /// compared as ordered vectors, so reordering them breaks equivalence.
+    #[test]
+    fn test_attributes_equivalent_value_order_significant() {
+        let a = vec![Attribute::builder("k").values(vec!["x", "y"])];
+        let b = vec![Attribute::builder("k").values(vec!["y", "x"])];
+        assert!(!attributes_equivalent(&a, &b));
     }
 }

--- a/vs/src/event_mgr.rs
+++ b/vs/src/event_mgr.rs
@@ -198,21 +198,20 @@ async fn handle_policy_updated(asm: &Arc<Assembly>, vinst: u64) -> Result<(), Se
 
      */
 
-    // For all connected nodes.
-    //   - are they still in policy? NO-> remove node (and links)
-    // For all remaining nodes.
-    //   - does node have peers? NO-> make sure no peers in topology
-    //   - YES -> check that existing peers in topo are still allowed. If not, remove link.
-    //
-    // .. finally send new link message to all nodes.
+    // Grab one consistent policy snapshot and use it for the entire synchronize-to-policy
+    // pass below, so revalidation and per-node link computation all read the same view.
+    let psnap = asm.policy_mgr.get_current_snapshot();
 
-    // alternatively- If I just ask topo manager to reconcile with policy
-    // we should get back a list of links/nodes removed.
-    // and we need to update our actor_mgr (stop vss workers etc).
-    //
-    // BUT, after this step there is nothing in topo that is at odds with policy.
-    // However, nodes in the wild will still be linked and our actor state etc is wrong.
-    // VS can drop l7 links with nodes. Then send disconnect message (new link message) to existing nodes.
+    // PolicyUpdated(vinst) is a trigger, not a guarantee that this handler reconciles that
+    // exact revision. If updates queue faster than we process them we reconcile against the
+    // latest snapshot.
+    let snapshot_vinst = psnap.vinst();
+    if snapshot_vinst != vinst {
+        info!(
+            target: EVENT,
+            "policy update event called with vinst={vinst}, using current snapshot vinst={snapshot_vinst}"
+        );
+    }
 
     info!(target: EVENT, "policy updated vinst={vinst}: TODO revalidate connected nodes");
     let connected_node_addrs = asm.actor_mgr.list_node_addrs().await?;
@@ -222,13 +221,10 @@ async fn handle_policy_updated(asm: &Arc<Assembly>, vinst: u64) -> Result<(), Se
     // Once validated the `connected_node_addrs` will be in sync with policy. And we should have already removed the stale
     // nodes from the actor_mgr state, disconnected from VSS, etc.
 
-    // TODO: We should grab a snap shot here and use it in all the following syncronize-to-policy code.
-    //let psnap = asm.policy_manager.get_current_snapshot().await?;
-
     info!(target: EVENT, "policy updated vinst={vinst}: revalidating topology");
     let report = asm
         .topo_mgr
-        .revalidate_against_policy(&asm.policy_mgr, &connected_node_addrs)
+        .revalidate_against_policy(&psnap, &connected_node_addrs)
         .await?;
     info!(
         target: EVENT,
@@ -239,17 +235,16 @@ async fn handle_policy_updated(asm: &Arc<Assembly>, vinst: u64) -> Result<(), Se
         report.orphaned_nodes.len()
     );
 
-    for naddr in &connected_node_addrs {
-        // TODO: Send updated topology to each connected node.
-        let links = asm.policy_mgr.resolved_links_for_node(naddr);
-        // let links = psnap.resolved_links_for_node(node_addr);
-
-        if let Some(vss_handle) = asm.vss_mgr.get_handle(&naddr) {
+    // Queue up setTopology messages in parallel.
+    let futs = connected_node_addrs.iter().filter_map(|naddr| {
+        let links = psnap.links_for_node(naddr);
+        asm.vss_mgr.get_handle(naddr).map(|vss_handle| async move {
             if let Err(e) = vss_handle.set_topology(links).await {
                 error!(target: EVENT, "failed to set topology for node {}: {}", naddr, e);
             }
-        }
-    }
+        })
+    });
+    futures::future::join_all(futs).await;
 
     Ok(())
 }

--- a/vs/src/event_mgr.rs
+++ b/vs/src/event_mgr.rs
@@ -7,7 +7,7 @@ use std::collections::HashSet;
 use std::net::IpAddr;
 use std::sync::Arc;
 use tokio::sync::mpsc;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
 
 use zpr::vsapi::v1::DisconnectReason;
 use zpr::vsapi_types::ServiceDescriptor;
@@ -168,7 +168,7 @@ async fn set_services_all_nodes(
     Ok(())
 }
 
-async fn handle_policy_updated(_asm: &Arc<Assembly>, vinst: u64) -> Result<(), ServiceError> {
+async fn handle_policy_updated(asm: &Arc<Assembly>, vinst: u64) -> Result<(), ServiceError> {
     /*
 
     https://github.com/org-zpr/zpr-visaservice/issues/219
@@ -184,6 +184,8 @@ async fn handle_policy_updated(_asm: &Arc<Assembly>, vinst: u64) -> Result<(), S
 
     - request re-auth all nodes.
 
+    - clear revocation list? May make more sense to keep it and make admin clear manually.
+
     - services -> ensure all services being offered are still allowed by policy.
        - What if an already connected adapter has a new service -> will need to re-connect?
        - We can do a basic check to see that all the services we have do exist in policy.
@@ -195,6 +197,59 @@ async fn handle_policy_updated(_asm: &Arc<Assembly>, vinst: u64) -> Result<(), S
        - Instead we will have already killed visas. Probably ok to let them be connected but unable to do anything.
 
      */
-    warn!(target: EVENT, "policy updated event vinst={vinst} (not implemented)");
+
+    // For all connected nodes.
+    //   - are they still in policy? NO-> remove node (and links)
+    // For all remaining nodes.
+    //   - does node have peers? NO-> make sure no peers in topology
+    //   - YES -> check that existing peers in topo are still allowed. If not, remove link.
+    //
+    // .. finally send new link message to all nodes.
+
+    // alternatively- If I just ask topo manager to reconcile with policy
+    // we should get back a list of links/nodes removed.
+    // and we need to update our actor_mgr (stop vss workers etc).
+    //
+    // BUT, after this step there is nothing in topo that is at odds with policy.
+    // However, nodes in the wild will still be linked and our actor state etc is wrong.
+    // VS can drop l7 links with nodes. Then send disconnect message (new link message) to existing nodes.
+
+    info!(target: EVENT, "policy updated vinst={vinst}: TODO revalidate connected nodes");
+    let connected_node_addrs = asm.actor_mgr.list_node_addrs().await?;
+
+    // TODO: Check existing nodes against policy.
+    // Until then  we just assume has not changed.
+    // Once validated the `connected_node_addrs` will be in sync with policy. And we should have already removed the stale
+    // nodes from the actor_mgr state, disconnected from VSS, etc.
+
+    // TODO: We should grab a snap shot here and use it in all the following syncronize-to-policy code.
+    //let psnap = asm.policy_manager.get_current_snapshot().await?;
+
+    info!(target: EVENT, "policy updated vinst={vinst}: revalidating topology");
+    let report = asm
+        .topo_mgr
+        .revalidate_against_policy(&asm.policy_mgr, &connected_node_addrs)
+        .await?;
+    info!(
+        target: EVENT,
+        "topology revalidated vinst={vinst}: removed={} updated={} repaired={} orphaned={}",
+        report.links_removed,
+        report.links_updated,
+        report.links_repaired,
+        report.orphaned_nodes.len()
+    );
+
+    for naddr in &connected_node_addrs {
+        // TODO: Send updated topology to each connected node.
+        let links = asm.policy_mgr.resolved_links_for_node(naddr);
+        // let links = psnap.resolved_links_for_node(node_addr);
+
+        if let Some(vss_handle) = asm.vss_mgr.get_handle(&naddr) {
+            if let Err(e) = vss_handle.set_topology(links).await {
+                error!(target: EVENT, "failed to set topology for node {}: {}", naddr, e);
+            }
+        }
+    }
+
     Ok(())
 }

--- a/vs/src/main.rs
+++ b/vs/src/main.rs
@@ -312,11 +312,10 @@ async fn main() -> std::process::ExitCode {
             return std::process::ExitCode::FAILURE;
         }
     };
-    if let Err(e) = asm
-        .topo_mgr
-        .restore_from_state(&asm.policy_mgr, &node_addrs)
-        .await
-    {
+    // Capture one consistent policy snapshot for the whole restore pass so every edge is
+    // validated against the same policy/links view.
+    let psnap = asm.policy_mgr.get_current_snapshot();
+    if let Err(e) = asm.topo_mgr.restore_from_state(&psnap, &node_addrs).await {
         error!(target: MAIN, "failed to restore topology state: {}", e);
         return std::process::ExitCode::FAILURE;
     }

--- a/vs/src/policy_mgr.rs
+++ b/vs/src/policy_mgr.rs
@@ -70,6 +70,73 @@ pub struct LinkDescription {
     pub cost: u32,
 }
 
+/// A consistent, owned snapshot of policy, source container, and resolved topology,
+/// all captured in a single atomic load. Cheap to clone (a refcount bump) and safe to
+/// hold across awaits: it pins the holder to one coherent view until dropped, so policy
+/// and links can never drift apart for the duration of a multi-step operation (e.g.
+/// topology revalidation after a policy update).
+#[derive(Clone)]
+pub struct PolicySnapshot(Arc<PolicyState>);
+
+impl PolicySnapshot {
+    /// The policy captured by this snapshot.
+    pub fn policy(&self) -> &Policy {
+        &self.0.policy
+    }
+
+    /// A clone of the policy Arc captured by this snapshot.
+    pub fn policy_arc(&self) -> Arc<Policy> {
+        self.0.policy.clone()
+    }
+
+    /// The version instance number of the captured policy.
+    pub fn vinst(&self) -> u64 {
+        self.policy().vinst()
+    }
+
+    /// A clone of the source container bytes captured by this snapshot.
+    pub fn container(&self) -> PolicyContainerBytes {
+        self.0.container.clone()
+    }
+
+    /// The resolved links for `node` as captured by this snapshot.
+    pub fn links_for_node(&self, node: &IpAddr) -> Vec<Link> {
+        self.0.links_by_node.get(node).cloned().unwrap_or_default()
+    }
+
+    /// Describe the link between `node_a` and `node_b` against the captured policy.
+    /// Both arguments are ZPR addresses.
+    ///
+    /// ## Errors
+    /// - `TopologyError::LinkNotFound` if there is no link between `node_a` and `node_b`
+    ///   in the captured policy.
+    pub fn describe_link(
+        &self,
+        node_a: &IpAddr,
+        node_b: &IpAddr,
+    ) -> Result<LinkDescription, ServiceError> {
+        let policy = self.policy();
+        if let Some(peers) = policy.get_peers_for_node(node_a) {
+            for peer in peers {
+                if &peer.remote_zpr_addr == node_b {
+                    let attrs = get_attributes_for_link(policy, &peer.link_id);
+                    let cost = if !attrs.is_empty() {
+                        get_link_cost(&attrs, DEFAULT_LINK_COST)
+                    } else {
+                        DEFAULT_LINK_COST
+                    };
+                    return Ok(LinkDescription {
+                        link_id: peer.link_id.clone(),
+                        attrs,
+                        cost,
+                    });
+                }
+            }
+        }
+        Err(TopologyError::LinkNotFound(format!("{node_a} <-> {node_b}")).into())
+    }
+}
+
 /// Production resolver that uses the OS/system resolver via `tokio::net::lookup_host`.
 pub struct SystemResolver;
 
@@ -224,63 +291,49 @@ impl PolicyMgr {
         Ok(vinst)
     }
 
-    /// Callers should drop the policy as quickly as possible to avoid missing a policy update.
+    /// A consistent snapshot of policy, container, and resolved links taken in
+    /// one atomic load. Holding it does not block updates, but it pins the
+    /// holder to an older view until dropped. Use this when a multi-step
+    /// operation must see one coherent policy/links pair; otherwise the
+    /// single-shot accessors below suffice.
     ///
-    /// Currently there is no way to get a consistent view of policy AND the node resolution cache.
-    /// If we find we need that we can add a snapshot mechanism.
+    /// `ArcSwap::load_full` is just a refcount bump, and the resulting owned
+    /// `Arc<PolicyState>` outlives the load `Guard` so the snapshot is safe to
+    /// hold across awaits.
+    pub fn get_current_snapshot(&self) -> PolicySnapshot {
+        PolicySnapshot(self.state.load_full())
+    }
+
+    /// Callers should drop the policy as quickly as possible to avoid missing a policy update.
     pub fn get_current(&self) -> Arc<Policy> {
-        self.state.load().policy.clone()
+        self.get_current_snapshot().policy_arc()
     }
 
     /// Get the source container bytes for the current policy (for the admin API).
     pub fn get_current_container(&self) -> PolicyContainerBytes {
-        self.state.load().container.clone()
+        self.get_current_snapshot().container()
     }
 
     /// When policy is updated, all the peer tables have their DNS names resolved and cached.
     /// Use this to get the links specified by policy for a node.
-    ///
-    /// Currently there is no way to get a consistent view of policy AND the node resolution cache.
-    /// If we find we need that we can add a snapshot mechanism.
-    ///
     pub fn resolved_links_for_node(&self, node: &IpAddr) -> Vec<Link> {
-        self.state
-            .load()
-            .links_by_node
-            .get(node)
-            .cloned()
-            .unwrap_or_default()
+        self.get_current_snapshot().links_for_node(node)
     }
 
     /// Consult policy to get a description of the link between `node_a` and `node_b`.
-    /// Both arguments are ZPR addresses.
+    /// Both arguments are ZPR addresses. A convenience single-shot wrapper over
+    /// [PolicySnapshot::describe_link]; callers needing a consistent multi-step view
+    /// should take a snapshot and call its method directly.
     ///
     /// ## Errors
     /// - `TopologyError::LinkNotFound` if there is no link between `node_a` and `node_b` in the policy.
+    #[allow(dead_code)]
     pub fn describe_link(
         &self,
         node_a: &IpAddr,
         node_b: &IpAddr,
     ) -> Result<LinkDescription, ServiceError> {
-        let policy = self.get_current();
-        if let Some(peers) = policy.get_peers_for_node(node_a) {
-            for peer in peers {
-                if &peer.remote_zpr_addr == node_b {
-                    let attrs = get_attributes_for_link(&policy, &peer.link_id);
-                    let cost = if !attrs.is_empty() {
-                        get_link_cost(&attrs, DEFAULT_LINK_COST)
-                    } else {
-                        DEFAULT_LINK_COST
-                    };
-                    return Ok(LinkDescription {
-                        link_id: peer.link_id.clone(),
-                        attrs,
-                        cost,
-                    });
-                }
-            }
-        }
-        Err(TopologyError::LinkNotFound(format!("{node_a} <-> {node_b}")).into())
+        self.get_current_snapshot().describe_link(node_a, node_b)
     }
 }
 
@@ -682,6 +735,50 @@ mod tests {
             .unwrap();
         assert_eq!(result.attrs.len(), 1);
         assert_eq!(result.attrs[0].get_key(), "link.class");
+    }
+
+    /// A snapshot is an internally-consistent, stable, owned view: its policy vinst and
+    /// resolved links agree at capture time, and a later update does not mutate a
+    /// snapshot already held.
+    #[tokio::test]
+    async fn test_snapshot_is_consistent_and_stable_across_update() {
+        let a = ip("fd5a:5052::1");
+        let b = ip("fd5a:5052::2");
+        // Start from a policy with one IP-resolvable link (vinst 1).
+        let mgr = make_policy_mgr(policy_with_peerings(&[make_peering(
+            a,
+            b,
+            "link-ab",
+            vec![],
+        )]))
+        .await;
+
+        // The captured policy vinst and links agree at capture time.
+        let snap = mgr.get_current_snapshot();
+        assert_eq!(snap.vinst(), 1);
+        assert!(
+            !snap.links_for_node(&a).is_empty(),
+            "snapshot must see the link its policy describes"
+        );
+
+        // Update to a fresh no-topology policy (vinst 2).
+        let new_vinst = mgr
+            .update_policy_from_container_bytes(policy_no_topology())
+            .await
+            .unwrap();
+        assert_eq!(new_vinst, 2);
+
+        // The already-held snapshot is unchanged: still vinst 1, still has the old link.
+        assert_eq!(snap.vinst(), 1, "held snapshot must not see the new vinst");
+        assert!(
+            !snap.links_for_node(&a).is_empty(),
+            "held snapshot must retain its captured links"
+        );
+
+        // A freshly taken snapshot reflects the update.
+        let snap2 = mgr.get_current_snapshot();
+        assert_eq!(snap2.vinst(), 2);
+        assert!(snap2.links_for_node(&a).is_empty());
     }
 
     fn ip_peer(link_id: &str, ip: IpAddr, port: u16) -> Peer {

--- a/vs/src/router.rs
+++ b/vs/src/router.rs
@@ -365,6 +365,9 @@ impl Router {
     /// - [TopologyError::LinkNotFound] if no link currently connects `a` and `b`.
     /// - [TopologyError::LinkExists] if `id` differs from the old id but is already used
     ///   by another live edge.
+    // Retained as a tested Router primitive; revalidation now does remove-then-install
+    // so it has no live caller.
+    #[allow(dead_code)]
     pub fn replace_link_between(
         &self,
         a: &IpAddr,
@@ -635,6 +638,7 @@ impl Graph {
     /// Replace the link currently connecting `a` and `b` with one carrying the given id,
     /// attributes, and cost. Validates fully before mutating so a rejected replacement
     /// leaves the existing link untouched. See [Router::replace_link_between].
+    #[allow(dead_code)]
     fn replace_link(
         &mut self,
         a: &NodeId,

--- a/vs/src/router.rs
+++ b/vs/src/router.rs
@@ -121,6 +121,17 @@ impl RouterInner {
     }
 }
 
+/// A snapshot of a single live link in the router, used by topology revalidation to
+/// compare the live router graph against what policy currently describes.
+#[derive(Debug, Clone)]
+pub struct RouterLink {
+    pub a: IpAddr,
+    pub b: IpAddr,
+    pub id: LinkId,
+    pub attributes: Vec<Attribute>,
+    pub cost: u32,
+}
+
 pub struct Router {
     inner: RwLock<RouterInner>,
 }
@@ -306,6 +317,75 @@ impl Router {
 
         inner.topology.remove_link(id);
         inner.topo_generation += 1;
+    }
+
+    /// Current link between two node addrs, in either order (edges are undirected).
+    /// Returns `None` if no link connects them.
+    pub fn link_between(&self, a: &IpAddr, b: &IpAddr) -> Option<RouterLink> {
+        let inner = self.inner.read().unwrap();
+        let na: NodeId = a.into();
+        let nb: NodeId = b.into();
+        let id = inner.topology.link_id_between(&na, &nb)?;
+        let link = inner.topology.edges.get(&id)?;
+        Some(RouterLink {
+            a: link.a.0,
+            b: link.b.0,
+            id,
+            attributes: link.attributes.clone(),
+            cost: link.cost,
+        })
+    }
+
+    /// Snapshot of all live router links.
+    pub fn link_snapshot(&self) -> Vec<RouterLink> {
+        let inner = self.inner.read().unwrap();
+        inner
+            .topology
+            .edges
+            .iter()
+            .map(|(id, link)| RouterLink {
+                a: link.a.0,
+                b: link.b.0,
+                id: id.clone(),
+                attributes: link.attributes.clone(),
+                cost: link.cost,
+            })
+            .collect()
+    }
+
+    /// Replace the existing link between two endpoints under a single router write lock.
+    ///
+    /// This validates fully before mutating, so a rejected replacement leaves the old
+    /// working link intact. It avoids the unsafe `remove_link(old)` + `add_link(new)`
+    /// sequence where the add can fail after the working link is already gone.
+    ///
+    /// ## Errors
+    /// - [TopologyError::LinkToSelf] if `a == b`.
+    /// - [TopologyError::NodeNotFound] if either endpoint is missing.
+    /// - [TopologyError::LinkNotFound] if no link currently connects `a` and `b`.
+    /// - [TopologyError::LinkExists] if `id` differs from the old id but is already used
+    ///   by another live edge.
+    pub fn replace_link_between(
+        &self,
+        a: &IpAddr,
+        b: &IpAddr,
+        id: LinkId,
+        attributes: Vec<Attribute>,
+        cost: u32,
+    ) -> Result<(), TopologyError> {
+        let mut inner = self.inner.write().unwrap();
+        let na: NodeId = a.into();
+        let nb: NodeId = b.into();
+        inner
+            .topology
+            .replace_link(&na, &nb, id, attributes, cost)?;
+
+        // A link's id/cost change can affect arbitrary cached pairs (as with add_link),
+        // so conservatively flush the whole route cache.
+        inner.route_cache.clear();
+        inner.link_to_cache_keys.clear();
+        inner.topo_generation += 1;
+        Ok(())
     }
 
     /// Given a node address, return the connected peers,
@@ -536,6 +616,76 @@ impl Graph {
     #[allow(dead_code)]
     fn link(&self, id: &LinkId) -> Option<&Link> {
         self.edges.get(id)
+    }
+
+    /// Return the id of the link connecting `a` and `b` (in either order), or `None`.
+    /// Scans `a`'s incident edges for the one whose other endpoint is `b`.
+    fn link_id_between(&self, a: &NodeId, b: &NodeId) -> Option<LinkId> {
+        let node = self.nodes.get(a)?;
+        for link_id in &node.edges {
+            let link = self.edges.get(link_id)?;
+            let other = if &link.a == a { &link.b } else { &link.a };
+            if other == b {
+                return Some(link_id.clone());
+            }
+        }
+        None
+    }
+
+    /// Replace the link currently connecting `a` and `b` with one carrying the given id,
+    /// attributes, and cost. Validates fully before mutating so a rejected replacement
+    /// leaves the existing link untouched. See [Router::replace_link_between].
+    fn replace_link(
+        &mut self,
+        a: &NodeId,
+        b: &NodeId,
+        new_id: LinkId,
+        attributes: Vec<Attribute>,
+        cost: u32,
+    ) -> Result<(), TopologyError> {
+        if a == b {
+            return Err(TopologyError::LinkToSelf(
+                "replace_link: self-links are not allowed".into(),
+            ));
+        }
+        if !self.nodes.contains_key(a) {
+            return Err(TopologyError::NodeNotFound(format!(
+                "replace_link: node {:?} does not exist",
+                a
+            )));
+        }
+        if !self.nodes.contains_key(b) {
+            return Err(TopologyError::NodeNotFound(format!(
+                "replace_link: node {:?} does not exist",
+                b
+            )));
+        }
+        let old_id = self.link_id_between(a, b).ok_or_else(|| {
+            TopologyError::LinkNotFound(format!(
+                "replace_link: no existing link between {:?} and {:?}",
+                a, b
+            ))
+        })?;
+        // A new id colliding with a different live edge would corrupt that edge.
+        if new_id != old_id && self.edges.contains_key(&new_id) {
+            return Err(TopologyError::LinkExists(new_id.0));
+        }
+
+        // Validated: swap the edge in place, then recompute once.
+        self.remove_link_impl(&old_id);
+        self.edges.insert(
+            new_id.clone(),
+            Link {
+                a: a.clone(),
+                b: b.clone(),
+                attributes,
+                cost,
+            },
+        );
+        self.nodes.get_mut(a).unwrap().edges.insert(new_id.clone());
+        self.nodes.get_mut(b).unwrap().edges.insert(new_id);
+        self.recompute();
+        Ok(())
     }
 
     /// Look up a link by id for mutation. Returns `None` if not found.
@@ -1201,6 +1351,80 @@ mod tests {
             r.route_to_path(&route, &na),
             Err(TopologyError::NodeNotFound(_))
         ));
+    }
+
+    // --- link_between / link_snapshot / replace_link_between tests ---
+
+    #[test]
+    fn test_link_between_returns_link_in_either_order() {
+        // link_between finds the link regardless of argument order.
+        let a = ip("10.0.0.1");
+        let b = ip("10.0.0.2");
+        let r = Router::new();
+        r.add_node(a).unwrap();
+        r.add_node(b).unwrap();
+        r.add_link(a, b, LinkId("ab".into()), vec![], 7).unwrap();
+        let fwd = r.link_between(&a, &b).unwrap();
+        assert_eq!(fwd.id, LinkId("ab".into()));
+        assert_eq!(fwd.cost, 7);
+        // Reverse order finds the same link.
+        assert_eq!(r.link_between(&b, &a).unwrap().id, LinkId("ab".into()));
+    }
+
+    #[test]
+    fn test_link_between_none_when_absent() {
+        // link_between returns None when no link connects the two nodes.
+        let (r, a, b, _c) = make_router_abc();
+        assert!(r.link_between(&a, &b).is_none());
+    }
+
+    #[test]
+    fn test_link_snapshot_returns_all_links() {
+        // link_snapshot returns one entry per live link.
+        let (r, a, b, c) = make_router_abc();
+        r.add_link(a, b, LinkId("ab".into()), vec![], 1).unwrap();
+        r.add_link(b, c, LinkId("bc".into()), vec![], 1).unwrap();
+        let mut ids: Vec<String> = r.link_snapshot().into_iter().map(|l| l.id.0).collect();
+        ids.sort();
+        assert_eq!(ids, vec!["ab".to_string(), "bc".to_string()]);
+    }
+
+    #[test]
+    fn test_replace_link_between_updates_cost() {
+        // Replacing a link with the same id but a new cost updates routing.
+        let a = ip("10.0.0.1");
+        let b = ip("10.0.0.2");
+        let r = Router::new();
+        r.add_node(a).unwrap();
+        r.add_node(b).unwrap();
+        r.add_link(a, b, LinkId("ab".into()), vec![], 1).unwrap();
+        r.replace_link_between(&a, &b, LinkId("ab".into()), vec![], 42)
+            .unwrap();
+        assert_eq!(r.get_best_route(&a, &b).unwrap().cost, 42);
+        assert_eq!(r.link_between(&a, &b).unwrap().cost, 42);
+    }
+
+    #[test]
+    fn test_replace_link_between_id_collision_errors_and_preserves() {
+        // Replacing with an id already used by another live link is rejected, leaving the
+        // original link intact.
+        let (r, a, b, c) = make_router_abc();
+        r.add_link(a, b, LinkId("ab".into()), vec![], 1).unwrap();
+        r.add_link(a, c, LinkId("ac".into()), vec![], 1).unwrap();
+        let err = r.replace_link_between(&a, &b, LinkId("ac".into()), vec![], 5);
+        assert!(matches!(err, Err(TopologyError::LinkExists(_))));
+        // Original a-b link unchanged.
+        let link = r.link_between(&a, &b).unwrap();
+        assert_eq!(link.id, LinkId("ab".into()));
+        assert_eq!(link.cost, 1);
+    }
+
+    #[test]
+    fn test_replace_link_between_no_link_errors() {
+        // Replacing a link that does not exist returns LinkNotFound.
+        let (r, a, b, _c) = make_router_abc();
+        let err = r.replace_link_between(&a, &b, LinkId("ab".into()), vec![], 1);
+        assert!(matches!(err, Err(TopologyError::LinkNotFound(_))));
     }
 
     // --- Graph unit tests ---

--- a/vs/src/router.rs
+++ b/vs/src/router.rs
@@ -132,6 +132,15 @@ pub struct RouterLink {
     pub cost: u32,
 }
 
+/// One link to install as part of an [Router::apply_link_batch] reconciliation.
+pub struct LinkSpec {
+    pub a: IpAddr,
+    pub b: IpAddr,
+    pub id: LinkId,
+    pub attributes: Vec<Attribute>,
+    pub cost: u32,
+}
+
 pub struct Router {
     inner: RwLock<RouterInner>,
 }
@@ -239,6 +248,42 @@ impl Router {
         inner.link_to_cache_keys.clear();
 
         inner.topology.add_link(a, b, id, attributes, cost)?;
+        inner.topo_generation += 1;
+        Ok(())
+    }
+
+    /// Atomically apply a batch of link removals followed by additions under a single
+    /// write lock, so no concurrent route observes a partially-rewritten graph.
+    pub fn apply_link_batch(
+        &self,
+        removals: &[LinkId],
+        additions: Vec<LinkSpec>,
+    ) -> Result<(), TopologyError> {
+        let mut inner = self.inner.write().unwrap();
+        for id in removals {
+            inner.topology.remove_link(id);
+        }
+        let mut added: Vec<LinkId> = Vec::with_capacity(additions.len());
+        for spec in additions {
+            if let Err(e) =
+                inner
+                    .topology
+                    .add_link(spec.a, spec.b, spec.id.clone(), spec.attributes, spec.cost)
+            {
+                for done in added.iter().rev() {
+                    inner.topology.remove_link(done);
+                }
+                inner.route_cache.clear();
+                inner.link_to_cache_keys.clear();
+                inner.topo_generation += 1;
+                return Err(e);
+            }
+            added.push(spec.id);
+        }
+        // A reconcile touches arbitrary edges, so a full cache flush is the only sound
+        // invalidation; targeted eviction is not worth the bookkeeping on this cold path.
+        inner.route_cache.clear();
+        inner.link_to_cache_keys.clear();
         inner.topo_generation += 1;
         Ok(())
     }

--- a/vs/src/topology_mgr.rs
+++ b/vs/src/topology_mgr.rs
@@ -116,20 +116,6 @@ impl TopologyMgr {
         connect_via: &IpAddr,
         new_node_addr: &IpAddr,
     ) -> Result<(), AddLinkedNodeError> {
-        // I think we need to add the node.
-        // But I'm not sure that the actor-mgr needs to know about links.
-        // It does know about tethers.  So maybe is should?  But the router has the
-        // actual graph. So maybe we add redis backing to the router???
-        //
-        // Is this node already in our graph over another link?
-        //
-        // QUESTION - how to tell if this node is just making a link or if it is reconnecting and we need to restore state?
-        //
-        // If a node is already connected to ZPR why does it need to authenticate again?
-        // Well, it may not be allowed to make the link for one thing.
-        //
-        // Computed before describe_link so even an early policy failure is classified
-        // (new vs pre-existing node) for the caller's address-release decision.
         let peer_node_addrs = self.router.get_peers(new_node_addr);
         let preexisting_node = self.router.has_node(new_node_addr);
 

--- a/vs/src/topology_mgr.rs
+++ b/vs/src/topology_mgr.rs
@@ -14,7 +14,7 @@ use crate::actor_mgr::ActorMgr;
 use crate::db::LinkRepo;
 use crate::error::{ServiceError, TopologyError};
 use crate::logging::targets::TOPO;
-use crate::policy_mgr::{LinkDescription, PolicyMgr};
+use crate::policy_mgr::{LinkDescription, PolicySnapshot};
 use crate::router::Router;
 
 use libeval::actor::Actor;
@@ -131,7 +131,7 @@ impl TopologyMgr {
     /// error, so we never report failure while leaving a router edge behind.
     pub async fn add_linked_node(
         &self,
-        policy_mgr: &PolicyMgr,
+        snapshot: &PolicySnapshot,
         actor_mgr: &ActorMgr,
         actor: &Actor,
         connect_via: &IpAddr,
@@ -140,7 +140,7 @@ impl TopologyMgr {
         let peer_node_addrs = self.router.get_peers(new_node_addr);
         let preexisting_node = self.router.has_node(new_node_addr);
 
-        let link_desc = match policy_mgr.describe_link(connect_via, new_node_addr) {
+        let link_desc = match snapshot.describe_link(connect_via, new_node_addr) {
             Ok(d) => d,
             Err(e) => return Err(AddLinkedNodeError::new(preexisting_node, e)),
         };
@@ -223,7 +223,7 @@ impl TopologyMgr {
     /// startup fails the service rather than silently deleting valid persisted edges.
     pub async fn restore_from_state(
         &self,
-        policy_mgr: &PolicyMgr,
+        snapshot: &PolicySnapshot,
         node_addrs: &[IpAddr],
     ) -> Result<(), ServiceError> {
         // In this code path there should be no cases for errors from add_node.
@@ -237,7 +237,7 @@ impl TopologyMgr {
             // Decide the edge's fate against the current policy + known-node set. Any
             // error other than the precise not-described case is propagated, so a
             // transient policy/DB problem fails startup rather than deleting valid edges.
-            match Self::decide_edge(policy_mgr, &known, &a, &b)? {
+            match Self::decide_edge(snapshot, &known, &a, &b)? {
                 EdgeDecision::Install(link_desc) => {
                     match self.install_router_link(&a, &b, link_desc) {
                         Ok(()) | Err(TopologyError::LinkExists(_)) => {}
@@ -264,7 +264,7 @@ impl TopologyMgr {
     /// `LinkNotFound`-in-policy case yields `Gc`; any other error propagates so a
     /// transient policy/DB failure never silently deletes a valid edge.
     fn decide_edge(
-        policy_mgr: &PolicyMgr,
+        snapshot: &PolicySnapshot,
         known: &HashSet<IpAddr>,
         a: &IpAddr,
         b: &IpAddr,
@@ -274,7 +274,7 @@ impl TopologyMgr {
         }
         // Edges are stored undirected, so try describing the link in either direction
         // before concluding the policy no longer describes it.
-        match Self::describe_policy_link_either(policy_mgr, a, b) {
+        match Self::describe_policy_link_either(snapshot, a, b) {
             Ok(desc) => Ok(EdgeDecision::Install(desc)),
             Err(ServiceError::Topology(TopologyError::LinkNotFound(_))) => Ok(EdgeDecision::Gc),
             Err(e) => Err(e),
@@ -297,7 +297,7 @@ impl TopologyMgr {
     /// pass.
     pub async fn revalidate_against_policy(
         &self,
-        policy_mgr: &PolicyMgr,
+        snapshot: &PolicySnapshot,
         node_addrs: &[IpAddr],
     ) -> Result<RevalidationReport, ServiceError> {
         let mut report = RevalidationReport::default();
@@ -326,7 +326,7 @@ impl TopologyMgr {
             let persisted = persisted_set.contains(&(a, b));
             let router_link = self.router.link_between(&a, &b);
 
-            match Self::decide_edge(policy_mgr, &known, &a, &b)? {
+            match Self::decide_edge(snapshot, &known, &a, &b)? {
                 EdgeDecision::Gc => {
                     let had_router = router_link.is_some();
                     if let Some(rl) = &router_link {
@@ -403,13 +403,13 @@ impl TopologyMgr {
     /// `LinkNotFound` only when neither direction matches; any other error from the
     /// first lookup is returned as-is.
     fn describe_policy_link_either(
-        policy_mgr: &PolicyMgr,
+        snapshot: &PolicySnapshot,
         a: &IpAddr,
         b: &IpAddr,
     ) -> Result<LinkDescription, ServiceError> {
-        match policy_mgr.describe_link(a, b) {
+        match snapshot.describe_link(a, b) {
             Err(ServiceError::Topology(TopologyError::LinkNotFound(_))) => {
-                policy_mgr.describe_link(b, a)
+                snapshot.describe_link(b, a)
             }
             other => other,
         }
@@ -513,6 +513,7 @@ mod tests {
     use crate::config;
     use crate::counters::Counters;
     use crate::db::{ActorRepo, DbConnection, FakeDb, LinkRepo, NodeRepo, PolicyRepo};
+    use crate::policy_mgr::PolicyMgr;
     use crate::test_helpers::{FakeResolver, make_container_bytes, make_node_actor_defexp};
 
     fn ip(s: &str) -> IpAddr {
@@ -608,9 +609,15 @@ mod tests {
         topo.add_node(a).unwrap();
         let actor_b = make_node_actor_defexp(&b.to_string(), "node-b", "[fd5a:5052::100]:1234");
 
-        topo.add_linked_node(&policy_mgr, &actor_mgr, &actor_b, &a, &b)
-            .await
-            .unwrap();
+        topo.add_linked_node(
+            &policy_mgr.get_current_snapshot(),
+            &actor_mgr,
+            &actor_b,
+            &a,
+            &b,
+        )
+        .await
+        .unwrap();
 
         let edges = LinkRepo::new(db).list_edges().await.unwrap();
         assert_eq!(edges.len(), 1);
@@ -643,9 +650,15 @@ mod tests {
 
         // Re-adding the same link hits the already-connected path and repairs Redis.
         let actor_b = make_node_actor_defexp(&b.to_string(), "node-b", "[fd5a:5052::100]:1234");
-        topo.add_linked_node(&policy_mgr, &actor_mgr, &actor_b, &a, &b)
-            .await
-            .unwrap();
+        topo.add_linked_node(
+            &policy_mgr.get_current_snapshot(),
+            &actor_mgr,
+            &actor_b,
+            &a,
+            &b,
+        )
+        .await
+        .unwrap();
 
         let edges = LinkRepo::new(db).list_edges().await.unwrap();
         assert_eq!(edges.len(), 1);
@@ -668,7 +681,13 @@ mod tests {
         db.set("topology:edges", "junk").await.unwrap();
 
         let result = topo
-            .add_linked_node(&policy_mgr, &actor_mgr, &actor_b, &a, &b)
+            .add_linked_node(
+                &policy_mgr.get_current_snapshot(),
+                &actor_mgr,
+                &actor_b,
+                &a,
+                &b,
+            )
             .await;
         // A brand-new node's failure must be reported as a new-node failure so the
         // caller releases the freshly allocated address.
@@ -713,7 +732,13 @@ mod tests {
 
         let actor_b = make_node_actor_defexp(&b.to_string(), "node-b", "[fd5a:5052::100]:1234");
         let result = topo
-            .add_linked_node(&policy_mgr, &actor_mgr, &actor_b, &a, &b)
+            .add_linked_node(
+                &policy_mgr.get_current_snapshot(),
+                &actor_mgr,
+                &actor_b,
+                &a,
+                &b,
+            )
             .await;
 
         assert!(
@@ -740,9 +765,15 @@ mod tests {
 
         topo.add_node(a).unwrap();
         let actor_b = make_node_actor_defexp(&b.to_string(), "node-b", "[fd5a:5052::100]:1234");
-        topo.add_linked_node(&policy_mgr, &actor_mgr, &actor_b, &a, &b)
-            .await
-            .unwrap();
+        topo.add_linked_node(
+            &policy_mgr.get_current_snapshot(),
+            &actor_mgr,
+            &actor_b,
+            &a,
+            &b,
+        )
+        .await
+        .unwrap();
         assert_eq!(
             LinkRepo::new(db.clone()).list_edges().await.unwrap().len(),
             1
@@ -768,7 +799,9 @@ mod tests {
         LinkRepo::new(db.clone()).add_edge(&a, &b).await.unwrap();
         let topo = TopologyMgr::new(LinkRepo::new(db.clone()));
 
-        topo.restore_from_state(&policy_mgr, &[a, b]).await.unwrap();
+        topo.restore_from_state(&policy_mgr.get_current_snapshot(), &[a, b])
+            .await
+            .unwrap();
 
         // The link is back: a and b are peers and a route exists.
         assert_eq!(topo.get_peers(&a), vec![b]);
@@ -786,7 +819,9 @@ mod tests {
         // Persist an edge directly, then restore into a fresh topology to simulate restart.
         LinkRepo::new(db.clone()).add_edge(&a, &b).await.unwrap();
         let topo = TopologyMgr::new(LinkRepo::new(db.clone()));
-        topo.restore_from_state(&policy_mgr, &[a, b]).await.unwrap();
+        topo.restore_from_state(&policy_mgr.get_current_snapshot(), &[a, b])
+            .await
+            .unwrap();
         assert_eq!(topo.get_peers(&a), vec![b], "precondition: link restored");
 
         let added = topo.add_node_if_not_exists(b);
@@ -816,7 +851,9 @@ mod tests {
         LinkRepo::new(db.clone()).add_edge(&a, &c).await.unwrap();
         let topo = TopologyMgr::new(LinkRepo::new(db.clone()));
 
-        topo.restore_from_state(&policy_mgr, &[a, c]).await.unwrap();
+        topo.restore_from_state(&policy_mgr.get_current_snapshot(), &[a, c])
+            .await
+            .unwrap();
 
         assert!(
             topo.get_peers(&a).is_empty(),
@@ -839,7 +876,9 @@ mod tests {
         let topo = TopologyMgr::new(LinkRepo::new(db.clone()));
 
         // Only `a` survived node-state refresh; `b` is gone.
-        topo.restore_from_state(&policy_mgr, &[a]).await.unwrap();
+        topo.restore_from_state(&policy_mgr.get_current_snapshot(), &[a])
+            .await
+            .unwrap();
 
         assert!(topo.get_peers(&a).is_empty());
         assert!(
@@ -859,7 +898,9 @@ mod tests {
         LinkRepo::new(db.clone()).add_edge(&a, &b).await.unwrap();
         let topo = TopologyMgr::new(LinkRepo::new(db.clone()));
 
-        topo.restore_from_state(&policy_mgr, &[]).await.unwrap();
+        topo.restore_from_state(&policy_mgr.get_current_snapshot(), &[])
+            .await
+            .unwrap();
 
         assert!(
             LinkRepo::new(db).list_edges().await.unwrap().is_empty(),
@@ -887,7 +928,7 @@ mod tests {
         LinkRepo::new(db.clone()).add_edge(&a, &c).await.unwrap();
 
         let report = topo
-            .revalidate_against_policy(&policy_mgr, &[a, c])
+            .revalidate_against_policy(&policy_mgr.get_current_snapshot(), &[a, c])
             .await
             .unwrap();
 
@@ -920,7 +961,7 @@ mod tests {
         LinkRepo::new(db.clone()).add_edge(&a, &b).await.unwrap();
 
         let report = topo
-            .revalidate_against_policy(&policy_mgr, &[a, b])
+            .revalidate_against_policy(&policy_mgr.get_current_snapshot(), &[a, b])
             .await
             .unwrap();
 
@@ -945,7 +986,7 @@ mod tests {
         let topo = TopologyMgr::new(LinkRepo::new(db.clone()));
 
         let report = topo
-            .revalidate_against_policy(&policy_mgr, &[a, b])
+            .revalidate_against_policy(&policy_mgr.get_current_snapshot(), &[a, b])
             .await
             .unwrap();
 
@@ -976,7 +1017,7 @@ mod tests {
         );
 
         let report = topo
-            .revalidate_against_policy(&policy_mgr, &[a, b])
+            .revalidate_against_policy(&policy_mgr.get_current_snapshot(), &[a, b])
             .await
             .unwrap();
 
@@ -1006,7 +1047,7 @@ mod tests {
             .unwrap();
 
         let report = topo
-            .revalidate_against_policy(&policy_mgr, &[a, c])
+            .revalidate_against_policy(&policy_mgr.get_current_snapshot(), &[a, c])
             .await
             .unwrap();
 
@@ -1024,13 +1065,13 @@ mod tests {
         LinkRepo::new(db.clone()).add_edge(&a, &b).await.unwrap();
         let topo = TopologyMgr::new(LinkRepo::new(db.clone()));
         // First pass installs the link from policy.
-        topo.revalidate_against_policy(&policy_mgr, &[a, b])
+        topo.revalidate_against_policy(&policy_mgr.get_current_snapshot(), &[a, b])
             .await
             .unwrap();
 
         // Second pass must be a no-op.
         let report = topo
-            .revalidate_against_policy(&policy_mgr, &[a, b])
+            .revalidate_against_policy(&policy_mgr.get_current_snapshot(), &[a, b])
             .await
             .unwrap();
 
@@ -1057,13 +1098,13 @@ mod tests {
         LinkRepo::new(db.clone()).add_edge(&a, &b).await.unwrap();
         let topo = TopologyMgr::new(LinkRepo::new(db.clone()));
         // First pass installs the attribute-bearing link.
-        topo.revalidate_against_policy(&policy_mgr, &[a, b])
+        topo.revalidate_against_policy(&policy_mgr.get_current_snapshot(), &[a, b])
             .await
             .unwrap();
 
         // Second pass must not report a spurious update from rebuilt attrs.
         let report = topo
-            .revalidate_against_policy(&policy_mgr, &[a, b])
+            .revalidate_against_policy(&policy_mgr.get_current_snapshot(), &[a, b])
             .await
             .unwrap();
 
@@ -1102,7 +1143,7 @@ mod tests {
             .unwrap();
 
         let result = topo
-            .revalidate_against_policy(&policy_mgr, &[a, b, c, d])
+            .revalidate_against_policy(&policy_mgr.get_current_snapshot(), &[a, b, c, d])
             .await;
 
         assert!(result.is_err(), "id collision must surface as an error");
@@ -1126,7 +1167,7 @@ mod tests {
 
         // `c` is a known node with no links.
         let report = topo
-            .revalidate_against_policy(&policy_mgr, &[a, b, c])
+            .revalidate_against_policy(&policy_mgr.get_current_snapshot(), &[a, b, c])
             .await
             .unwrap();
 

--- a/vs/src/topology_mgr.rs
+++ b/vs/src/topology_mgr.rs
@@ -18,13 +18,34 @@ use crate::policy_mgr::{LinkDescription, PolicyMgr};
 use crate::router::Router;
 
 use libeval::actor::Actor;
-use libeval::attribute::{AttrMatch, Attribute};
+use libeval::attribute::{AttrMatch, Attribute, attributes_equivalent};
 use libeval::eval_route::{RouteHint, TopologyQueryApi};
 use libeval::route::{LinkId, NodeId, Route};
 
 pub struct TopologyMgr {
     router: Router,
     link_repo: LinkRepo,
+}
+
+/// The fate of a persisted/live edge when validated against the current policy.
+enum EdgeDecision {
+    /// Policy still describes this link; install/refresh it with this description.
+    Install(LinkDescription),
+    /// Policy no longer describes this link (or an endpoint is gone); garbage-collect it.
+    Gc,
+}
+
+/// Summary of what [TopologyMgr::revalidate_against_policy] changed, for logging by the caller.
+#[derive(Debug, Default)]
+pub struct RevalidationReport {
+    /// Links removed because policy no longer describes them.
+    pub links_removed: usize,
+    /// Links whose id/attrs/cost were refreshed to match policy.
+    pub links_updated: usize,
+    /// Links re-installed/re-persisted to repair router/persistence drift.
+    pub links_repaired: usize,
+    /// Known nodes left with no remaining links. Detected and reported only.
+    pub orphaned_nodes: Vec<IpAddr>,
 }
 
 /// Special error returned by [TopologyMgr::add_linked_node] that records
@@ -213,36 +234,168 @@ impl TopologyMgr {
         let known: HashSet<IpAddr> = node_addrs.iter().copied().collect();
 
         for (a, b) in self.link_repo.list_edges().await? {
-            // GC edges whose endpoints are no longer known nodes.
-            if !known.contains(&a) || !known.contains(&b) {
-                info!(target: TOPO, "restore: GC stale edge {} <-> {} (endpoint no longer a known node)", a, b);
-                if let Err(e) = self.link_repo.remove_edge(&a, &b).await {
-                    warn!(target: TOPO, "restore: failed to GC stale edge {} <-> {}: {}", a, b, e);
+            // Decide the edge's fate against the current policy + known-node set. Any
+            // error other than the precise not-described case is propagated, so a
+            // transient policy/DB problem fails startup rather than deleting valid edges.
+            match Self::decide_edge(policy_mgr, &known, &a, &b)? {
+                EdgeDecision::Install(link_desc) => {
+                    match self.install_router_link(&a, &b, link_desc) {
+                        Ok(()) | Err(TopologyError::LinkExists(_)) => {}
+                        Err(e) => return Err(e.into()),
+                    }
                 }
-                continue;
-            }
-
-            // Edges are stored undirected, so try describing the link in either
-            // direction before concluding the policy no longer describes it.
-            match Self::describe_policy_link_either(policy_mgr, &a, &b) {
-                Ok(link_desc) => match self.install_router_link(&a, &b, link_desc) {
-                    Ok(()) | Err(TopologyError::LinkExists(_)) => {}
-                    Err(e) => return Err(e.into()),
-                },
-                // Policy no longer describes this link in either direction: GC it.
-                Err(ServiceError::Topology(TopologyError::LinkNotFound(_))) => {
-                    info!(target: TOPO, "restore: GC stale edge {} <-> {} (policy no longer describes link)", a, b);
+                EdgeDecision::Gc => {
+                    info!(target: TOPO, "restore: GC stale edge {} <-> {}", a, b);
                     if let Err(e) = self.link_repo.remove_edge(&a, &b).await {
                         warn!(target: TOPO, "restore: failed to GC stale edge {} <-> {}: {}", a, b, e);
                     }
                 }
-                // Any other error (policy not loaded, resolver failure, etc.) must NOT
-                // GC the edge: fail startup instead of silently deleting valid edges.
-                Err(e) => return Err(e),
             }
         }
 
         Ok(())
+    }
+
+    /// Decide whether an edge should be installed (policy still describes it) or
+    /// garbage-collected (an endpoint is no longer a known node, or policy no longer
+    /// describes the link in either direction).
+    ///
+    /// Preserves the "load completely or fail" rule: only the precise
+    /// `LinkNotFound`-in-policy case yields `Gc`; any other error propagates so a
+    /// transient policy/DB failure never silently deletes a valid edge.
+    fn decide_edge(
+        policy_mgr: &PolicyMgr,
+        known: &HashSet<IpAddr>,
+        a: &IpAddr,
+        b: &IpAddr,
+    ) -> Result<EdgeDecision, ServiceError> {
+        if !known.contains(a) || !known.contains(b) {
+            return Ok(EdgeDecision::Gc);
+        }
+        // Edges are stored undirected, so try describing the link in either direction
+        // before concluding the policy no longer describes it.
+        match Self::describe_policy_link_either(policy_mgr, a, b) {
+            Ok(desc) => Ok(EdgeDecision::Install(desc)),
+            Err(ServiceError::Topology(TopologyError::LinkNotFound(_))) => Ok(EdgeDecision::Gc),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Revalidate the live topology against the current policy after a policy
+    /// update.
+    ///
+    /// Unlike [TopologyMgr::restore_from_state], which rebuilds an empty router
+    /// at startup, this reconciles the live router plus the persisted edge set.
+    /// Per edge we either prune it (policy no longer describes it), refresh its
+    /// attrs/cost (policy changed), or repair router/persistence drift. Nodes
+    /// left with no links are detected and reported but not torn down — node
+    /// membership is governed by the passed in `node_addrs` (the authoritative
+    /// known-node set), not by edge count.
+    ///
+    /// Validation always runs against the current policy. The pass is
+    /// idempotent, so a policy update racing mid-pass simply produces another
+    /// pass.
+    pub async fn revalidate_against_policy(
+        &self,
+        policy_mgr: &PolicyMgr,
+        node_addrs: &[IpAddr],
+    ) -> Result<RevalidationReport, ServiceError> {
+        let mut report = RevalidationReport::default();
+        let known: HashSet<IpAddr> = node_addrs.iter().copied().collect();
+
+        // Actor/node state is the authoritative live-node set; make sure each such node
+        // exists in the router before repairing its links.
+        for addr in node_addrs {
+            self.add_node_if_not_exists(*addr);
+        }
+
+        // Reconcile the union of persisted and live-router edges: either store may hold
+        // an edge the other is missing.
+        let persisted_edges = self.link_repo.list_edges().await?;
+        let router_links = self.router.link_snapshot();
+        let persisted_set: HashSet<(IpAddr, IpAddr)> = persisted_edges
+            .iter()
+            .map(|(a, b)| Self::canonical_pair(*a, *b))
+            .collect();
+        let mut work_edges: HashSet<(IpAddr, IpAddr)> = persisted_set.clone();
+        for link in &router_links {
+            work_edges.insert(Self::canonical_pair(link.a, link.b));
+        }
+
+        for (a, b) in work_edges {
+            let persisted = persisted_set.contains(&(a, b));
+            let router_link = self.router.link_between(&a, &b);
+
+            match Self::decide_edge(policy_mgr, &known, &a, &b)? {
+                EdgeDecision::Gc => {
+                    let had_router = router_link.is_some();
+                    if let Some(rl) = &router_link {
+                        self.router.remove_link(&rl.id);
+                    }
+                    if persisted {
+                        // Best-effort, same as restore: a surviving stale edge is
+                        // re-validated on the next pass / restart.
+                        if let Err(e) = self.link_repo.remove_edge(&a, &b).await {
+                            warn!(target: TOPO, "revalidate: failed to GC edge {} <-> {}: {}", a, b, e);
+                        }
+                    }
+                    if had_router || persisted {
+                        info!(target: TOPO, "revalidate: removed edge {} <-> {} (policy no longer describes link)", a, b);
+                        report.links_removed += 1;
+                    }
+                }
+                EdgeDecision::Install(desc) => {
+                    // Repair persistence drift: router knows the link but Redis missed it.
+                    if !persisted {
+                        self.persist_edge(&a, &b).await?;
+                        report.links_repaired += 1;
+                    }
+                    match &router_link {
+                        // Repair router drift: persisted edge missing from the live router.
+                        None => {
+                            match self.install_router_link(&a, &b, desc) {
+                                Ok(()) | Err(TopologyError::LinkExists(_)) => {}
+                                Err(e) => return Err(e.into()),
+                            }
+                            report.links_repaired += 1;
+                        }
+                        // Link present in both stores: refresh only if policy changed it.
+                        Some(rl) => {
+                            let changed = rl.id.0 != desc.link_id
+                                || rl.cost != desc.cost
+                                || !attributes_equivalent(&rl.attributes, &desc.attrs);
+                            if changed {
+                                self.router.replace_link_between(
+                                    &a,
+                                    &b,
+                                    desc.link_id.into(),
+                                    desc.attrs,
+                                    desc.cost,
+                                )?;
+                                report.links_updated += 1;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Detect + report orphans. An orphan node is a legitimate state and stays in the
+        // topology so long as it remains a known node; removing it belongs to the
+        // node-leave / re-auth path, not here.
+        for addr in node_addrs {
+            if self.router.get_peers(addr).is_empty() {
+                warn!(target: TOPO, "revalidate: node {} has no remaining valid links (orphaned)", addr);
+                report.orphaned_nodes.push(*addr);
+            }
+        }
+
+        Ok(report)
+    }
+
+    /// Return an ordered undirected key so router and LinkRepo edges compare the same way.
+    fn canonical_pair(a: IpAddr, b: IpAddr) -> (IpAddr, IpAddr) {
+        if a <= b { (a, b) } else { (b, a) }
     }
 
     /// Describe a link defined in policy in either direction. Edges are stored undirected, so a stored
@@ -354,7 +507,7 @@ mod tests {
     use std::sync::Arc;
 
     use zpr::policy::v1 as policy_capnp;
-    use zpr::policy_types::{NetAddr, Peering};
+    use zpr::policy_types::{AttrExp, AttrOp, NetAddr, Peering};
     use zpr::write_to::WriteTo;
 
     use crate::config;
@@ -366,34 +519,52 @@ mod tests {
         s.parse().unwrap()
     }
 
-    /// Build a Policy containing a single peering between `node_a` and `node_b`.
-    /// Substrate addresses use the node IPs with port 0 so the IP-only resolver works.
-    fn policy_with_link(node_a: IpAddr, node_b: IpAddr, link_id: &str) -> Vec<u8> {
-        let peering = Peering {
+    /// Build a single peering between `node_a` and `node_b` carrying the given link
+    /// attributes. Substrate addresses use the node IPs with port 0 so the IP-only
+    /// resolver works.
+    fn peering(node_a: IpAddr, node_b: IpAddr, link_id: &str, attributes: Vec<AttrExp>) -> Peering {
+        Peering {
             link_id: link_id.to_string(),
             node_a,
             substrate_a: NetAddr::new_for_ip_or_host(&node_a.to_string(), 0),
             node_b,
             substrate_b: NetAddr::new_for_ip_or_host(&node_b.to_string(), 0),
-            attributes: vec![],
-        };
+            attributes,
+        }
+    }
+
+    /// A `link.zpr.cost` attribute carrying the given cost, for exercising the cost path.
+    fn cost_attr(cost: u32) -> AttrExp {
+        AttrExp {
+            key: "link.zpr.cost".to_string(),
+            op: AttrOp::Eq,
+            value: vec![cost.to_string()],
+        }
+    }
+
+    /// Serialize a policy whose topology is exactly the given peerings.
+    fn policy_bytes_from_peerings(peerings: &[Peering]) -> Vec<u8> {
         let mut msg = capnp::message::Builder::new_default();
         {
             let mut policy = msg.init_root::<policy_capnp::policy::Builder>();
             policy.reborrow().set_created("1970-01-01T00:00:00Z");
-            let mut topo = policy.reborrow().init_topology(1);
-            peering.write_to(&mut topo.reborrow().get(0));
+            let mut topo = policy.reborrow().init_topology(peerings.len() as u32);
+            for (i, p) in peerings.iter().enumerate() {
+                p.write_to(&mut topo.reborrow().get(i as u32));
+            }
         }
         let mut bytes = Vec::new();
         capnp::serialize::write_message(&mut bytes, &msg).unwrap();
-        // Policy::new_from_policy_bytes(Bytes::from(bytes)).unwrap()
         bytes
     }
 
-    /// Create a PolicyMgr over the given db preloaded with a single-link policy.
-    async fn make_policy_mgr(db: Arc<FakeDb>, a: IpAddr, b: IpAddr, link_id: &str) -> PolicyMgr {
-        let pol_bytes = policy_with_link(a, b, link_id);
+    /// Build a Policy containing a single attribute-free peering between `node_a` and `node_b`.
+    fn policy_with_link(node_a: IpAddr, node_b: IpAddr, link_id: &str) -> Vec<u8> {
+        policy_bytes_from_peerings(&[peering(node_a, node_b, link_id, vec![])])
+    }
 
+    /// Create a PolicyMgr over the given db preloaded with the given policy bytes.
+    async fn make_policy_mgr_from_bytes(db: Arc<FakeDb>, pol_bytes: Vec<u8>) -> PolicyMgr {
         let repo = PolicyRepo::new(db);
         PolicyMgr::new_with_initial_policy(
             make_container_bytes(
@@ -407,6 +578,11 @@ mod tests {
         )
         .await
         .unwrap()
+    }
+
+    /// Create a PolicyMgr over the given db preloaded with a single-link policy.
+    async fn make_policy_mgr(db: Arc<FakeDb>, a: IpAddr, b: IpAddr, link_id: &str) -> PolicyMgr {
+        make_policy_mgr_from_bytes(db, policy_with_link(a, b, link_id)).await
     }
 
     /// Build an ActorMgr over the given db.
@@ -688,6 +864,280 @@ mod tests {
         assert!(
             LinkRepo::new(db).list_edges().await.unwrap().is_empty(),
             "with no surviving nodes every edge is GC'd"
+        );
+    }
+
+    // --- revalidate_against_policy tests ---
+
+    /// A live + persisted link the new policy no longer describes is removed from both
+    /// the router and persisted state.
+    #[tokio::test]
+    async fn test_revalidate_removes_link_not_in_policy() {
+        let db = Arc::new(FakeDb::new());
+        let a = ip("fd5a:5052::1");
+        let b = ip("fd5a:5052::2");
+        let c = ip("fd5a:5052::3");
+        // New policy only describes a<->b; the live a<->c link is now stale.
+        let policy_mgr = make_policy_mgr(db.clone(), a, b, "link-ab").await;
+        let topo = TopologyMgr::new(LinkRepo::new(db.clone()));
+        topo.add_node(a).unwrap();
+        topo.add_node(c).unwrap();
+        topo.add_link(a, c, LinkId("link-ac".into()), vec![], 1)
+            .unwrap();
+        LinkRepo::new(db.clone()).add_edge(&a, &c).await.unwrap();
+
+        let report = topo
+            .revalidate_against_policy(&policy_mgr, &[a, c])
+            .await
+            .unwrap();
+
+        assert_eq!(report.links_removed, 1);
+        assert!(topo.get_peers(&a).is_empty(), "stale router link removed");
+        assert!(
+            LinkRepo::new(db).list_edges().await.unwrap().is_empty(),
+            "stale persisted edge GC'd"
+        );
+    }
+
+    /// A still-valid link whose policy cost changed is updated in the router.
+    #[tokio::test]
+    async fn test_revalidate_updates_changed_cost() {
+        let db = Arc::new(FakeDb::new());
+        let a = ip("fd5a:5052::1");
+        let b = ip("fd5a:5052::2");
+        // New policy describes a<->b with cost 9.
+        let policy_mgr = make_policy_mgr_from_bytes(
+            db.clone(),
+            policy_bytes_from_peerings(&[peering(a, b, "link-ab", vec![cost_attr(9)])]),
+        )
+        .await;
+        let topo = TopologyMgr::new(LinkRepo::new(db.clone()));
+        // Live router link still has the old cost of 1.
+        topo.add_node(a).unwrap();
+        topo.add_node(b).unwrap();
+        topo.add_link(a, b, LinkId("link-ab".into()), vec![], 1)
+            .unwrap();
+        LinkRepo::new(db.clone()).add_edge(&a, &b).await.unwrap();
+
+        let report = topo
+            .revalidate_against_policy(&policy_mgr, &[a, b])
+            .await
+            .unwrap();
+
+        assert_eq!(report.links_updated, 1);
+        assert_eq!(report.links_removed, 0);
+        assert_eq!(
+            topo.get_best_route(&a, &b).unwrap().cost,
+            9,
+            "router link cost refreshed from policy"
+        );
+    }
+
+    /// A persisted edge missing from the live router is re-installed (repair).
+    #[tokio::test]
+    async fn test_revalidate_repairs_missing_router_link() {
+        let db = Arc::new(FakeDb::new());
+        let a = ip("fd5a:5052::1");
+        let b = ip("fd5a:5052::2");
+        let policy_mgr = make_policy_mgr(db.clone(), a, b, "link-ab").await;
+        // Edge persisted but router is empty (drift).
+        LinkRepo::new(db.clone()).add_edge(&a, &b).await.unwrap();
+        let topo = TopologyMgr::new(LinkRepo::new(db.clone()));
+
+        let report = topo
+            .revalidate_against_policy(&policy_mgr, &[a, b])
+            .await
+            .unwrap();
+
+        assert_eq!(report.links_repaired, 1);
+        assert_eq!(topo.get_peers(&a), vec![b], "router link re-installed");
+    }
+
+    /// A live router link missing from persisted state, still described by policy, has its
+    /// persisted edge repaired.
+    #[tokio::test]
+    async fn test_revalidate_repairs_missing_persisted_edge() {
+        let db = Arc::new(FakeDb::new());
+        let a = ip("fd5a:5052::1");
+        let b = ip("fd5a:5052::2");
+        let policy_mgr = make_policy_mgr(db.clone(), a, b, "link-ab").await;
+        let topo = TopologyMgr::new(LinkRepo::new(db.clone()));
+        // Router link present at the policy's default cost; nothing persisted.
+        topo.add_node(a).unwrap();
+        topo.add_node(b).unwrap();
+        topo.add_link(a, b, LinkId("link-ab".into()), vec![], 1)
+            .unwrap();
+        assert!(
+            LinkRepo::new(db.clone())
+                .list_edges()
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        let report = topo
+            .revalidate_against_policy(&policy_mgr, &[a, b])
+            .await
+            .unwrap();
+
+        assert_eq!(report.links_repaired, 1);
+        assert_eq!(report.links_updated, 0, "matching link must not be updated");
+        assert_eq!(
+            LinkRepo::new(db).list_edges().await.unwrap().len(),
+            1,
+            "missing persisted edge repaired"
+        );
+    }
+
+    /// A live router link missing from persisted state that policy no longer describes is
+    /// removed from the router.
+    #[tokio::test]
+    async fn test_revalidate_removes_unpersisted_router_link_not_in_policy() {
+        let db = Arc::new(FakeDb::new());
+        let a = ip("fd5a:5052::1");
+        let b = ip("fd5a:5052::2");
+        let c = ip("fd5a:5052::3");
+        // Policy describes a<->b only; the live (unpersisted) a<->c link is stale.
+        let policy_mgr = make_policy_mgr(db.clone(), a, b, "link-ab").await;
+        let topo = TopologyMgr::new(LinkRepo::new(db.clone()));
+        topo.add_node(a).unwrap();
+        topo.add_node(c).unwrap();
+        topo.add_link(a, c, LinkId("link-ac".into()), vec![], 1)
+            .unwrap();
+
+        let report = topo
+            .revalidate_against_policy(&policy_mgr, &[a, c])
+            .await
+            .unwrap();
+
+        assert_eq!(report.links_removed, 1);
+        assert!(topo.get_peers(&a).is_empty());
+    }
+
+    /// A valid unchanged link is left intact and its edge preserved (idempotent pass).
+    #[tokio::test]
+    async fn test_revalidate_leaves_unchanged_link_intact() {
+        let db = Arc::new(FakeDb::new());
+        let a = ip("fd5a:5052::1");
+        let b = ip("fd5a:5052::2");
+        let policy_mgr = make_policy_mgr(db.clone(), a, b, "link-ab").await;
+        LinkRepo::new(db.clone()).add_edge(&a, &b).await.unwrap();
+        let topo = TopologyMgr::new(LinkRepo::new(db.clone()));
+        // First pass installs the link from policy.
+        topo.revalidate_against_policy(&policy_mgr, &[a, b])
+            .await
+            .unwrap();
+
+        // Second pass must be a no-op.
+        let report = topo
+            .revalidate_against_policy(&policy_mgr, &[a, b])
+            .await
+            .unwrap();
+
+        assert_eq!(report.links_removed, 0);
+        assert_eq!(report.links_updated, 0);
+        assert_eq!(report.links_repaired, 0);
+        assert_eq!(topo.get_peers(&a), vec![b]);
+        assert_eq!(LinkRepo::new(db).list_edges().await.unwrap().len(), 1);
+    }
+
+    /// A valid unchanged link with non-empty attributes must not be falsely updated:
+    /// policy rebuilds attrs with a fresh `expires_at`, but stable-content comparison
+    /// must treat them as equivalent.
+    #[tokio::test]
+    async fn test_revalidate_nonempty_attrs_not_falsely_updated() {
+        let db = Arc::new(FakeDb::new());
+        let a = ip("fd5a:5052::1");
+        let b = ip("fd5a:5052::2");
+        let policy_mgr = make_policy_mgr_from_bytes(
+            db.clone(),
+            policy_bytes_from_peerings(&[peering(a, b, "link-ab", vec![cost_attr(5)])]),
+        )
+        .await;
+        LinkRepo::new(db.clone()).add_edge(&a, &b).await.unwrap();
+        let topo = TopologyMgr::new(LinkRepo::new(db.clone()));
+        // First pass installs the attribute-bearing link.
+        topo.revalidate_against_policy(&policy_mgr, &[a, b])
+            .await
+            .unwrap();
+
+        // Second pass must not report a spurious update from rebuilt attrs.
+        let report = topo
+            .revalidate_against_policy(&policy_mgr, &[a, b])
+            .await
+            .unwrap();
+
+        assert_eq!(report.links_updated, 0, "rebuilt attrs must compare equal");
+        assert_eq!(report.links_repaired, 0);
+        assert_eq!(topo.get_best_route(&a, &b).unwrap().cost, 5);
+    }
+
+    /// A policy whose link id collides with another live router link's id makes the
+    /// replacement fail; the error propagates and the old link is left intact.
+    #[tokio::test]
+    async fn test_revalidate_id_collision_errors_and_preserves_link() {
+        let db = Arc::new(FakeDb::new());
+        let a = ip("fd5a:5052::1");
+        let b = ip("fd5a:5052::2");
+        let c = ip("fd5a:5052::3");
+        let d = ip("fd5a:5052::4");
+        // Policy describes a<->b and c<->d both under link id "shared".
+        let policy_mgr = make_policy_mgr_from_bytes(
+            db.clone(),
+            policy_bytes_from_peerings(&[
+                peering(a, b, "shared", vec![]),
+                peering(c, d, "shared", vec![]),
+            ]),
+        )
+        .await;
+        let topo = TopologyMgr::new(LinkRepo::new(db.clone()));
+        topo.add_node(a).unwrap();
+        topo.add_node(b).unwrap();
+        topo.add_node(c).unwrap();
+        topo.add_node(d).unwrap();
+        // a<->b currently has a different id; c<->d already holds "shared".
+        topo.add_link(a, b, LinkId("old-ab".into()), vec![], 1)
+            .unwrap();
+        topo.add_link(c, d, LinkId("shared".into()), vec![], 1)
+            .unwrap();
+
+        let result = topo
+            .revalidate_against_policy(&policy_mgr, &[a, b, c, d])
+            .await;
+
+        assert!(result.is_err(), "id collision must surface as an error");
+        // The old a<->b link must survive the rejected replacement.
+        assert!(
+            topo.get_best_route(&a, &b).is_some(),
+            "old link must be left intact after a failed replacement"
+        );
+    }
+
+    /// A known node whose links were all pruned is reported as orphaned (but not removed).
+    #[tokio::test]
+    async fn test_revalidate_reports_orphaned_node() {
+        let db = Arc::new(FakeDb::new());
+        let a = ip("fd5a:5052::1");
+        let b = ip("fd5a:5052::2");
+        let c = ip("fd5a:5052::3");
+        let policy_mgr = make_policy_mgr(db.clone(), a, b, "link-ab").await;
+        LinkRepo::new(db.clone()).add_edge(&a, &b).await.unwrap();
+        let topo = TopologyMgr::new(LinkRepo::new(db.clone()));
+
+        // `c` is a known node with no links.
+        let report = topo
+            .revalidate_against_policy(&policy_mgr, &[a, b, c])
+            .await
+            .unwrap();
+
+        assert!(
+            report.orphaned_nodes.contains(&c),
+            "linkless known node must be reported orphaned"
+        );
+        assert!(!report.orphaned_nodes.contains(&a));
+        assert!(
+            topo.add_node(c).is_err(),
+            "orphaned node must remain in the topology"
         );
     }
 }

--- a/vs/src/topology_mgr.rs
+++ b/vs/src/topology_mgr.rs
@@ -15,7 +15,7 @@ use crate::db::LinkRepo;
 use crate::error::{ServiceError, TopologyError};
 use crate::logging::targets::TOPO;
 use crate::policy_mgr::{LinkDescription, PolicySnapshot};
-use crate::router::Router;
+use crate::router::{LinkSpec, Router};
 
 use libeval::actor::Actor;
 use libeval::attribute::{AttrMatch, Attribute, attributes_equivalent};
@@ -399,11 +399,16 @@ impl TopologyMgr {
             }
         }
 
-        // Apply removals first so every reassigned id is free before any install.
-        for r in &removals {
-            if let Some(id) = &r.old_id {
-                self.router.remove_link(id);
+        // Do all fallible async persistence before touching the router, so a persistence
+        // failure returns with the live graph untouched rather than half-rewritten.
+        // Repair persistence drift: router knows the link but Redis missed it.
+        for e in &surviving {
+            if !e.persisted {
+                self.persist_edge(&e.a, &e.b).await?;
+                report.links_repaired += 1;
             }
+        }
+        for r in &removals {
             if r.persisted {
                 // Best-effort, same as restore: a surviving stale edge is
                 // re-validated on the next pass / restart.
@@ -416,31 +421,36 @@ impl TopologyMgr {
                 report.links_removed += 1;
             }
         }
-        // Vacate the old id of every changed edge before installing, so a moved id can't
-        // collide with the edge it is moving away from.
-        for e in &surviving {
-            if let Action::Replace(old) = &e.action {
-                self.router.remove_link(old);
-            }
-        }
+
+        // Collect every router mutation and apply it as one atomic batch: no concurrent
+        // visa route can observe a half-rewritten graph, and a rejected install rolls back
+        // instead of leaving moved ids vacated. Removals (GC'd edges plus the old id of
+        // every changed edge) are listed first so each reassigned id is free before reuse.
+        let mut removal_ids: Vec<LinkId> =
+            removals.iter().filter_map(|r| r.old_id.clone()).collect();
+        let mut additions: Vec<LinkSpec> = Vec::new();
         for e in surviving {
-            // Repair persistence drift: router knows the link but Redis missed it.
-            if !e.persisted {
-                self.persist_edge(&e.a, &e.b).await?;
-                report.links_repaired += 1;
-            }
+            let spec = LinkSpec {
+                a: e.a,
+                b: e.b,
+                id: e.desc.link_id.into(),
+                attributes: e.desc.attrs,
+                cost: e.desc.cost,
+            };
             match e.action {
                 Action::Keep => {}
                 Action::Fresh => {
-                    self.install_router_link(&e.a, &e.b, e.desc)?;
+                    additions.push(spec);
                     report.links_repaired += 1;
                 }
-                Action::Replace(_) => {
-                    self.install_router_link(&e.a, &e.b, e.desc)?;
+                Action::Replace(old) => {
+                    removal_ids.push(old);
+                    additions.push(spec);
                     report.links_updated += 1;
                 }
             }
         }
+        self.router.apply_link_batch(&removal_ids, additions)?;
 
         // Detect + report orphans. An orphan node is a legitimate state and stays in the
         // topology so long as it remains a known node; removing it belongs to the

--- a/vs/src/topology_mgr.rs
+++ b/vs/src/topology_mgr.rs
@@ -322,60 +322,122 @@ impl TopologyMgr {
             work_edges.insert(Self::canonical_pair(link.a, link.b));
         }
 
+        // Reconcile in two phases: decide every edge first, then mutate. A policy update
+        // can move a link id from one edge to another; doing the work edge-by-edge would
+        // let an install collide with the id's prior holder when `work_edges` (a HashSet)
+        // happens to visit the new edge first, aborting the whole pass nondeterministically.
+        // Deciding first lets us free every reassigned id before installing any, and lets
+        // us reject a genuinely invalid policy (two surviving edges claiming one id)
+        // up front so the live topology is left untouched rather than half-rewritten.
+
+        /// How a surviving edge's router link must change to match policy.
+        enum Action {
+            /// Router already matches policy; nothing to install.
+            Keep,
+            /// Router missing the link (drift) — install fresh.
+            Fresh,
+            /// Router link differs (id/cost/attrs changed) — vacate this old id, then reinstall.
+            Replace(LinkId),
+        }
+        struct Surviving {
+            a: IpAddr,
+            b: IpAddr,
+            persisted: bool,
+            desc: LinkDescription,
+            action: Action,
+        }
+        struct Removal {
+            a: IpAddr,
+            b: IpAddr,
+            persisted: bool,
+            old_id: Option<LinkId>,
+        }
+
+        let mut surviving: Vec<Surviving> = Vec::new();
+        let mut removals: Vec<Removal> = Vec::new();
         for (a, b) in work_edges {
             let persisted = persisted_set.contains(&(a, b));
             let router_link = self.router.link_between(&a, &b);
-
             match Self::decide_edge(snapshot, &known, &a, &b)? {
-                EdgeDecision::Gc => {
-                    let had_router = router_link.is_some();
-                    if let Some(rl) = &router_link {
-                        self.router.remove_link(&rl.id);
-                    }
-                    if persisted {
-                        // Best-effort, same as restore: a surviving stale edge is
-                        // re-validated on the next pass / restart.
-                        if let Err(e) = self.link_repo.remove_edge(&a, &b).await {
-                            warn!(target: TOPO, "revalidate: failed to GC edge {} <-> {}: {}", a, b, e);
-                        }
-                    }
-                    if had_router || persisted {
-                        info!(target: TOPO, "revalidate: removed edge {} <-> {} (policy no longer describes link)", a, b);
-                        report.links_removed += 1;
-                    }
-                }
+                EdgeDecision::Gc => removals.push(Removal {
+                    a,
+                    b,
+                    persisted,
+                    old_id: router_link.map(|rl| rl.id),
+                }),
                 EdgeDecision::Install(desc) => {
-                    // Repair persistence drift: router knows the link but Redis missed it.
-                    if !persisted {
-                        self.persist_edge(&a, &b).await?;
-                        report.links_repaired += 1;
-                    }
-                    match &router_link {
-                        // Repair router drift: persisted edge missing from the live router.
-                        None => {
-                            match self.install_router_link(&a, &b, desc) {
-                                Ok(()) | Err(TopologyError::LinkExists(_)) => {}
-                                Err(e) => return Err(e.into()),
-                            }
-                            report.links_repaired += 1;
-                        }
-                        // Link present in both stores: refresh only if policy changed it.
+                    let action = match &router_link {
+                        None => Action::Fresh,
                         Some(rl) => {
                             let changed = rl.id.0 != desc.link_id
                                 || rl.cost != desc.cost
                                 || !attributes_equivalent(&rl.attributes, &desc.attrs);
                             if changed {
-                                self.router.replace_link_between(
-                                    &a,
-                                    &b,
-                                    desc.link_id.into(),
-                                    desc.attrs,
-                                    desc.cost,
-                                )?;
-                                report.links_updated += 1;
+                                Action::Replace(rl.id.clone())
+                            } else {
+                                Action::Keep
                             }
                         }
-                    }
+                    };
+                    surviving.push(Surviving {
+                        a,
+                        b,
+                        persisted,
+                        desc,
+                        action,
+                    });
+                }
+            }
+        }
+
+        // Reject genuine id collisions (two surviving edges want the same id) before any
+        // mutation. A surviving edge's final id is always its policy `link_id`.
+        let mut claimed: HashSet<&str> = HashSet::new();
+        for e in &surviving {
+            if !claimed.insert(e.desc.link_id.as_str()) {
+                return Err(TopologyError::LinkExists(e.desc.link_id.clone()).into());
+            }
+        }
+
+        // Apply removals first so every reassigned id is free before any install.
+        for r in &removals {
+            if let Some(id) = &r.old_id {
+                self.router.remove_link(id);
+            }
+            if r.persisted {
+                // Best-effort, same as restore: a surviving stale edge is
+                // re-validated on the next pass / restart.
+                if let Err(e) = self.link_repo.remove_edge(&r.a, &r.b).await {
+                    warn!(target: TOPO, "revalidate: failed to GC edge {} <-> {}: {}", r.a, r.b, e);
+                }
+            }
+            if r.old_id.is_some() || r.persisted {
+                info!(target: TOPO, "revalidate: removed edge {} <-> {} (policy no longer describes link)", r.a, r.b);
+                report.links_removed += 1;
+            }
+        }
+        // Vacate the old id of every changed edge before installing, so a moved id can't
+        // collide with the edge it is moving away from.
+        for e in &surviving {
+            if let Action::Replace(old) = &e.action {
+                self.router.remove_link(old);
+            }
+        }
+        for e in surviving {
+            // Repair persistence drift: router knows the link but Redis missed it.
+            if !e.persisted {
+                self.persist_edge(&e.a, &e.b).await?;
+                report.links_repaired += 1;
+            }
+            match e.action {
+                Action::Keep => {}
+                Action::Fresh => {
+                    self.install_router_link(&e.a, &e.b, e.desc)?;
+                    report.links_repaired += 1;
+                }
+                Action::Replace(_) => {
+                    self.install_router_link(&e.a, &e.b, e.desc)?;
+                    report.links_updated += 1;
                 }
             }
         }
@@ -1151,6 +1213,62 @@ mod tests {
         assert!(
             topo.get_best_route(&a, &b).is_some(),
             "old link must be left intact after a failed replacement"
+        );
+    }
+
+    /// A policy update that reassigns link ids between two still-valid edges must
+    /// reconcile successfully. Here a<->b and c<->d swap ids: each id stays unique in
+    /// the new policy, but during the single reconciliation pass the target id is still
+    /// held by the other live edge that hasn't been processed yet. Because `work_edges`
+    /// is a HashSet, neither processing order can avoid the in-pass collision, so this
+    /// fails deterministically today (replace_link_between returns LinkExists and the
+    /// whole pass aborts) — the deterministic instance of the move/reuse class flagged
+    /// in review.
+    #[tokio::test]
+    async fn test_revalidate_swaps_link_ids_between_valid_edges() {
+        let db = Arc::new(FakeDb::new());
+        let a = ip("fd5a:5052::1");
+        let b = ip("fd5a:5052::2");
+        let c = ip("fd5a:5052::3");
+        let d = ip("fd5a:5052::4");
+        // New policy keeps both edges but swaps their link ids.
+        let policy_mgr = make_policy_mgr_from_bytes(
+            db.clone(),
+            policy_bytes_from_peerings(&[
+                peering(a, b, "link-2", vec![]),
+                peering(c, d, "link-1", vec![]),
+            ]),
+        )
+        .await;
+        let topo = TopologyMgr::new(LinkRepo::new(db.clone()));
+        topo.add_node(a).unwrap();
+        topo.add_node(b).unwrap();
+        topo.add_node(c).unwrap();
+        topo.add_node(d).unwrap();
+        // Live router currently has the ids the policy is about to swap.
+        topo.add_link(a, b, LinkId("link-1".into()), vec![], 1)
+            .unwrap();
+        topo.add_link(c, d, LinkId("link-2".into()), vec![], 1)
+            .unwrap();
+        LinkRepo::new(db.clone()).add_edge(&a, &b).await.unwrap();
+        LinkRepo::new(db.clone()).add_edge(&c, &d).await.unwrap();
+
+        let report = topo
+            .revalidate_against_policy(&policy_mgr.get_current_snapshot(), &[a, b, c, d])
+            .await
+            .expect("id reassignment between valid edges must reconcile, not abort");
+
+        assert_eq!(report.links_updated, 2, "both edges' ids refreshed");
+        assert_eq!(report.links_removed, 0, "neither edge is stale");
+        assert_eq!(
+            topo.router.link_between(&a, &b).unwrap().id.0,
+            "link-2",
+            "a<->b took the new id"
+        );
+        assert_eq!(
+            topo.router.link_between(&c, &d).unwrap().id.0,
+            "link-1",
+            "c<->d took the new id"
         );
     }
 

--- a/vs/src/vsapi_worker.rs
+++ b/vs/src/vsapi_worker.rs
@@ -977,11 +977,19 @@ impl vsapi::v_s_handle::Server for VSHandleImpl {
         let actor_addr = actor.get_zpr_addr().unwrap().clone(); // MUST have an addr by now.
 
         if actor.is_node() {
+            // Capture a policy snapshot right before installing the topology link so the
+            // link description is read from one consistent view.
+            //
+            // TODO: Plumb the auth-time policy vinst through this path and detect/retry if
+            // policy changed underneath us while adding a new node. Authentication reads
+            // policy earlier in authorize_connect, so this snapshot does not yet close that
+            // window. ( https://github.com/org-zpr/zpr-visaservice/issues/232 )
+            let psnap = self.asm.policy_mgr.get_current_snapshot();
             if let Err(add_err) = self
                 .asm
                 .topo_mgr
                 .add_linked_node(
-                    &self.asm.policy_mgr,
+                    &psnap,
                     &self.asm.actor_mgr,
                     &actor,
                     &connect_via,

--- a/vs/src/vss.rs
+++ b/vs/src/vss.rs
@@ -3,7 +3,7 @@
 use std::net::IpAddr;
 use tokio::sync::oneshot;
 
-use zpr::vsapi_types::{Param, ServiceDescriptor, Visa};
+use zpr::vsapi_types::{Link, Param, ServiceDescriptor, Visa};
 
 use crate::error::VssSyncError;
 
@@ -11,6 +11,7 @@ pub type VssPushResponse = Result<usize, VssSyncError>; // usize is number items
 pub type VssRevokeAuthResponse = Result<usize, VssSyncError>; // usize is number of items revoked.
 pub type VssSetServicesResponse = Result<(), VssSyncError>;
 pub type VssConfigureResponse = Result<(), VssSyncError>;
+pub type VssSetTopologyResponse = Result<(), VssSyncError>;
 
 // Each API call is expressed as a message using this enum.
 #[allow(dead_code)]
@@ -24,4 +25,5 @@ pub enum VssCmd {
         oneshot::Sender<VssSetServicesResponse>,
     ), // (version, services-descriptor-list, channel)
     Configure(Vec<Param>, oneshot::Sender<VssConfigureResponse>),
+    SetTopology(Vec<Link>, oneshot::Sender<VssSetTopologyResponse>),
 }

--- a/vs/src/vss_mgr.rs
+++ b/vs/src/vss_mgr.rs
@@ -7,7 +7,7 @@ use tokio::sync::oneshot;
 use tokio::task::LocalSet;
 use tracing::{debug, info};
 
-use zpr::vsapi_types::{ServiceDescriptor, Visa};
+use zpr::vsapi_types::{Link, ServiceDescriptor, Visa};
 
 use crate::assembly::Assembly;
 use crate::error::VssSyncError;
@@ -201,6 +201,14 @@ impl VssHandle {
     pub async fn set_services(&self, services: Vec<ServiceDescriptor>) -> Result<(), VssSyncError> {
         let (resp_tx, resp_rx) = oneshot::channel();
         let cmd = VssCmd::SetServices(services, resp_tx);
+        self.send_command(cmd).await?;
+        resp_rx.await.map_err(|_| VssSyncError::ConnClosed)?
+    }
+
+    /// Send a `setTopology` message to the node.
+    pub async fn set_topology(&self, links: Vec<Link>) -> Result<(), VssSyncError> {
+        let (resp_tx, resp_rx) = oneshot::channel();
+        let cmd = VssCmd::SetTopology(links, resp_tx);
         self.send_command(cmd).await?;
         resp_rx.await.map_err(|_| VssSyncError::ConnClosed)?
     }

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -61,14 +61,13 @@ impl VssState {
         self.services_state.mark_synced();
     }
 
-    /// TODO: This is not yet tracking policy changes. So only returns TRUE first time it is created.
     fn needs_set_topology(&self) -> bool {
         self.topology_state.needs_sync()
     }
 
     /// If topology effecting this node has been updated, indicate that here.
-    /// TODO: Not used yet.
-    #[allow(dead_code)]
+    /// Marking it updated makes housekeeping re-send topology if the inline
+    /// set-topology RPC fails, so the node never sticks with stale topology.
     fn mark_topology_updated(&mut self) {
         self.topology_state.last_update = Instant::now();
     }
@@ -176,6 +175,7 @@ pub async fn vss_worker_loop(
                             }
                         }
                         VssCmd::SetTopology(links, resp_tx) => {
+                            state.mark_topology_updated();
                             if let Err(e) = resp_tx.send(vss_do_set_topology(&vss_handle, &links).await) {
                                 error!(target: VSS, "failed to send response for set-topology command: {:?}", e);
                                 asm.counters.incr(CounterType::VssErrors);

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -175,6 +175,12 @@ pub async fn vss_worker_loop(
                                 asm.counters.incr(CounterType::VssErrors);
                             }
                         }
+                        VssCmd::SetTopology(links, resp_tx) => {
+                            if let Err(e) = resp_tx.send(vss_do_set_topology(&vss_handle, &links).await) {
+                                error!(target: VSS, "failed to send response for set-topology command: {:?}", e);
+                                asm.counters.incr(CounterType::VssErrors);
+                            }
+                        }
                     }
                     None => {
                         // Uh oh - channel closed.


### PR DESCRIPTION
This is the first part of the #219 (post policy housekeeping) work.  This makes sure topology is still in sync with policy and sends links message to all connected nodes.

Major Changes:

- **event_mgr.rs** — handle_policy_updated -> kicks off the housekeeping.

- **topology_mgr.rs** — new revalidate_against_policy which builds on the code used to restore from state.

- **policy_mgr.rs** — new PolicySnapshot safe to hold across awaits so policy and links can't drift mid-reconciliation. Existing accessors now delegate through it.


In general a fair amount of hackery to make sure that policy does not change while I operate using it, and that the topology manager doesn't suffer competing changes during a policy re-sync.



