### PR TITLE
Mk/store vinst on store 5t :  persist the vinst to the DB (and reload it at start)

### DIFF
--- a/vs/src/db/policy.rs
+++ b/vs/src/db/policy.rs
@@ -24,6 +24,13 @@ use crate::logging::targets::DB;
 const KEY_POLICIES: &str = "policies";
 const KEY_POLICY: &str = "policy";
 
+/// The identifiers of the current policy as persisted in `policy:current`:
+/// the container content hash and its monotonic version instance number.
+pub struct PolicyIdentifier {
+    pub phash: String,
+    pub vinst: u64,
+}
+
 pub struct PolicyRepo {
     db: Arc<dyn DbConnection>,
 }
@@ -33,43 +40,46 @@ impl PolicyRepo {
         PolicyRepo { db }
     }
 
-    /// Set the current policy information into the database.
-    /// Unless `force_overwrite` is true, only updates the database if the current
-    /// policy is different (by its phash) from the one already stored.
+    /// Set the current policy information into the database. Unless
+    /// `force_overwrite` is true, only updates the policy data in the database
+    /// if the current policy is different (by its phash) from the one already
+    /// stored.
     ///
     /// Only the container half of `loaded` is persisted; the decoded policy is
     /// always re-derived from it on load. Taking `&LoadedPolicy` makes it
     /// impossible to persist bytes that never decoded into a valid artifact.
     ///
-    /// Return TRUE only if database was written to.
+    /// The vinst is always persisted, even when the container is unchanged:
+    /// `update_policy_internal` bumps vinst while leaving identical container
+    /// bytes, and that bump must reach the DB so vinst survives a restart.
     pub async fn set_current_policy(
         &self,
         loaded: &LoadedPolicy,
         force_overwrite: bool,
-    ) -> Result<bool, StoreError> {
+    ) -> Result<(), StoreError> {
         let container_bytes = loaded.container().as_bytes();
         let phash = loaded.hash_container_bytes()?;
+        let vinst = loaded.policy().vinst().to_string();
         let maybe_curhash: Option<String> = self.db.hget("policy:current", "phash").await?;
         let curhash = maybe_curhash.unwrap_or_default();
         let container_key = format!("{KEY_POLICIES}:{phash}:container");
+        let key_current = format!("{KEY_POLICY}:current");
 
         // Require the container blob to exist, so a half-written state (current
         // pointer present, container missing) still forces a rewrite.
         let exists: bool = (curhash == phash) && self.db.exists(&container_key).await?;
-        let mut updated = false;
         if !exists || force_overwrite {
             debug!(target: DB, "updating current policy in DB to phash {phash}");
-
-            let key_current = format!("{KEY_POLICY}:current");
 
             //
             // policies:<PHASH>:container -> <capn proto container bytes>
             // policy:current
             //          |- phash -> the string <PHASH> value
+            //          |- vinst -> the version instance number as a string
             //          |- ctime -> string
             //
-            // All written in one atomic pipeline so the current pointer never
-            // points at a missing container.
+            // All written in one atomic pipeline so the current pointer, its
+            // container, and its vinst can never drift apart.
             //
             let ops = vec![
                 DbOp::SetBin {
@@ -82,19 +92,53 @@ impl PolicyRepo {
                     value: phash.clone(),
                 },
                 DbOp::HSet {
+                    hash_key: key_current.clone(),
+                    field: "vinst".to_string(),
+                    value: vinst,
+                },
+                DbOp::HSet {
                     hash_key: key_current,
                     field: "ctime".to_string(),
                     value: db::gen_timestamp(),
                 },
             ];
             self.db.atomic_pipeline(&ops).await?;
-
-            updated = true;
         } else {
-            debug!(target: DB, "set_current_policy found policy already set, hash={phash}");
+            // Container unchanged, but vinst may have advanced (an update that
+            // reuses identical container bytes). Persist the vinst on its own so
+            // the bump is not lost on restart; atomicity with the container is
+            // irrelevant here since the container is unchanged.
+            debug!(target: DB, "set_current_policy container unchanged, updating vinst, hash={phash}");
+            self.db.hset(&key_current, "vinst", &vinst).await?;
         }
 
-        Ok(updated)
+        Ok(())
+    }
+
+    /// Read the current-policy identifier (phash + vinst) from
+    /// `policy:current`.
+    ///
+    /// Returns `None` when no current policy is set (fresh DB). A present phash
+    /// is always written alongside its vinst, so a phash with a missing or
+    /// unparsable vinst is a corrupt state and an `InvalidData` error. Both
+    /// fields are read together so startup never mixes a phash and vinst from
+    /// separate writes.
+    pub async fn get_current_identifier(&self) -> Result<Option<PolicyIdentifier>, StoreError> {
+        let maybe_phash: Option<String> = self.db.hget("policy:current", "phash").await?;
+        let Some(phash) = maybe_phash else {
+            return Ok(None);
+        };
+        let vinst_str: String =
+            self.db
+                .hget("policy:current", "vinst")
+                .await?
+                .ok_or_else(|| {
+                    StoreError::InvalidData(format!("current policy {phash} has no vinst field"))
+                })?;
+        let vinst = vinst_str
+            .parse::<u64>()
+            .map_err(|e| StoreError::InvalidData(format!("unparsable vinst {vinst_str:?}: {e}")))?;
+        Ok(Some(PolicyIdentifier { phash, vinst }))
     }
 
     /// Load the current policy artifact and decode it into a [LoadedPolicy].
@@ -120,7 +164,6 @@ mod test {
     use super::*;
     use crate::config;
     use crate::db::db_fake::FakeDb;
-    use std::time::Duration;
     use zpr::policy::v1 as policy_capnp;
 
     /// Build a [LoadedPolicy] by encoding a minimal policy, wrapping it in a
@@ -155,8 +198,7 @@ mod test {
         let repo = PolicyRepo::new(db.clone());
         let loaded = make_loaded("2024-01-01T00:00:00Z", 1, Some("meta"));
 
-        let updated = repo.set_current_policy(&loaded, false).await.unwrap();
-        assert!(updated);
+        repo.set_current_policy(&loaded, false).await.unwrap();
 
         let phash = db.hget("policy:current", "phash").await.unwrap().unwrap();
         let container_key = format!("{KEY_POLICIES}:{phash}:container");
@@ -165,30 +207,40 @@ mod test {
     }
 
     #[tokio::test]
-    /// Re-writing the same artifact is a no-op (no DB write).
+    /// Re-writing the same artifact is a no-op for the write branch. Probed via a
+    /// sentinel `ctime`: the write branch always rewrites `ctime`, so its survival
+    /// proves the branch did not run.
     async fn test_set_current_policy_no_change() {
         let db = Arc::new(FakeDb::new());
-        let repo = PolicyRepo::new(db);
+        let repo = PolicyRepo::new(db.clone());
         let loaded = make_loaded("2024-01-01T00:00:00Z", 2, Some("meta"));
 
-        let updated = repo.set_current_policy(&loaded, false).await.unwrap();
-        assert!(updated);
-        let updated = repo.set_current_policy(&loaded, false).await.unwrap();
-        assert!(!updated);
+        repo.set_current_policy(&loaded, false).await.unwrap();
+        db.hset("policy:current", "ctime", "SENTINEL")
+            .await
+            .unwrap();
+        repo.set_current_policy(&loaded, false).await.unwrap();
+
+        let ctime = db.hget("policy:current", "ctime").await.unwrap().unwrap();
+        assert_eq!(ctime, "SENTINEL", "write branch must not run for no change");
     }
 
     #[tokio::test]
-    /// force_overwrite rewrites even when the artifact is unchanged.
+    /// force_overwrite rewrites even when the artifact is unchanged. Probed via a
+    /// sentinel `ctime` the write branch overwrites.
     async fn test_set_current_policy_force_overwrite() {
         let db = Arc::new(FakeDb::new());
-        let repo = PolicyRepo::new(db);
+        let repo = PolicyRepo::new(db.clone());
         let loaded = make_loaded("2024-01-01T00:00:00Z", 3, Some("meta"));
 
-        let updated = repo.set_current_policy(&loaded, false).await.unwrap();
-        assert!(updated);
-        tokio::time::sleep(Duration::from_millis(10)).await;
-        let updated = repo.set_current_policy(&loaded, true).await.unwrap();
-        assert!(updated);
+        repo.set_current_policy(&loaded, false).await.unwrap();
+        db.hset("policy:current", "ctime", "SENTINEL")
+            .await
+            .unwrap();
+        repo.set_current_policy(&loaded, true).await.unwrap();
+
+        let ctime = db.hget("policy:current", "ctime").await.unwrap().unwrap();
+        assert_ne!(ctime, "SENTINEL", "force write branch must run");
     }
 
     #[tokio::test]
@@ -199,16 +251,14 @@ mod test {
         let repo = PolicyRepo::new(db.clone());
         let loaded = make_loaded("2024-01-01T00:00:00Z", 4, Some("meta"));
 
-        let updated = repo.set_current_policy(&loaded, false).await.unwrap();
-        assert!(updated);
+        repo.set_current_policy(&loaded, false).await.unwrap();
 
         let phash = db.hget("policy:current", "phash").await.unwrap().unwrap();
-        db.del(&format!("{KEY_POLICIES}:{phash}:container"))
-            .await
-            .unwrap();
+        let container_key = format!("{KEY_POLICIES}:{phash}:container");
+        db.del(&container_key).await.unwrap();
 
-        let updated = repo.set_current_policy(&loaded, false).await.unwrap();
-        assert!(updated);
+        repo.set_current_policy(&loaded, false).await.unwrap();
+        assert!(db.exists(&container_key).await.unwrap());
     }
 
     #[tokio::test]
@@ -271,5 +321,78 @@ mod test {
             .get_current_loaded_policy(&config::POLICY_MIN_VERSION)
             .await;
         assert!(matches!(res, Err(StoreError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    /// The write branch persists the vinst; get_current_identifier round-trips
+    /// both phash and vinst.
+    async fn test_set_current_policy_persists_vinst() {
+        let db = Arc::new(FakeDb::new());
+        let repo = PolicyRepo::new(db);
+        let mut loaded = make_loaded("2024-01-01T00:00:00Z", 1, Some("meta"));
+        loaded.set_vinst(5);
+
+        repo.set_current_policy(&loaded, false).await.unwrap();
+
+        let ident = repo.get_current_identifier().await.unwrap().unwrap();
+        assert_eq!(ident.phash, loaded.hash_container_bytes().unwrap());
+        assert_eq!(ident.vinst, 5);
+    }
+
+    #[tokio::test]
+    /// A vinst bump on identical container bytes still reaches the DB even though
+    /// the container write branch is skipped.
+    async fn test_set_current_policy_updates_vinst_when_container_unchanged() {
+        let db = Arc::new(FakeDb::new());
+        let repo = PolicyRepo::new(db);
+        let mut loaded = make_loaded("2024-01-01T00:00:00Z", 1, Some("meta"));
+        loaded.set_vinst(1);
+        repo.set_current_policy(&loaded, false).await.unwrap();
+
+        // Same container bytes, higher vinst: the no-change branch must still
+        // persist the bumped vinst.
+        loaded.set_vinst(2);
+        repo.set_current_policy(&loaded, false).await.unwrap();
+
+        let ident = repo.get_current_identifier().await.unwrap().unwrap();
+        assert_eq!(ident.vinst, 2);
+    }
+
+    #[tokio::test]
+    /// get_current_identifier returns None on a fresh DB.
+    async fn test_get_current_identifier_none_on_fresh_db() {
+        let db = Arc::new(FakeDb::new());
+        let repo = PolicyRepo::new(db);
+        assert!(repo.get_current_identifier().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    /// A phash with no vinst field is a corrupt state, not a valid default: it is
+    /// an InvalidData error, since a phash is always written alongside its vinst.
+    async fn test_get_current_identifier_errors_on_missing_vinst() {
+        let db = Arc::new(FakeDb::new());
+        db.hset("policy:current", "phash", "deadbeef")
+            .await
+            .unwrap();
+        let repo = PolicyRepo::new(db);
+
+        let res = repo.get_current_identifier().await;
+        assert!(matches!(res, Err(StoreError::InvalidData(_))));
+    }
+
+    #[tokio::test]
+    /// An unparsable vinst is an InvalidData error, not a silent default.
+    async fn test_get_current_identifier_errors_on_garbage_vinst() {
+        let db = Arc::new(FakeDb::new());
+        db.hset("policy:current", "phash", "deadbeef")
+            .await
+            .unwrap();
+        db.hset("policy:current", "vinst", "not-a-number")
+            .await
+            .unwrap();
+        let repo = PolicyRepo::new(db);
+
+        let res = repo.get_current_identifier().await;
+        assert!(matches!(res, Err(StoreError::InvalidData(_))));
     }
 }

--- a/vs/src/policy_mgr.rs
+++ b/vs/src/policy_mgr.rs
@@ -25,7 +25,7 @@ use zpr::vsapi_types::{Link, LinkRole, SockAddr};
 
 use crate::config;
 use crate::db;
-use crate::error::{ResolverError, ServiceError, TopologyError};
+use crate::error::{ResolverError, ServiceError, StoreError, TopologyError};
 use crate::loaded_policy::LoadedPolicy;
 use crate::logging::targets::MAIN;
 
@@ -143,7 +143,19 @@ impl PolicyMgr {
             PolicyContainerBytes::from(container_bytes),
             &config::POLICY_MIN_VERSION,
         )?;
-        loaded.set_vinst(1);
+        // Derive the vinst from any persisted identifier so it is monotonic
+        // across restarts. Same container (matching phash) is a plain restart:
+        // reuse its vinst. A different container (or a fresh DB) is a new policy
+        // install and gets the next vinst.
+        let ident = repo.get_current_identifier().await?;
+        let vinst = match &ident {
+            Some(i) if i.phash == loaded.hash_container_bytes()? => i.vinst,
+            Some(i) => i.vinst.checked_add(1).ok_or_else(|| {
+                StoreError::InvalidData("persisted vinst is u64::MAX; cannot advance".into())
+            })?,
+            None => 1,
+        };
+        loaded.set_vinst(vinst);
 
         let resolver = PolicyResolver::new(resolver);
 
@@ -151,7 +163,7 @@ impl PolicyMgr {
         // stored as the current policy. build_state borrows `loaded`, leaving it
         // available for the post-resolution persist below.
         let state = Self::build_state(&resolver, &loaded).await?;
-        let _db_updated = repo.set_current_policy(&loaded, false).await?;
+        repo.set_current_policy(&loaded, false).await?;
 
         debug!(target: MAIN, "policy manager initialized successfully");
         Ok(Self::from_state(state, repo, resolver))
@@ -170,9 +182,12 @@ impl PolicyMgr {
         resolver: Arc<dyn DnsResolver>,
     ) -> Result<Self, ServiceError> {
         debug!(target: MAIN, "initializing policy manager from state");
-        let loaded = repo
+        let mut loaded = repo
             .get_current_loaded_policy(&config::POLICY_MIN_VERSION)
             .await?;
+        // Restore the persisted vinst.
+        let ident = repo.get_current_identifier().await?;
+        loaded.set_vinst(ident.map_or(1, |i| i.vinst));
         {
             let policy = loaded.policy();
             info!(target: MAIN, "loaded policy from state version:{}, created:{}", policy.get_version().unwrap_or(0),
@@ -255,7 +270,7 @@ impl PolicyMgr {
         // the current policy, container, and topology untouched. The new policy,
         // container, and links swap in together as one PolicyState.
         let state = Self::build_state(&self.resolver, &loaded).await?;
-        let _db_updated = self.repo.set_current_policy(&loaded, false).await?;
+        self.repo.set_current_policy(&loaded, false).await?;
 
         self.state.store(Arc::new(state));
         Ok(vinst)
@@ -383,7 +398,7 @@ mod tests {
     use zpr::policy_types::{AttrExp, NetAddr, Peering};
     use zpr::write_to::WriteTo;
 
-    use crate::db::{FakeDb, PolicyRepo};
+    use crate::db::{DbConnection, FakeDb, PolicyRepo};
     use crate::test_helpers::FakeResolver;
 
     fn ip(s: &str) -> IpAddr {
@@ -666,6 +681,92 @@ mod tests {
         let result = presolver.peers_to_links(&[good, bad]).await;
 
         assert!(result.is_err());
+    }
+
+    /// After an update bumps vinst, a fresh PolicyMgr built from the same DB via
+    /// new_from_state restores that vinst rather than the decoded default.
+    #[tokio::test]
+    async fn test_new_from_state_restores_vinst() {
+        let db = Arc::new(FakeDb::new());
+        let mgr = PolicyMgr::new_with_initial_policy(
+            policy_no_topology(),
+            PolicyRepo::new(db.clone()),
+            Arc::new(FakeResolver::ip_only()),
+        )
+        .await
+        .unwrap();
+        // Update to a distinct container so vinst advances to 2.
+        let peering = make_peering(ip("fd5a:5052::1"), ip("fd5a:5052::2"), "link-1", vec![]);
+        mgr.update_policy_from_container_bytes(policy_with_peerings(&[peering]))
+            .await
+            .unwrap();
+
+        let restored =
+            PolicyMgr::new_from_state(PolicyRepo::new(db), Arc::new(FakeResolver::ip_only()))
+                .await
+                .unwrap();
+        assert_eq!(restored.get_current().vinst(), 2);
+    }
+
+    /// Rebooting with the same container reuses the persisted vinst (plain
+    /// restart); a different container advances it (new install).
+    #[tokio::test]
+    async fn test_new_with_initial_policy_vinst_from_persisted_identifier() {
+        let db = Arc::new(FakeDb::new());
+        let container = policy_no_topology();
+        // First boot: fresh DB → vinst 1.
+        let mgr = PolicyMgr::new_with_initial_policy(
+            container.clone(),
+            PolicyRepo::new(db.clone()),
+            Arc::new(FakeResolver::ip_only()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(mgr.get_current().vinst(), 1);
+
+        // Reboot with the same container: same phash → vinst stays 1.
+        let same = PolicyMgr::new_with_initial_policy(
+            container,
+            PolicyRepo::new(db.clone()),
+            Arc::new(FakeResolver::ip_only()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(same.get_current().vinst(), 1);
+
+        // Reboot with a different container: new phash → vinst advances to 2.
+        let peering = make_peering(ip("fd5a:5052::1"), ip("fd5a:5052::2"), "link-1", vec![]);
+        let different = PolicyMgr::new_with_initial_policy(
+            policy_with_peerings(&[peering]),
+            PolicyRepo::new(db),
+            Arc::new(FakeResolver::ip_only()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(different.get_current().vinst(), 2);
+    }
+
+    /// A corrupt DB (policy present, no persisted vinst field) fails startup
+    /// rather than silently defaulting the vinst.
+    #[tokio::test]
+    async fn test_new_from_state_missing_vinst_errors() {
+        let db = Arc::new(FakeDb::new());
+        // Seed a current policy, then rewrite policy:current without a vinst
+        // field to mimic a corrupt state (the container blob is left intact).
+        PolicyMgr::new_with_initial_policy(
+            policy_no_topology(),
+            PolicyRepo::new(db.clone()),
+            Arc::new(FakeResolver::ip_only()),
+        )
+        .await
+        .unwrap();
+        let phash = db.hget("policy:current", "phash").await.unwrap().unwrap();
+        db.del("policy:current").await.unwrap();
+        db.hset("policy:current", "phash", &phash).await.unwrap();
+
+        let res =
+            PolicyMgr::new_from_state(PolicyRepo::new(db), Arc::new(FakeResolver::ip_only())).await;
+        assert!(res.is_err());
     }
 
     /// A hostname peer is resolved to the expected IP address via the FakeResolver.


### PR DESCRIPTION
Second PR in the sequence of PRs building up to "re-check all visas on policy change".

The `vinst` value stored with the installed policy is now stored in redis and reloaded on boot (used to always reset to 1). 


