### PR TITLE
Mk/visa write thru on store vinst : Convert visa repo to a write-through model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,3 +18,4 @@ Rust workspace with main crate `vs` (visa service) and supporting crates:
 
 ## Project Note
 - ZPR addresses are IPv6 and must use prefix `fd5a:5052`.
+- This is early release code so we do not care about migrating existing database state.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5241,6 +5241,7 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 [[package]]
 name = "zpr"
 version = "0.19.2"
+source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.19.2#2a4c9857ab8772fb4328bf9e9d94c0c99e6e9ad5"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5240,8 +5240,7 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zpr"
-version = "0.19.1"
-source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.19.1#5a812cb609fd7a9821ce8dc464a495620d4dbd89"
+version = "0.19.2"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,5 @@ serde_with = { version = "3.18.0", default-features = false, features = ["std", 
 thiserror = "2.0.18"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.20"
-zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.19.1", features = ["vsapi", "policy"]}
+zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.19.2", features = ["vsapi", "policy"]}
 

--- a/vs/src/db/db_fake.rs
+++ b/vs/src/db/db_fake.rs
@@ -494,6 +494,11 @@ impl DbConnection for FakeDb {
     /// To simulate atomic we take a lock that prevents all the other operations
     /// from running.
     async fn atomic_pipeline(&self, ops: &[DbOp]) -> DbResult<()> {
+        // Models Redis MULTI/EXEC atomicity: a Reject fails the whole pipeline
+        // before any op applies, so callers can test the all-or-nothing contract.
+        if *self.set_ex_fault.lock().unwrap() == FaultMode::Reject {
+            return Err(injected_fault_err());
+        }
         let _wlock = self.lock.write().await;
         for op in ops {
             match op {

--- a/vs/src/db/db_fake.rs
+++ b/vs/src/db/db_fake.rs
@@ -9,12 +9,31 @@ use tokio::time::Instant;
 
 use crate::db::{DbConnection, DbOp, DbResult, LockDescriptor};
 
+/// Fault-injection mode for a specific write op, used by write-through tests.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FaultMode {
+    /// No fault: op behaves normally.
+    #[default]
+    None,
+    /// Return an error without applying the mutation.
+    Reject,
+    /// Apply the mutation but still return an error (simulates an ambiguous
+    /// commit where the reply was lost).
+    ApplyThenError,
+}
+
 #[allow(dead_code)]
 pub struct FakeDb {
     store: DashMap<String, Entry>,
 
     // All the operations take read lock except *_atomic ones which take write lock.
     lock: RwLock<()>,
+
+    // Sticky fault injected on the corresponding op until reset. std Mutex is
+    // fine: no await is held across it.
+    set_ex_fault: std::sync::Mutex<FaultMode>,
+    del_fault: std::sync::Mutex<FaultMode>,
 }
 
 #[allow(dead_code)]
@@ -37,8 +56,27 @@ impl FakeDb {
         FakeDb {
             store: DashMap::new(),
             lock: RwLock::new(()),
+            set_ex_fault: std::sync::Mutex::new(FaultMode::None),
+            del_fault: std::sync::Mutex::new(FaultMode::None),
         }
     }
+
+    /// Inject a fault mode on the next (and subsequent) `set_ex` calls.
+    #[allow(dead_code)]
+    pub fn set_set_ex_fault(&self, mode: FaultMode) {
+        *self.set_ex_fault.lock().unwrap() = mode;
+    }
+
+    /// Inject a fault mode on the next (and subsequent) `del` calls.
+    #[allow(dead_code)]
+    pub fn set_del_fault(&self, mode: FaultMode) {
+        *self.del_fault.lock().unwrap() = mode;
+    }
+}
+
+/// A generic redis-shaped error to surface an injected fault.
+fn injected_fault_err() -> redis::RedisError {
+    redis::RedisError::from((redis::ErrorKind::UnexpectedReturnType, "injected fault"))
 }
 
 impl Entry {
@@ -188,11 +226,18 @@ impl DbConnection for FakeDb {
 
     /// Set a string value with expiration.
     async fn set_ex(&self, key: &str, value: &str, seconds: u64) -> DbResult<()> {
+        let fault = *self.set_ex_fault.lock().unwrap();
+        if fault == FaultMode::Reject {
+            return Err(injected_fault_err());
+        }
         let _rlock = self.lock.read().await;
         self.store.insert(
             key.to_string(),
             Entry::new_ex(FakeDbValue::Str(value.to_string()), seconds),
         );
+        if fault == FaultMode::ApplyThenError {
+            return Err(injected_fault_err());
+        }
         Ok(())
     }
 
@@ -260,8 +305,16 @@ impl DbConnection for FakeDb {
 
     /// Delete a key.
     async fn del(&self, key: &str) -> DbResult<()> {
+        let fault = *self.del_fault.lock().unwrap();
+        if fault == FaultMode::Reject {
+            return Err(injected_fault_err());
+        }
         let _rlock = self.lock.read().await;
-        self.del_with_lock(key).await
+        self.del_with_lock(key).await?;
+        if fault == FaultMode::ApplyThenError {
+            return Err(injected_fault_err());
+        }
+        Ok(())
     }
 
     /// Get all members of a set.  Returns empty set if key does not exist.

--- a/vs/src/db/mod.rs
+++ b/vs/src/db/mod.rs
@@ -35,6 +35,7 @@ pub enum LockType {
 
 pub type DbResult<T> = redis::RedisResult<T>;
 
+// TODO: At some point remove this dead code and remove the unused functions.
 #[allow(dead_code)]
 #[async_trait::async_trait]
 pub trait DbConnection: Send + Sync {

--- a/vs/src/db/mod.rs
+++ b/vs/src/db/mod.rs
@@ -16,7 +16,7 @@ pub use policy::PolicyRepo;
 pub use visa::{NodeVisaState, VisaMetadata, VisaRepo};
 
 #[cfg(test)]
-pub use db_fake::FakeDb;
+pub use db_fake::{FakeDb, FaultMode};
 
 use chrono::Utc;
 use percent_encoding::CONTROLS;
@@ -35,6 +35,7 @@ pub enum LockType {
 
 pub type DbResult<T> = redis::RedisResult<T>;
 
+#[allow(dead_code)]
 #[async_trait::async_trait]
 pub trait DbConnection: Send + Sync {
     /// May be called during a clean shutdown so that DB can do any necessary cleanup (e.g. releasing locks).
@@ -42,15 +43,11 @@ pub trait DbConnection: Send + Sync {
 
     async fn exists(&self, key: &str) -> DbResult<bool>;
     async fn set(&self, key: &str, value: &str) -> DbResult<()>;
-
-    #[allow(dead_code)]
     async fn set_ex(&self, key: &str, value: &str, seconds: u64) -> DbResult<()>;
-
     async fn get(&self, key: &str) -> DbResult<Option<String>>;
 
     /// Set a binary value directly. For atomic writes alongside other ops, use
     /// `DbOp::SetBin` in an `atomic_pipeline` instead.
-    #[allow(dead_code)]
     async fn set_bin(&self, key: &str, value: &[u8]) -> DbResult<()>;
     async fn set_bin_ex(&self, key: &str, value: &[u8], seconds: u64) -> DbResult<()>;
     async fn get_bin(&self, key: &str) -> DbResult<Vec<u8>>;
@@ -125,6 +122,7 @@ impl PartialEq for LockDescriptor {
 
 impl Eq for LockDescriptor {}
 
+#[allow(dead_code)]
 pub enum DbOp {
     Del(String),
     /// Set a binary value at `key`. Lets binary blobs join an atomic pipeline.

--- a/vs/src/db/visa.rs
+++ b/vs/src/db/visa.rs
@@ -66,16 +66,19 @@ pub struct VisaMetadata {
 }
 
 /// Persisted per-node state within a `VisaRecord` (keyed by ZAddr string).
+/// This is the persisted [NodeState].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct StoredNodeState {
     state: NodeVisaState,
     utime: String,
-    revoke_vinst: Option<u64>, // TODO: Will be set if we need to revoke this visa.
+    revoke_vinst: Option<u64>,
 }
 
 /// The single JSON value persisted at `visa:<id>`. Redis's only jobs are
 /// persisting and expiring whole visas, so everything a visa needs lives here.
 /// Expiry lives in the capnp blob (`visa.expires`) and is recovered on decode.
+///
+/// This is the persisted [VisaEntry].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct VisaRecord {
     blob: String, // base64 capnp visa bytes (Visa is not serde)
@@ -83,14 +86,14 @@ struct VisaRecord {
     node_states: HashMap<String, StoredNodeState>, // keyed by ZAddr string
 }
 
-/// In-memory per-node state for a visa.
+/// In-memory, authoritative per-node state for a visa.
 #[derive(Debug, Clone)]
 struct NodeState {
     state: NodeVisaState,
-    revoke_vinst: Option<u64>, // TODO: will be stamped when marked PendingRevoke
+    revoke_vinst: Option<u64>, // TODO: will be stamped with a policy `vinst` when marked PendingRevoke
 }
 
-/// In-memory authoritative copy of one visa.
+/// In-memory, authoritative copy of one visa.
 struct VisaEntry {
     visa: Visa,
     metadata: VisaMetadata,

--- a/vs/src/db/visa.rs
+++ b/vs/src/db/visa.rs
@@ -226,6 +226,11 @@ impl VisaRepo {
 
     /// Store a new visa, setting its state w.r.t. the requesting node to `nstate`
     /// and any other path nodes to `PendingInstall`.
+    ///
+    /// If the visa is already expired, this is a NOP and returns `Ok`.
+    ///
+    /// ### Errrors
+    /// - Errors if there is a problem writing to Redis or serializing the record.
     pub async fn store_visa(
         &self,
         visa: &Visa,
@@ -235,9 +240,8 @@ impl VisaRepo {
         let visa_id = visa.issuer_id;
         let ttl = seconds_until(visa.expires);
         if ttl == 0 {
-            return Err(StoreError::InvalidData(
-                "attempt to store already expired visa".into(),
-            ));
+            // already expired.
+            return Ok(());
         }
 
         // Build the per-node state map: requesting node gets `nstate`, other path
@@ -749,18 +753,21 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_store_visa_rejects_expired() {
+    async fn test_store_visa_nop_expired() {
         let db = Arc::new(FakeDb::new());
         let repo = VisaRepo::new(db, 1).await.unwrap();
         let node_addr: IpAddr = "fd5a:5052::4".parse().unwrap();
         let mut visa = make_visa(8, Duration::from_secs(1));
         visa.expires = SystemTime::now() - Duration::from_secs(1);
 
-        let err = repo
+        let _res = repo
             .store_visa(&visa, md(node_addr), NodeVisaState::PendingInstall)
             .await
-            .unwrap_err();
-        assert!(matches!(err, StoreError::InvalidData(_)));
+            .unwrap();
+
+        // Not written
+        let store = repo.store.read().await;
+        assert!(!store.visas.contains_key(&8));
     }
 
     #[tokio::test(start_paused = true)]

--- a/vs/src/db/visa.rs
+++ b/vs/src/db/visa.rs
@@ -40,6 +40,12 @@ use crate::logging::targets::DB;
 const KEY_VISA: &str = "visa";
 const KEY_NEXT_VISA_ID: &str = "visa:next_visa_id";
 
+/// Minimum wall-gap between actual purge scans. Housekeeping calls
+/// `purge_expired` once per node per heartbeat, so with N nodes it fires N× per
+/// interval; this collapses those to one real scan and spares readers the extra
+/// store-write-lock acquisitions.
+const PURGE_MIN_INTERVAL: Duration = Duration::from_millis(800);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum NodeVisaState {
     PendingInstall,
@@ -138,6 +144,9 @@ pub struct VisaRepo {
     ///
     /// See https://github.com/org-zpr/zpr-visaservice/issues/246
     store: RwLock<VisaStoreInner>,
+    /// Last time `purge_expired` actually scanned. `None` until the first purge.
+    /// Throttles the per-node housekeeping stampede (see `PURGE_MIN_INTERVAL`).
+    last_purge: std::sync::Mutex<Option<Instant>>,
 }
 
 impl VisaMetadata {
@@ -187,6 +196,7 @@ impl VisaRepo {
             db,
             backing: Mutex::new(()),
             store: RwLock::new(inner),
+            last_purge: std::sync::Mutex::new(None),
         })
     }
 
@@ -515,6 +525,19 @@ impl VisaRepo {
     /// Drop expired entries and their `by_node` index rows. Redis needs no
     /// matching delete since the TTL should have already fired. Called by housekeeping.
     pub fn purge_expired(&self) -> Result<(), StoreError> {
+        // Throttle: skip if the last real scan was under PURGE_MIN_INTERVAL ago,
+        // so N node workers ticking together don't each take the store write
+        // lock. Stamped before the scan; a purge at most one interval stale is
+        // fine since reads already filter expired entries.
+        {
+            let mut last = self.last_purge.lock().unwrap();
+            if let Some(t) = *last {
+                if Instant::now().saturating_duration_since(t) < PURGE_MIN_INTERVAL {
+                    return Ok(());
+                }
+            }
+            *last = Some(Instant::now());
+        }
         // INVARIANT D: memory-only writer. purge does NOT take `backing` — it
         // writes no Redis key (the keys expire on their own TTL), so there is no
         // Redis/memory order to enforce, and it is exempt from Invariant A.

--- a/vs/src/db/visa.rs
+++ b/vs/src/db/visa.rs
@@ -98,8 +98,15 @@ struct VisaEntry {
     visa: Visa,
     metadata: VisaMetadata,
     // Expiry moment as a tokio Instant, derived from `visa.expires` at insert /
-    // state_load time. Using the tokio clock (not SystemTime) keeps liveness in
-    // lockstep with Redis/FakeDb TTLs and lets paused-clock tests advance expiry.
+    // state_load time. The tokio (monotonic) clock, not SystemTime, is deliberate:
+    // it lets paused-clock tests drive expiry with tokio::time::advance().
+    //
+    // NOTE: Monotonic deadline can diverge from Redis's wall-clock TTL if the
+    // host suspends or NTP steps the clock — CLOCK_MONOTONIC freezes/ignores those.
+    // Memory may then serve a visa Redis has already dropped, and a rewrite can
+    // resurrect the key with a fresh TTL. Bounded and self-healing: restart
+    // re-hydrates from Redis. If suspend/NTP-step becomes a real deployment
+    // concern, AND-guard liveness with `seconds_until(visa.expires) > 0`.
     deadline: Instant,
     node_states: HashMap<IpAddr, NodeState>,
 }

--- a/vs/src/db/visa.rs
+++ b/vs/src/db/visa.rs
@@ -21,9 +21,9 @@ use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime};
-use tokio::sync::RwLock;
+use tokio::sync::Mutex;
 use tokio::time::Instant;
 use tracing::{debug, info, warn};
 
@@ -105,6 +105,10 @@ struct VisaEntry {
 }
 
 /// The in-memory store guarded by a single `RwLock`.
+///
+/// INVARIANT C: `visas` and `by_node` must be updated under the same `store`
+/// write guard; a reader must never see one without the other. Today the single
+/// `store` lock gives this for free (both live behind one guard).
 #[derive(Default)]
 struct VisaStoreInner {
     visas: HashMap<u64, VisaEntry>,
@@ -113,6 +117,19 @@ struct VisaStoreInner {
 
 pub struct VisaRepo {
     db: Arc<dyn DbConnection>,
+    /// Serializes ALL write paths (store/update/clear/clean_up). Held across the
+    /// Redis I/O so writes commit to Redis and then to memory in one global
+    /// order. Readers never take this lock. `purge_expired` is the sole writer
+    /// exempt (Invariant D: memory-only, no Redis write to order).
+    ///
+    /// INVARIANT A: every mutation that writes Redis must take `backing` before
+    /// touching Redis or the memory image.
+    backing: Mutex<()>,
+    /// Guards the in-memory image. Taken briefly and NEVER held across an
+    /// `.await` — it is a `std::sync::RwLock`, so its `!Send` guard makes holding
+    /// it across `.await` a compile error.
+    ///
+    /// See https://github.com/org-zpr/zpr-visaservice/issues/246
     store: RwLock<VisaStoreInner>,
 }
 
@@ -161,6 +178,7 @@ impl VisaRepo {
         let inner = restore_from_state(&db).await?;
         Ok(VisaRepo {
             db,
+            backing: Mutex::new(()),
             store: RwLock::new(inner),
         })
     }
@@ -176,11 +194,15 @@ impl VisaRepo {
     /// TODO: Will be used by future `remove_visa` function.
     #[allow(dead_code)]
     async fn clean_up(&self, visa_id: u64) -> Result<(), StoreError> {
+        // INVARIANT A: backing held for the whole write.
+        let _backing = self.backing.lock().await;
         let key = visa_key_for_visa(visa_id);
-        let mut store = self.store.write().await;
         // Redis first. On an ApplyThenError-style ambiguous DEL we still return
         // the error and keep the memory entry; a later rewrite recreates the key.
         self.db.del(&key).await?;
+        // Memory second. `remove_entry` is a no-op on a missing row, so a
+        // concurrent `purge_expired` that already dropped the entry is harmless.
+        let mut store = self.store.write().unwrap();
         remove_entry(&mut store, visa_id);
         Ok(())
     }
@@ -191,35 +213,60 @@ impl VisaRepo {
     /// `by_node` index, but the visa record itself is never deleted, even if
     /// `node_states` becomes empty.
     pub async fn clear_node_state(&self, node_addr: &IpAddr) -> Result<(), StoreError> {
-        let mut store = self.store.write().await;
-        let ids: Vec<u64> = store
-            .by_node
-            .get(node_addr)
-            .map(|s| s.iter().copied().collect())
-            .unwrap_or_default();
+        // INVARIANT A: backing held for the whole write.
+        let _backing = self.backing.lock().await;
 
-        for id in ids {
-            let Some(entry) = store.visas.get(&id) else {
-                continue;
-            };
-            if !entry.node_states.contains_key(node_addr) {
-                continue;
+        // Snapshot the work under a short read guard: for each visa referencing
+        // the node, its id and the rewritten JSON to persist (None if the entry
+        // is effectively expired — its TTL has fired / is about to, so we skip
+        // the rewrite but still drop the node from memory below).
+        //
+        // INVARIANT B: dropping this read guard is safe — backing blocks other
+        // writers, so these entries can't change under us before the apply.
+        let writes: Vec<(u64, Option<(String, u64)>)> = {
+            let store = self.store.read().unwrap();
+            let ids: Vec<u64> = store
+                .by_node
+                .get(node_addr)
+                .map(|s| s.iter().copied().collect())
+                .unwrap_or_default();
+            let mut writes = Vec::new();
+            for id in ids {
+                let Some(entry) = store.visas.get(&id) else {
+                    continue;
+                };
+                if !entry.node_states.contains_key(node_addr) {
+                    continue;
+                }
+                let ttl = remaining_secs(entry.deadline);
+                let json = if ttl > 0 {
+                    let mut new_states = entry.node_states.clone();
+                    new_states.remove(node_addr);
+                    let record = build_record(&entry.visa, &entry.metadata, &new_states)?;
+                    Some((serde_json::to_string(&record)?, ttl))
+                } else {
+                    None
+                };
+                writes.push((id, json));
             }
-            let ttl = remaining_secs(entry.deadline);
-            // Rewrite the record without the node (unless it is effectively
-            // expired, in which case its TTL has fired / is about to).
-            if ttl > 0 {
-                let mut new_states = entry.node_states.clone();
-                new_states.remove(node_addr);
-                let record = build_record(&entry.visa, &entry.metadata, &new_states)?;
-                let json = serde_json::to_string(&record)?;
-                self.db.set_ex(&visa_key_for_visa(id), &json, ttl).await?;
+            writes
+        };
+
+        // Redis first.
+        for (id, json) in &writes {
+            if let Some((json, ttl)) = json {
+                self.db.set_ex(&visa_key_for_visa(*id), json, *ttl).await?;
             }
-            // Memory second.
-            if let Some(entry) = store.visas.get_mut(&id) {
+        }
+
+        // Memory second. A concurrent purge may have dropped an entry during the
+        // I/O gap; `get_mut` and `unindex_node` both no-op on a missing row.
+        let mut store = self.store.write().unwrap();
+        for (id, _) in &writes {
+            if let Some(entry) = store.visas.get_mut(id) {
                 entry.node_states.remove(node_addr);
             }
-            unindex_node(&mut store, node_addr, id);
+            unindex_node(&mut store, node_addr, *id);
         }
         Ok(())
     }
@@ -273,7 +320,8 @@ impl VisaRepo {
         let json = serde_json::to_string(&record)?;
         let key = visa_key_for_visa(visa_id);
 
-        let mut store = self.store.write().await;
+        // INVARIANT A: backing held for the whole write.
+        let _backing = self.backing.lock().await;
         // Redis first.
         if let Err(e) = self.db.set_ex(&key, &json, ttl).await {
             // The write may have applied but the reply was lost (ambiguous
@@ -283,13 +331,15 @@ impl VisaRepo {
             let _ = self.db.del(&key).await;
             return Err(e.into());
         }
-        // Memory second.
+        // Memory second. Pure insert: the id does not exist until now and purge
+        // only removes, so there is nothing to re-check.
         let entry = VisaEntry {
             visa: visa.clone(),
             metadata,
             deadline: Instant::now() + Duration::from_secs(ttl),
             node_states,
         };
+        let mut store = self.store.write().unwrap();
         insert_entry(&mut store, visa_id, entry);
 
         debug!(target: DB, "stored visa {visa_id} expires in {ttl} seconds");
@@ -304,44 +354,57 @@ impl VisaRepo {
         visa_id: u64,
         new_state: NodeVisaState,
     ) -> Result<(), StoreError> {
-        let mut store = self.store.write().await;
-        let entry = live_entry(&store, visa_id).ok_or_else(|| {
-            StoreError::NotFound(format!("node-visa record not found: {node_addr} {visa_id}"))
-        })?;
-        if !entry.node_states.contains_key(node_addr) {
-            return Err(StoreError::NotFound(format!(
-                "node-visa record not found: {node_addr} {visa_id}"
-            )));
-        }
-        let ttl = remaining_secs(entry.deadline);
-        if ttl == 0 {
-            return Err(StoreError::NotFound(format!(
-                "node-visa record not found: {node_addr} {visa_id}"
-            )));
-        }
-        let mut new_states = entry.node_states.clone();
-        new_states.get_mut(node_addr).unwrap().state = new_state;
-        let record = build_record(&entry.visa, &entry.metadata, &new_states)?;
-        let json = serde_json::to_string(&record)?;
+        // INVARIANT A: backing held for the whole write.
+        let _backing = self.backing.lock().await;
+
+        // Snapshot + build the record under a short read guard, run the
+        // not-found / ttl==0 checks, then drop the guard for the Redis I/O.
+        //
+        // INVARIANT B: safe to drop the read guard — backing blocks other
+        // writers, so this entry can't change under us before the apply.
+        let (json, ttl, new_states) = {
+            let store = self.store.read().unwrap();
+            let entry = live_entry(&store, visa_id).ok_or_else(|| {
+                StoreError::NotFound(format!("node-visa record not found: {node_addr} {visa_id}"))
+            })?;
+            if !entry.node_states.contains_key(node_addr) {
+                return Err(StoreError::NotFound(format!(
+                    "node-visa record not found: {node_addr} {visa_id}"
+                )));
+            }
+            let ttl = remaining_secs(entry.deadline);
+            if ttl == 0 {
+                return Err(StoreError::NotFound(format!(
+                    "node-visa record not found: {node_addr} {visa_id}"
+                )));
+            }
+            let mut new_states = entry.node_states.clone();
+            new_states.get_mut(node_addr).unwrap().state = new_state;
+            let record = build_record(&entry.visa, &entry.metadata, &new_states)?;
+            (serde_json::to_string(&record)?, ttl, new_states)
+        };
 
         // Redis first.
         self.db
             .set_ex(&visa_key_for_visa(visa_id), &json, ttl)
             .await?;
-        // Memory second.
-        store.visas.get_mut(&visa_id).unwrap().node_states = new_states;
+        // Memory second. If purge_expired dropped the entry during the set_ex
+        // gap the visa expired mid-update; skipping the apply is correct.
+        if let Some(entry) = self.store.write().unwrap().visas.get_mut(&visa_id) {
+            entry.node_states = new_states;
+        }
 
         debug!(target: DB, "updated nodevisa state node={node_addr} visa={visa_id} -> {new_state:?}");
         Ok(())
     }
 
     /// All visas for a node in the given state (blobs cloned from memory).
-    pub async fn get_visas_for_node_by_state(
+    pub fn get_visas_for_node_by_state(
         &self,
         node_addr: &IpAddr,
         state: NodeVisaState,
     ) -> Result<Vec<Visa>, StoreError> {
-        let store = self.store.read().await;
+        let store = self.store.read().unwrap();
         let mut visas = Vec::new();
         if let Some(ids) = store.by_node.get(node_addr) {
             for &id in ids {
@@ -360,12 +423,12 @@ impl VisaRepo {
     }
 
     /// The visa IDs for a node filtered by state, without cloning the visas.
-    pub async fn get_visa_ids_for_node_by_state(
+    pub fn get_visa_ids_for_node_by_state(
         &self,
         node_addr: &IpAddr,
         state: NodeVisaState,
     ) -> Result<Vec<u64>, StoreError> {
-        let store = self.store.read().await;
+        let store = self.store.read().unwrap();
         let mut ids = Vec::new();
         if let Some(node_ids) = store.by_node.get(node_addr) {
             for &id in node_ids {
@@ -384,14 +447,12 @@ impl VisaRepo {
     }
 
     /// Count the visas for a node that are in the given state.
-    pub async fn get_count_visas_for_node_by_state(
+    pub fn get_count_visas_for_node_by_state(
         &self,
         node_addr: &IpAddr,
         state: NodeVisaState,
     ) -> Result<u32, StoreError> {
-        let ids = self
-            .get_visa_ids_for_node_by_state(node_addr, state)
-            .await?;
+        let ids = self.get_visa_ids_for_node_by_state(node_addr, state)?;
         Ok(ids.len() as u32)
     }
 
@@ -399,8 +460,8 @@ impl VisaRepo {
     ///
     /// ## Errors
     /// - [StoreError::NotFound] if the visa does not exist (or has expired).
-    pub async fn get_visa_by_id(&self, visa_id: u64) -> Result<Visa, StoreError> {
-        let store = self.store.read().await;
+    pub fn get_visa_by_id(&self, visa_id: u64) -> Result<Visa, StoreError> {
+        let store = self.store.read().unwrap();
         live_entry(&store, visa_id)
             .map(|e| e.visa.clone())
             .ok_or_else(|| StoreError::NotFound(format!("visa not found for ID {visa_id}")))
@@ -410,8 +471,8 @@ impl VisaRepo {
     ///
     /// ## Errors
     /// - [StoreError::NotFound] if the visa metadata does not exist (or has expired).
-    pub async fn get_visa_metadata_by_id(&self, visa_id: u64) -> Result<VisaMetadata, StoreError> {
-        let store = self.store.read().await;
+    pub fn get_visa_metadata_by_id(&self, visa_id: u64) -> Result<VisaMetadata, StoreError> {
+        let store = self.store.read().unwrap();
         live_entry(&store, visa_id)
             .map(|e| e.metadata.clone())
             .ok_or_else(|| {
@@ -420,8 +481,8 @@ impl VisaRepo {
     }
 
     /// Copy all the live visa IDs into a vec.
-    pub async fn list_visa_ids(&self) -> Result<Vec<u64>, StoreError> {
-        let store = self.store.read().await;
+    pub fn list_visa_ids(&self) -> Result<Vec<u64>, StoreError> {
+        let store = self.store.read().unwrap();
         Ok(store
             .visas
             .iter()
@@ -432,8 +493,14 @@ impl VisaRepo {
 
     /// Drop expired entries and their `by_node` index rows. Redis needs no
     /// matching delete since the TTL should have already fired. Called by housekeeping.
-    pub async fn purge_expired(&self) -> Result<(), StoreError> {
-        let mut store = self.store.write().await;
+    pub fn purge_expired(&self) -> Result<(), StoreError> {
+        // INVARIANT D: memory-only writer. purge does NOT take `backing` — it
+        // writes no Redis key (the keys expire on their own TTL), so there is no
+        // Redis/memory order to enforce, and it is exempt from Invariant A.
+        // Because it skips `backing`, it is the one writer that can interleave
+        // inside a read-modify-write's Redis-I/O gap; that is why every writer's
+        // memory-apply tolerates a vanished entry.
+        let mut store = self.store.write().unwrap();
         let expired: Vec<u64> = store
             .visas
             .iter()
@@ -650,7 +717,7 @@ mod test {
     /// Assert the persisted VisaRecord for `id` matches the in-memory entry.
     async fn assert_memory_matches_redis(repo: &VisaRepo, db: &FakeDb, id: u64) {
         let record = read_record(db, id).await;
-        let store = repo.store.read().await;
+        let store = repo.store.read().unwrap();
         let entry = store.visas.get(&id).unwrap();
         assert_eq!(record.node_states.len(), entry.node_states.len());
         for (addr, ns) in &entry.node_states {
@@ -690,7 +757,6 @@ mod test {
 
         let pending = repo
             .get_visas_for_node_by_state(&node_addr, NodeVisaState::PendingInstall)
-            .await
             .unwrap();
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].issuer_id, 42);
@@ -700,13 +766,11 @@ mod test {
             .unwrap();
         let pending = repo
             .get_visas_for_node_by_state(&node_addr, NodeVisaState::PendingInstall)
-            .await
             .unwrap();
         assert!(pending.is_empty());
 
         let installed = repo
             .get_visas_for_node_by_state(&node_addr, NodeVisaState::Installed)
-            .await
             .unwrap();
         assert_eq!(installed.len(), 1);
         assert_eq!(installed[0].issuer_id, 42);
@@ -747,7 +811,7 @@ mod test {
                 .is_none()
         );
         // Memory agrees.
-        let store = repo.store.read().await;
+        let store = repo.store.read().unwrap();
         assert!(store.visas.contains_key(&7));
         assert!(!store.by_node.contains_key(&node_addr));
     }
@@ -766,7 +830,7 @@ mod test {
             .unwrap();
 
         // Not written
-        let store = repo.store.read().await;
+        let store = repo.store.read().unwrap();
         assert!(!store.visas.contains_key(&8));
     }
 
@@ -803,7 +867,7 @@ mod test {
                 .unwrap();
         }
 
-        let mut ids = repo.list_visa_ids().await.unwrap();
+        let mut ids = repo.list_visa_ids().unwrap();
         ids.sort_unstable();
         assert_eq!(ids, vec![1, 5, 42]);
     }
@@ -819,7 +883,7 @@ mod test {
             .await
             .unwrap();
 
-        let loaded = repo.get_visa_by_id(77).await.unwrap();
+        let loaded = repo.get_visa_by_id(77).unwrap();
         assert_eq!(loaded.issuer_id, 77);
         assert_eq!(
             loaded.dock_pep.as_ref().unwrap().source_addr,
@@ -835,7 +899,7 @@ mod test {
     async fn test_get_visa_by_id_missing() {
         let db = Arc::new(FakeDb::new());
         let repo = VisaRepo::new(db, 1).await.unwrap();
-        let err = repo.get_visa_by_id(1234).await.unwrap_err();
+        let err = repo.get_visa_by_id(1234).unwrap_err();
         assert!(matches!(err, StoreError::NotFound(_)));
     }
 
@@ -850,7 +914,7 @@ mod test {
             .await
             .unwrap();
 
-        let metadata = repo.get_visa_metadata_by_id(88).await.unwrap();
+        let metadata = repo.get_visa_metadata_by_id(88).unwrap();
         assert_eq!(metadata.requesting_node, node_addr);
         assert!(metadata.ctime > SystemTime::UNIX_EPOCH);
     }
@@ -859,7 +923,7 @@ mod test {
     async fn test_get_visa_metadata_by_id_missing() {
         let db = Arc::new(FakeDb::new());
         let repo = VisaRepo::new(db, 1).await.unwrap();
-        let err = repo.get_visa_metadata_by_id(999).await.unwrap_err();
+        let err = repo.get_visa_metadata_by_id(999).unwrap_err();
         assert!(matches!(err, StoreError::NotFound(_)));
     }
 
@@ -1045,12 +1109,10 @@ mod test {
 
         let ids = repo
             .get_visa_ids_for_node_by_state(&path_node, NodeVisaState::PendingInstall)
-            .await
             .unwrap();
         assert_eq!(ids, vec![102]);
         assert!(
             repo.get_visa_ids_for_node_by_state(&path_node, NodeVisaState::Installed)
-                .await
                 .unwrap()
                 .is_empty()
         );
@@ -1098,19 +1160,16 @@ mod test {
 
         let pending_ids = repo
             .get_visa_ids_for_node_by_state(&node_addr, NodeVisaState::PendingInstall)
-            .await
             .unwrap();
         assert_eq!(pending_ids, vec![10]);
         assert_eq!(
             repo.get_count_visas_for_node_by_state(&node_addr, NodeVisaState::PendingInstall)
-                .await
                 .unwrap(),
             1
         );
 
         let installed_ids = repo
             .get_visa_ids_for_node_by_state(&node_addr, NodeVisaState::Installed)
-            .await
             .unwrap();
         assert_eq!(installed_ids, vec![11]);
     }
@@ -1142,8 +1201,8 @@ mod test {
             .unwrap();
 
         let repo2 = VisaRepo::new(db.clone(), 1).await.unwrap();
-        let s1 = repo1.store.read().await;
-        let s2 = repo2.store.read().await;
+        let s1 = repo1.store.read().unwrap();
+        let s2 = repo2.store.read().unwrap();
         assert_eq!(
             s1.visas.keys().collect::<HashSet<_>>(),
             s2.visas.keys().collect::<HashSet<_>>()
@@ -1191,13 +1250,13 @@ mod test {
             .unwrap();
 
         let repo = VisaRepo::new(db.clone(), 1).await.unwrap();
-        assert!(repo.store.read().await.visas.is_empty());
+        assert!(repo.store.read().unwrap().visas.is_empty());
         assert!(!db.exists("visa:900").await.unwrap());
         assert!(!db.exists("visa:901").await.unwrap());
 
         // A second load has nothing to drop.
         let repo2 = VisaRepo::new(db.clone(), 1).await.unwrap();
-        assert!(repo2.store.read().await.visas.is_empty());
+        assert!(repo2.store.read().unwrap().visas.is_empty());
     }
 
     /// After each mutator the persisted record matches the in-memory image.
@@ -1235,7 +1294,7 @@ mod test {
         assert!(matches!(err, StoreError::Redis(_)));
 
         assert!(!db.exists("visa:400").await.unwrap());
-        assert!(repo.store.read().await.visas.is_empty());
+        assert!(repo.store.read().unwrap().visas.is_empty());
     }
 
     /// Ambiguous store_visa: set_ex applies but errors → the compensating DEL
@@ -1255,7 +1314,7 @@ mod test {
         assert!(matches!(err, StoreError::Redis(_)));
 
         assert!(!db.exists("visa:401").await.unwrap());
-        assert!(repo.store.read().await.visas.is_empty());
+        assert!(repo.store.read().unwrap().visas.is_empty());
     }
 
     /// Ambiguous store_visa where the compensating DEL also fails: the key
@@ -1274,13 +1333,13 @@ mod test {
             .unwrap_err();
 
         assert!(db.exists("visa:402").await.unwrap());
-        assert!(repo.store.read().await.visas.is_empty());
+        assert!(repo.store.read().unwrap().visas.is_empty());
 
         // Reset faults and reload — the orphan comes back.
         db.set_set_ex_fault(FaultMode::None);
         db.set_del_fault(FaultMode::None);
         let repo2 = VisaRepo::new(db.clone(), 1).await.unwrap();
-        assert!(repo2.store.read().await.visas.contains_key(&402));
+        assert!(repo2.store.read().unwrap().visas.contains_key(&402));
     }
 
     /// Ambiguous record rewrite: Redis takes the new state, memory keeps the old
@@ -1302,7 +1361,7 @@ mod test {
 
         // Memory kept the old state; Redis diverged to the new one.
         {
-            let store = repo.store.read().await;
+            let store = repo.store.read().unwrap();
             assert_eq!(
                 store
                     .visas
@@ -1349,7 +1408,7 @@ mod test {
         repo.clean_up(404).await.unwrap_err();
         // Redis key gone, memory keeps the entry.
         assert!(!db.exists("visa:404").await.unwrap());
-        assert!(repo.store.read().await.visas.contains_key(&404));
+        assert!(repo.store.read().unwrap().visas.contains_key(&404));
 
         // A rewrite recreates the key.
         db.set_del_fault(FaultMode::None);
@@ -1386,7 +1445,7 @@ mod test {
             .unwrap();
 
         {
-            let store = repo.store.read().await;
+            let store = repo.store.read().unwrap();
             for n in [req, node_b, node_c] {
                 assert!(store.by_node.get(&n).unwrap().contains(&500));
             }
@@ -1394,7 +1453,7 @@ mod test {
 
         repo.clear_node_state(&node_b).await.unwrap();
         {
-            let store = repo.store.read().await;
+            let store = repo.store.read().unwrap();
             assert!(!store.by_node.contains_key(&node_b));
             assert!(store.by_node.get(&req).unwrap().contains(&500));
             assert!(store.by_node.get(&node_c).unwrap().contains(&500));
@@ -1402,7 +1461,7 @@ mod test {
 
         repo.clean_up(500).await.unwrap();
         {
-            let store = repo.store.read().await;
+            let store = repo.store.read().unwrap();
             assert!(store.visas.is_empty());
             assert!(store.by_node.is_empty());
         }
@@ -1423,15 +1482,15 @@ mod test {
         tokio::time::advance(Duration::from_secs(6)).await;
 
         // Invisible to reads, but still resident until purge.
-        assert!(repo.list_visa_ids().await.unwrap().is_empty());
+        assert!(repo.list_visa_ids().unwrap().is_empty());
         assert!(matches!(
-            repo.get_visa_by_id(600).await.unwrap_err(),
+            repo.get_visa_by_id(600).unwrap_err(),
             StoreError::NotFound(_)
         ));
-        assert!(repo.store.read().await.visas.contains_key(&600));
+        assert!(repo.store.read().unwrap().visas.contains_key(&600));
 
-        repo.purge_expired().await.unwrap();
-        let store = repo.store.read().await;
+        repo.purge_expired().unwrap();
+        let store = repo.store.read().unwrap();
         assert!(store.visas.is_empty());
         assert!(store.by_node.is_empty());
     }

--- a/vs/src/db/visa.rs
+++ b/vs/src/db/visa.rs
@@ -839,6 +839,8 @@ mod test {
         assert!(matches!(err, StoreError::NotFound(_)));
     }
 
+    /// clear_node_state drops the node from a visa's states and the by_node
+    /// index, but keeps the visa record itself (and both Redis and memory agree).
     #[tokio::test]
     async fn test_clear_node_state_only_removes_node_from_record() {
         let db = Arc::new(FakeDb::new());
@@ -907,6 +909,8 @@ mod test {
         assert!(store.visas[&71].node_states.contains_key(&node_addr));
     }
 
+    /// Storing an already-expired visa is a NOP (not an error): it returns Ok
+    /// but writes nothing to memory (nor Redis, since ttl==0 short-circuits).
     #[tokio::test]
     async fn test_store_visa_nop_expired() {
         let db = Arc::new(FakeDb::new());
@@ -1093,6 +1097,8 @@ mod test {
         }
     }
 
+    /// With a path, the requesting node gets the passed state (Installed) and
+    /// every other node on the path gets PendingInstall.
     #[tokio::test]
     async fn test_store_visa_with_path_sets_path_nodes_pending() {
         let db = Arc::new(FakeDb::new());
@@ -1136,6 +1142,8 @@ mod test {
         }
     }
 
+    /// When the requesting node also appears in the path, it keeps its passed
+    /// state (Installed) rather than being downgraded to PendingInstall.
     #[tokio::test]
     async fn test_store_visa_requesting_node_in_path_not_overwritten() {
         let db = Arc::new(FakeDb::new());
@@ -1209,6 +1217,8 @@ mod test {
         );
     }
 
+    /// With no path, only the requesting node gets a state entry; unrelated
+    /// nodes are absent from the record.
     #[tokio::test]
     async fn test_store_visa_no_path_only_requesting_node_gets_state() {
         let db = Arc::new(FakeDb::new());

--- a/vs/src/db/visa.rs
+++ b/vs/src/db/visa.rs
@@ -437,19 +437,7 @@ impl VisaRepo {
     ) -> Result<Vec<Visa>, StoreError> {
         let store = self.store.read().unwrap();
         let mut visas = Vec::new();
-        if let Some(ids) = store.by_node.get(node_addr) {
-            for &id in ids {
-                if let Some(entry) = live_entry(&store, id) {
-                    if entry
-                        .node_states
-                        .get(node_addr)
-                        .is_some_and(|ns| ns.state == state)
-                    {
-                        visas.push(entry.visa.clone());
-                    }
-                }
-            }
-        }
+        for_each_node_visa_in_state(&store, node_addr, state, |_, e| visas.push(e.visa.clone()));
         Ok(visas)
     }
 
@@ -461,19 +449,7 @@ impl VisaRepo {
     ) -> Result<Vec<u64>, StoreError> {
         let store = self.store.read().unwrap();
         let mut ids = Vec::new();
-        if let Some(node_ids) = store.by_node.get(node_addr) {
-            for &id in node_ids {
-                if let Some(entry) = live_entry(&store, id) {
-                    if entry
-                        .node_states
-                        .get(node_addr)
-                        .is_some_and(|ns| ns.state == state)
-                    {
-                        ids.push(id);
-                    }
-                }
-            }
-        }
+        for_each_node_visa_in_state(&store, node_addr, state, |id, _| ids.push(id));
         Ok(ids)
     }
 
@@ -483,8 +459,10 @@ impl VisaRepo {
         node_addr: &IpAddr,
         state: NodeVisaState,
     ) -> Result<u32, StoreError> {
-        let ids = self.get_visa_ids_for_node_by_state(node_addr, state)?;
-        Ok(ids.len() as u32)
+        let store = self.store.read().unwrap();
+        let mut count = 0u32;
+        for_each_node_visa_in_state(&store, node_addr, state, |_, _| count += 1);
+        Ok(count)
     }
 
     /// Get the visa by ID.
@@ -517,7 +495,7 @@ impl VisaRepo {
         Ok(store
             .visas
             .iter()
-            .filter(|(_, e)| remaining_secs(e.deadline) > 0)
+            .filter(|(_, e)| e.is_live())
             .map(|(id, _)| *id)
             .collect())
     }
@@ -548,7 +526,7 @@ impl VisaRepo {
         let expired: Vec<u64> = store
             .visas
             .iter()
-            .filter(|(_, e)| remaining_secs(e.deadline) == 0)
+            .filter(|(_, e)| !e.is_live())
             .map(|(id, _)| *id)
             .collect();
         for id in expired {
@@ -584,7 +562,7 @@ async fn restore_from_state(db: &Arc<dyn DbConnection>) -> Result<VisaStoreInner
             }
         };
         match decode_record(&raw) {
-            Ok(entry) if remaining_secs(entry.deadline) > 0 => {
+            Ok(entry) if entry.is_live() => {
                 node_count += entry.node_states.len();
                 insert_entry(&mut inner, visa_id, entry);
             }
@@ -679,13 +657,41 @@ fn visa_to_capnp_bytes(visa: &Visa) -> Result<Vec<u8>, StoreError> {
     Ok(words)
 }
 
+impl VisaEntry {
+    /// True while the visa has not yet reached its expiry deadline. The single
+    /// liveness rule used by every read/iteration site.
+    fn is_live(&self) -> bool {
+        remaining_secs(self.deadline) > 0
+    }
+}
+
 /// Return the entry only if it is still live (`deadline` in the future).
 /// All reads go through this so expired entries read as absent.
 fn live_entry(inner: &VisaStoreInner, id: u64) -> Option<&VisaEntry> {
-    inner
-        .visas
-        .get(&id)
-        .filter(|e| remaining_secs(e.deadline) > 0)
+    inner.visas.get(&id).filter(|e| e.is_live())
+}
+
+/// Visit each live visa referencing `node_addr` whose per-node state == `state`,
+/// calling `f(id, entry)`. Backs the per-node get/ids/count query methods.
+fn for_each_node_visa_in_state<F: FnMut(u64, &VisaEntry)>(
+    inner: &VisaStoreInner,
+    node_addr: &IpAddr,
+    state: NodeVisaState,
+    mut f: F,
+) {
+    if let Some(ids) = inner.by_node.get(node_addr) {
+        for &id in ids {
+            if let Some(entry) = live_entry(inner, id) {
+                if entry
+                    .node_states
+                    .get(node_addr)
+                    .is_some_and(|ns| ns.state == state)
+                {
+                    f(id, entry);
+                }
+            }
+        }
+    }
 }
 
 /// Insert an entry and index all its nodes in `by_node`.

--- a/vs/src/db/visa.rs
+++ b/vs/src/db/visa.rs
@@ -1,18 +1,31 @@
 //! Redis/ValKey operations related to visas.
 //!
-//! This updates:
-//! - visa:next_visa_id a counter for the next visa ID to use (actually this is set to the last visa ID handed out).
-//! - visa:<ID> a hash of metadata about each visa.
-//! - visas:<ID>:blob the capnp encoded visa blob itself.
-//! - nodevisa:<ZADDR>:<ID> a hash of state about each visa on each node.
+//! `VisaRepo` is a **write-through store**: an in-memory image is authoritative
+//! for all reads/iteration; Redis is the persistence backing. Every mutation
+//! writes Redis first, then applies to memory, both under the store write lock.
+//! At startup the image is loaded from Redis in one pass. The service holds an
+//! exclusive DB instance lock (see `db_worker`), so nothing else mutates visa
+//! keys.
+//!
+//! Redis schema (one key per visa):
+//! - `visa:next_visa_id` a counter for the next visa ID (INCR).
+//! - `visa:<ID>` a JSON `VisaRecord` (visa blob + metadata + per-node states),
+//!   with TTL = visa expiry.
+//!
+//! TODO: At some point more of the redis stored state will be moved to write-through
+//! schemes like this, which may involve some refactoring.
 
 use capnp;
 
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
-use tracing::{debug, error, warn};
+use tokio::sync::RwLock;
+use tokio::time::Instant;
+use tracing::{debug, info, warn};
 
 use ::zpr::vsapi::v1 as vsapi;
 use libeval::eval_result::Direction;
@@ -20,14 +33,12 @@ use serde_with::{TimestampSeconds, serde_as};
 use zpr::vsapi_types::{PacketDesc, Visa, VsapiFiveTuple};
 use zpr::write_to::WriteTo;
 
-use crate::db::{DbConnection, DbOp, ZAddr, gen_timestamp};
+use crate::db::{DbConnection, ZAddr, gen_timestamp};
 use crate::error::StoreError;
 use crate::logging::targets::DB;
 
 const KEY_VISA: &str = "visa";
 const KEY_NEXT_VISA_ID: &str = "visa:next_visa_id";
-const KEY_VISAS: &str = "visas";
-const KEY_NODEVISA: &str = "nodevisa";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum NodeVisaState {
@@ -54,8 +65,52 @@ pub struct VisaMetadata {
     pub five_tuple: VsapiFiveTuple,
 }
 
+/// Persisted per-node state within a `VisaRecord` (keyed by ZAddr string).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredNodeState {
+    state: NodeVisaState,
+    utime: String,
+    revoke_vinst: Option<u64>, // TODO: Will be set if we need to revoke this visa.
+}
+
+/// The single JSON value persisted at `visa:<id>`. Redis's only jobs are
+/// persisting and expiring whole visas, so everything a visa needs lives here.
+/// Expiry lives in the capnp blob (`visa.expires`) and is recovered on decode.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct VisaRecord {
+    blob: String, // base64 capnp visa bytes (Visa is not serde)
+    metadata: VisaMetadata,
+    node_states: HashMap<String, StoredNodeState>, // keyed by ZAddr string
+}
+
+/// In-memory per-node state for a visa.
+#[derive(Debug, Clone)]
+struct NodeState {
+    state: NodeVisaState,
+    revoke_vinst: Option<u64>, // TODO: will be stamped when marked PendingRevoke
+}
+
+/// In-memory authoritative copy of one visa.
+struct VisaEntry {
+    visa: Visa,
+    metadata: VisaMetadata,
+    // Expiry moment as a tokio Instant, derived from `visa.expires` at insert /
+    // state_load time. Using the tokio clock (not SystemTime) keeps liveness in
+    // lockstep with Redis/FakeDb TTLs and lets paused-clock tests advance expiry.
+    deadline: Instant,
+    node_states: HashMap<IpAddr, NodeState>,
+}
+
+/// The in-memory store guarded by a single `RwLock`.
+#[derive(Default)]
+struct VisaStoreInner {
+    visas: HashMap<u64, VisaEntry>,
+    by_node: HashMap<IpAddr, HashSet<u64>>, // secondary index for per-node queries
+}
+
 pub struct VisaRepo {
     db: Arc<dyn DbConnection>,
+    store: RwLock<VisaStoreInner>,
 }
 
 impl VisaMetadata {
@@ -92,20 +147,19 @@ impl VisaMetadata {
 }
 
 impl VisaRepo {
-    /// Set up and initialize the visa store.
-    /// We set `initial_visa_id` only if the key is not already present.
+    /// Set up and initialize the visa store, loading the in-memory image from
+    /// Redis. We set `initial_visa_id` only if the key is not already present.
     pub async fn new(db: Arc<dyn DbConnection>, initial_visa_id: u64) -> Result<Self, StoreError> {
-        // TODO: More intialization is probably needed.
-
         // Only set the initial visa id if the key is not ready present.
-        // We don't use the redis NX feature here since we are not concerned with any sort of concurrency
-        // at startup time.
         if !db.exists(KEY_NEXT_VISA_ID).await? {
             db.set(KEY_NEXT_VISA_ID, &initial_visa_id.to_string())
                 .await?;
         }
-
-        Ok(VisaRepo { db })
+        let inner = restore_from_state(&db).await?;
+        Ok(VisaRepo {
+            db,
+            store: RwLock::new(inner),
+        })
     }
 
     pub async fn get_next_visa_id(&self) -> Result<u64, StoreError> {
@@ -113,377 +167,435 @@ impl VisaRepo {
         Ok(next_id)
     }
 
-    /// Remove references to a visa from the state datbase. Caller must make sure
-    /// that any revocation messages or whatever have already been sent.
+    /// Remove all references to a visa: DEL the Redis key, then drop it from
+    /// memory (Redis first so memory never claims state persistence lacks).
+    ///
+    /// TODO: Will be used by future `remove_visa` function.
+    #[allow(dead_code)]
     async fn clean_up(&self, visa_id: u64) -> Result<(), StoreError> {
-        let blob_key = blob_key_for_visa(visa_id);
-        let visa_id_key = visa_key_for_visa(visa_id);
-
-        let ops = vec![DbOp::Del(blob_key.clone()), DbOp::Del(visa_id_key.clone())];
-        self.db.atomic_pipeline(&ops).await?;
-
-        // Remove any nodevisa references to this visa.
-        let nodevisa_keys = self
-            .db
-            .scan_match_all(format!("{KEY_NODEVISA}:*:{visa_id}"))
-            .await?;
-        if !nodevisa_keys.is_empty() {
-            let ops = nodevisa_keys
-                .iter()
-                .map(|k| DbOp::Del(k.clone()))
-                .collect::<Vec<DbOp>>();
-            self.db.atomic_pipeline(&ops).await?;
-        }
+        let key = visa_key_for_visa(visa_id);
+        let mut store = self.store.write().await;
+        // Redis first. On an ApplyThenError-style ambiguous DEL we still return
+        // the error and keep the memory entry; a later rewrite recreates the key.
+        self.db.del(&key).await?;
+        remove_entry(&mut store, visa_id);
         Ok(())
     }
 
-    /// Force remove all the nodevisa:<ZADDR>:<ID> tables that refer to the
-    /// passed `node_addr`.
+    /// Force remove the node's state from every visa record that references it.
     ///
-    /// Does not remove visa:* entries or the flowid entries.
-    ///
-    /// TODO: A future version may remove the visa:ID entries so long as they
-    /// are not referenced on another node.
-    ///
+    /// The node is dropped from each record's `node_states` and from the
+    /// `by_node` index, but the visa record itself is never deleted, even if
+    /// `node_states` becomes empty.
     pub async fn clear_node_state(&self, node_addr: &IpAddr) -> Result<(), StoreError> {
-        let zaddr = ZAddr::from(node_addr);
-        let nodevisa_keys = self
-            .db
-            .scan_match_all(format!("{KEY_NODEVISA}:{zaddr}:*"))
-            .await?;
-        if !nodevisa_keys.is_empty() {
-            let ops = nodevisa_keys
-                .iter()
-                .map(|k| DbOp::Del(k.clone()))
-                .collect::<Vec<DbOp>>();
-            self.db.atomic_pipeline(&ops).await?;
+        let mut store = self.store.write().await;
+        let ids: Vec<u64> = store
+            .by_node
+            .get(node_addr)
+            .map(|s| s.iter().copied().collect())
+            .unwrap_or_default();
+
+        for id in ids {
+            let Some(entry) = store.visas.get(&id) else {
+                continue;
+            };
+            if !entry.node_states.contains_key(node_addr) {
+                continue;
+            }
+            let ttl = remaining_secs(entry.deadline);
+            // Rewrite the record without the node (unless it is effectively
+            // expired, in which case its TTL has fired / is about to).
+            if ttl > 0 {
+                let mut new_states = entry.node_states.clone();
+                new_states.remove(node_addr);
+                let record = build_record(&entry.visa, &entry.metadata, &new_states)?;
+                let json = serde_json::to_string(&record)?;
+                self.db.set_ex(&visa_key_for_visa(id), &json, ttl).await?;
+            }
+            // Memory second.
+            if let Some(entry) = store.visas.get_mut(&id) {
+                entry.node_states.remove(node_addr);
+            }
+            unindex_node(&mut store, node_addr, id);
         }
         Ok(())
     }
 
-    /// Store a new visa in the database, also sets the visa state with respect to the requesting node as
-    /// `nstate`.
-    ///
-    /// If the `metadata` includes a `path` then visa is set PENDING on all nodes in the path.
-    ///
-    /// TODO: We may want to code path that does not include a requesting node.
-    ///
+    /// Store a new visa, setting its state w.r.t. the requesting node to `nstate`
+    /// and any other path nodes to `PendingInstall`.
     pub async fn store_visa(
         &self,
         visa: &Visa,
         metadata: VisaMetadata,
         nstate: NodeVisaState,
     ) -> Result<(), StoreError> {
-        match self.try_store_visa(&metadata, visa, nstate).await {
-            Ok(_) => Ok(()),
-            Err(e) => {
-                warn!(target: DB, "failed to store visa: {}, attempting cleanup", visa.issuer_id);
-                match self.clean_up(visa.issuer_id).await {
-                    Ok(_) => (),
-                    Err(cleanup_err) => {
-                        error!(target: DB, "failed to store visa {} and clean up failed too: {}", visa.issuer_id, cleanup_err);
-                    }
-                }
-                Err(e)
-            }
-        }
-    }
-
-    /// Attempt to store a visa.
-    ///
-    /// Will set the state w/ respect to the requesting_node to the passed `nstate`. Normally
-    /// this should be [NodeVisaState::PendingInstall] but there are occasions where you may
-    /// want to set it as [NodeVisaState::Installed].
-    ///
-    /// Nodes on the path (if any) are marked [NodeVisaState::PendingInstall].
-    async fn try_store_visa(
-        &self,
-        metadata: &VisaMetadata,
-        visa: &Visa,
-        nstate: NodeVisaState,
-    ) -> Result<(), StoreError> {
-        // write capnpn version of visa into the store.
-
         let visa_id = visa.issuer_id;
-
-        let expiration_seconds = seconds_until(visa.expires);
-        if expiration_seconds == 0 {
+        let ttl = seconds_until(visa.expires);
+        if ttl == 0 {
             return Err(StoreError::InvalidData(
                 "attempt to store already expired visa".into(),
             ));
         }
 
-        // Store the whole visa in there in capnp format
-        let mut msg = capnp::message::Builder::new_default();
-        {
-            let mut visa_bldr = msg.init_root::<vsapi::visa::Builder>();
-            visa.write_to(&mut visa_bldr);
-            // Ends up dropping the visa_bldr and forgetting the mut borrow of msg.
-        }
-        let mut words: Vec<u8> = Vec::new();
-        capnp::serialize::write_message(&mut words, &msg)?;
-
-        //
-        // visa:<ID>:blob -> <capn proto bytes>
-        //
-        self.db
-            .set_bin_ex(&blob_key_for_visa(visa_id), &words, expiration_seconds)
-            .await?;
-
-        let key_visa = visa_key_for_visa(visa_id);
-
-        //
-        // visa:<ID>
-        //       |- JSON(VisaMetadata)
-        //
-        self.db
-            .set(&key_visa, &serde_json::to_string(&metadata)?)
-            .await?;
-        self.db.expire(&key_visa, expiration_seconds as i64).await?;
-
-        // Now update the state/time for the requesting node and any nodes on the path.
-        //
-        // nodevisa:<ZADDR>:<ID>
-        //                   |- state -> string, JSON serialized NodeVisaState
-        //                   |- utime -> string, timestamp
-        //
-        {
-            let mut ops = Vec::new();
-
-            let key_nodevisa = node_visa_key_for_visa(&metadata.requesting_node, visa_id);
-            ops.push(DbOp::HSetMultiple {
-                hash_key: key_nodevisa.clone(),
-                field_values: vec![
-                    ("state".to_string(), serde_json::to_string(&nstate)?),
-                    ("utime".to_string(), gen_timestamp()),
-                ],
-            });
-            ops.push(DbOp::Expire {
-                key: key_nodevisa,
-                seconds: expiration_seconds as i64,
-            });
-
-            if let Some(path) = &metadata.path {
-                for node in path {
-                    if node == &metadata.requesting_node {
-                        continue;
-                    }
-                    let key_nodevisa = node_visa_key_for_visa(node, visa_id);
-                    ops.push(DbOp::HSetMultiple {
-                        hash_key: key_nodevisa.clone(),
-                        field_values: vec![
-                            (
-                                "state".to_string(),
-                                serde_json::to_string(&NodeVisaState::PendingInstall)?,
-                            ),
-                            ("utime".to_string(), gen_timestamp()),
-                        ],
-                    });
-                    ops.push(DbOp::Expire {
-                        key: key_nodevisa,
-                        seconds: expiration_seconds as i64,
-                    });
+        // Build the per-node state map: requesting node gets `nstate`, other path
+        // nodes get PendingInstall.
+        let mut node_states = HashMap::new();
+        node_states.insert(
+            metadata.requesting_node,
+            NodeState {
+                state: nstate,
+                revoke_vinst: None,
+            },
+        );
+        if let Some(path) = &metadata.path {
+            for node in path {
+                if node == &metadata.requesting_node {
+                    continue;
                 }
+                node_states.insert(
+                    *node,
+                    NodeState {
+                        state: NodeVisaState::PendingInstall,
+                        revoke_vinst: None,
+                    },
+                );
             }
-
-            self.db.atomic_pipeline(&ops).await?;
         }
 
-        debug!(target: DB, "stored visa {visa_id} expires in {expiration_seconds} seconds");
+        let record = build_record(visa, &metadata, &node_states)?;
+        let json = serde_json::to_string(&record)?;
+        let key = visa_key_for_visa(visa_id);
+
+        let mut store = self.store.write().await;
+        // Redis first.
+        if let Err(e) = self.db.set_ex(&key, &json, ttl).await {
+            // The write may have applied but the reply was lost (ambiguous
+            // commit) — issue one best-effort DEL so an unknown visa is not left
+            // behind. If that also fails the TTL bounds the orphan; one restart
+            // may resurrect it (documented residual risk).
+            let _ = self.db.del(&key).await;
+            return Err(e.into());
+        }
+        // Memory second.
+        let entry = VisaEntry {
+            visa: visa.clone(),
+            metadata,
+            deadline: Instant::now() + Duration::from_secs(ttl),
+            node_states,
+        };
+        insert_entry(&mut store, visa_id, entry);
+
+        debug!(target: DB, "stored visa {visa_id} expires in {ttl} seconds");
         Ok(())
     }
 
-    /// Update the nodevisa state information for the node and visa.
+    /// Update the state for the given node/visa. Rewrites the record with the
+    /// remaining TTL (Redis first, memory second).
     pub async fn update_node_visa_state(
         &self,
         node_addr: &IpAddr,
         visa_id: u64,
         new_state: NodeVisaState,
     ) -> Result<(), StoreError> {
-        let key_nodevisa = node_visa_key_for_visa(node_addr, visa_id);
-        if !self.db.exists(&key_nodevisa).await? {
+        let mut store = self.store.write().await;
+        let entry = live_entry(&store, visa_id).ok_or_else(|| {
+            StoreError::NotFound(format!("node-visa record not found: {node_addr} {visa_id}"))
+        })?;
+        if !entry.node_states.contains_key(node_addr) {
             return Err(StoreError::NotFound(format!(
-                "node-visa record not found: {key_nodevisa}"
+                "node-visa record not found: {node_addr} {visa_id}"
             )));
         }
+        let ttl = remaining_secs(entry.deadline);
+        if ttl == 0 {
+            return Err(StoreError::NotFound(format!(
+                "node-visa record not found: {node_addr} {visa_id}"
+            )));
+        }
+        let mut new_states = entry.node_states.clone();
+        new_states.get_mut(node_addr).unwrap().state = new_state;
+        let record = build_record(&entry.visa, &entry.metadata, &new_states)?;
+        let json = serde_json::to_string(&record)?;
+
+        // Redis first.
         self.db
-            .hset_multiple(
-                &key_nodevisa,
-                &[
-                    ("state", &serde_json::to_string(&new_state)?),
-                    ("last_update", &gen_timestamp()),
-                ],
-            )
+            .set_ex(&visa_key_for_visa(visa_id), &json, ttl)
             .await?;
+        // Memory second.
+        store.visas.get_mut(&visa_id).unwrap().node_states = new_states;
 
         debug!(target: DB, "updated nodevisa state node={node_addr} visa={visa_id} -> {new_state:?}");
         Ok(())
     }
 
-    /// Expired visas will have been removed from redis, so if we find any empty
-    /// keys they are just skipped.
+    /// All visas for a node in the given state (blobs cloned from memory).
     pub async fn get_visas_for_node_by_state(
         &self,
         node_addr: &IpAddr,
         state: NodeVisaState,
     ) -> Result<Vec<Visa>, StoreError> {
-        let zaddr = ZAddr::from(node_addr);
+        let store = self.store.read().await;
         let mut visas = Vec::new();
-
-        let vkeys = self
-            .db
-            .scan_match_all(format!("{KEY_NODEVISA}:{zaddr}:*"))
-            .await?;
-
-        for key in &vkeys {
-            let state_str: String = self.db.hget(&key, "state").await?.unwrap_or_default();
-            let entry_state: NodeVisaState = serde_json::from_str(&state_str)?;
-            if entry_state == state {
-                // Extract visa ID from key
-                let parts: Vec<&str> = key.rsplitn(2, ':').collect();
-                if parts.len() != 2 {
-                    warn!(target: DB, "malformed nodevisa key: {}", key);
-                    continue;
-                }
-                let visa_id: u64 = parts[0].parse().map_err(|_| {
-                    StoreError::InvalidData(format!("invalid visa ID in nodevisa key: {}", key))
-                })?;
-
-                // Load the visa blob
-                let blob_key = blob_key_for_visa(visa_id);
-                match self.db.get_bin(&blob_key).await {
-                    Ok(visa_blob) => {
-                        let visa = Visa::from_capnp_bytes(&visa_blob)?;
-                        visas.push(visa);
+        if let Some(ids) = store.by_node.get(node_addr) {
+            for &id in ids {
+                if let Some(entry) = live_entry(&store, id) {
+                    if entry
+                        .node_states
+                        .get(node_addr)
+                        .is_some_and(|ns| ns.state == state)
+                    {
+                        visas.push(entry.visa.clone());
                     }
-                    Err(err) if err.kind() == redis::ErrorKind::UnexpectedReturnType => {
-                        // Missing/expired visa blob. Skip it but keep other visas.
-                        warn!(target: DB, "visa blob missing for key {}", blob_key);
-                        continue;
-                    }
-                    Err(err) => return Err(err.into()),
                 }
             }
         }
-
         Ok(visas)
     }
 
-    /// Get the visa IDs for a node filtered by state, without loading the visa blobs.
+    /// The visa IDs for a node filtered by state, without cloning the visas.
     pub async fn get_visa_ids_for_node_by_state(
         &self,
         node_addr: &IpAddr,
         state: NodeVisaState,
     ) -> Result<Vec<u64>, StoreError> {
-        let zaddr = ZAddr::from(node_addr);
-        let mut visa_ids = Vec::new();
-
-        let vkeys = self
-            .db
-            .scan_match_all(format!("{KEY_NODEVISA}:{zaddr}:*"))
-            .await?;
-
-        for key in &vkeys {
-            let state_str: String = self.db.hget(key, "state").await?.unwrap_or_default();
-            let entry_state: NodeVisaState = serde_json::from_str(&state_str)?;
-            if entry_state == state {
-                let parts: Vec<&str> = key.rsplitn(2, ':').collect();
-                if parts.len() != 2 {
-                    warn!(target: DB, "malformed nodevisa key: {}", key);
-                    continue;
+        let store = self.store.read().await;
+        let mut ids = Vec::new();
+        if let Some(node_ids) = store.by_node.get(node_addr) {
+            for &id in node_ids {
+                if let Some(entry) = live_entry(&store, id) {
+                    if entry
+                        .node_states
+                        .get(node_addr)
+                        .is_some_and(|ns| ns.state == state)
+                    {
+                        ids.push(id);
+                    }
                 }
-                let visa_id: u64 = parts[0].parse().map_err(|_| {
-                    StoreError::InvalidData(format!("invalid visa ID in nodevisa key: {}", key))
-                })?;
-                visa_ids.push(visa_id);
             }
         }
-
-        Ok(visa_ids)
+        Ok(ids)
     }
 
-    /// Count the number of visas for a node that are in the given state.
+    /// Count the visas for a node that are in the given state.
     pub async fn get_count_visas_for_node_by_state(
         &self,
         node_addr: &IpAddr,
         state: NodeVisaState,
     ) -> Result<u32, StoreError> {
-        let zaddr = ZAddr::from(node_addr);
-        let mut count = 0;
-
-        let vkeys = self
-            .db
-            .scan_match_all(format!("{KEY_NODEVISA}:{zaddr}:*"))
+        let ids = self
+            .get_visa_ids_for_node_by_state(node_addr, state)
             .await?;
-
-        for key in &vkeys {
-            let state_str: String = self.db.hget(key, "state").await?.unwrap_or_default();
-            let entry_state: NodeVisaState = serde_json::from_str(&state_str)?;
-            if entry_state == state {
-                count += 1;
-            }
-        }
-
-        Ok(count)
+        Ok(ids.len() as u32)
     }
 
     /// Get the visa by ID.
     ///
     /// ## Errors
-    /// - [DBError::NotFound] if the visa does not exist.
+    /// - [StoreError::NotFound] if the visa does not exist (or has expired).
     pub async fn get_visa_by_id(&self, visa_id: u64) -> Result<Visa, StoreError> {
-        let blob_key = blob_key_for_visa(visa_id);
-        if !self.db.exists(&blob_key).await? {
-            return Err(StoreError::NotFound(format!(
-                "visa blob not found for ID {}",
-                visa_id
-            )));
-        }
-        let visa_blob = self.db.get_bin(&blob_key).await?;
-        let visa = Visa::from_capnp_bytes(&visa_blob)?;
-        Ok(visa)
+        let store = self.store.read().await;
+        live_entry(&store, visa_id)
+            .map(|e| e.visa.clone())
+            .ok_or_else(|| StoreError::NotFound(format!("visa not found for ID {visa_id}")))
     }
 
     /// Get the metadata for the visa by ID.
     ///
     /// ## Errors
-    /// - [StoreError::NotFound] if the visa metadata does not exist.
+    /// - [StoreError::NotFound] if the visa metadata does not exist (or has expired).
     pub async fn get_visa_metadata_by_id(&self, visa_id: u64) -> Result<VisaMetadata, StoreError> {
-        let visa_key = visa_key_for_visa(visa_id);
-        if !self.db.exists(&visa_key).await? {
-            return Err(StoreError::NotFound(format!(
-                "visa metadata not found for ID {}",
-                visa_id
-            )));
-        }
-        let metadata_str: String = self.db.get(&visa_key).await?.ok_or_else(|| {
-            StoreError::NotFound(format!("visa metadata not found for ID {}", visa_id))
-        })?;
-        let metadata: VisaMetadata = serde_json::from_str(&metadata_str)?;
-        Ok(metadata)
+        let store = self.store.read().await;
+        live_entry(&store, visa_id)
+            .map(|e| e.metadata.clone())
+            .ok_or_else(|| {
+                StoreError::NotFound(format!("visa metadata not found for ID {visa_id}"))
+            })
     }
 
-    /// Copy all the visa IDs into a vec.
+    /// Copy all the live visa IDs into a vec.
     pub async fn list_visa_ids(&self) -> Result<Vec<u64>, StoreError> {
-        let visa_keys = self.db.scan_match_all(format!("{KEY_VISA}:[0-9]*")).await?;
-        let mut visa_ids = Vec::new();
-        for key in &visa_keys {
-            let parts: Vec<&str> = key.rsplitn(2, ':').collect();
-            if parts.len() != 2 {
-                warn!(target: DB, "malformed visa key: {}", key);
+        let store = self.store.read().await;
+        Ok(store
+            .visas
+            .iter()
+            .filter(|(_, e)| remaining_secs(e.deadline) > 0)
+            .map(|(id, _)| *id)
+            .collect())
+    }
+
+    /// Drop expired entries and their `by_node` index rows. Redis needs no
+    /// matching delete since the TTL should have already fired. Called by housekeeping.
+    pub async fn purge_expired(&self) -> Result<(), StoreError> {
+        let mut store = self.store.write().await;
+        let expired: Vec<u64> = store
+            .visas
+            .iter()
+            .filter(|(_, e)| remaining_secs(e.deadline) == 0)
+            .map(|(id, _)| *id)
+            .collect();
+        for id in expired {
+            remove_entry(&mut store, id);
+        }
+        Ok(())
+    }
+}
+
+/// Build the in-memory image by scanning `visa:[0-9]*`, decoding each value as
+/// a `VisaRecord`. Undecodable or already-expired values are DELeted and
+/// skipped so they are never rescanned.
+async fn restore_from_state(db: &Arc<dyn DbConnection>) -> Result<VisaStoreInner, StoreError> {
+    let mut inner = VisaStoreInner::default();
+    let keys = db.scan_match_all(format!("{KEY_VISA}:[0-9]*")).await?;
+    let mut node_count = 0usize;
+    let mut deleted = 0usize;
+
+    for key in &keys {
+        let Some(raw) = db.get(key).await? else {
+            continue; // vanished (TTL) between scan and get.
+        };
+        let visa_id = match key
+            .rsplit_once(':')
+            .and_then(|(_, id)| id.parse::<u64>().ok())
+        {
+            Some(id) => id,
+            None => {
+                warn!(target: DB, "malformed visa key {key}, deleting");
+                db.del(key).await?;
+                deleted += 1;
                 continue;
             }
-            let visa_id: u64 = match parts[0].parse() {
-                Err(_) => {
-                    // TODO: Should we just crash here?
-                    warn!(target: DB, "invalid visa ID in visa key: {}, skipping entry", key);
-                    continue;
-                }
-                Ok(id) => id,
-            };
-            visa_ids.push(visa_id);
+        };
+        match decode_record(&raw) {
+            Ok(entry) if remaining_secs(entry.deadline) > 0 => {
+                node_count += entry.node_states.len();
+                insert_entry(&mut inner, visa_id, entry);
+            }
+            // Expired or undecodable/legacy: delete so it is not rescanned.
+            Ok(_) => {
+                db.del(key).await?;
+                deleted += 1;
+            }
+            Err(e) => {
+                warn!(target: DB, "deleting undecodable visa record {key}: {e}");
+                db.del(key).await?;
+                deleted += 1;
+            }
         }
-        Ok(visa_ids)
+    }
+
+    info!(
+        target: DB,
+        "loaded {} visas, {} node entries, deleted {} broken/legacy keys",
+        inner.visas.len(),
+        node_count,
+        deleted
+    );
+    Ok(inner)
+}
+
+/// Decode a JSON `VisaRecord` string into a `VisaEntry`.
+fn decode_record(raw: &str) -> Result<VisaEntry, StoreError> {
+    let record: VisaRecord = serde_json::from_str(raw)?;
+    let bytes = BASE64
+        .decode(record.blob.as_bytes())
+        .map_err(|e| StoreError::InvalidData(format!("visa blob base64 decode: {e}")))?;
+    let visa = Visa::from_capnp_bytes(&bytes)?;
+    let deadline = Instant::now() + Duration::from_secs(seconds_until(visa.expires));
+
+    let mut node_states = HashMap::new();
+    for (zaddr_str, sns) in record.node_states {
+        let addr = IpAddr::try_from(ZAddr::new_from_encoded(&zaddr_str))
+            .map_err(|e| StoreError::InvalidData(format!("bad zaddr {zaddr_str}: {e}")))?;
+        node_states.insert(
+            addr,
+            NodeState {
+                state: sns.state,
+                revoke_vinst: sns.revoke_vinst,
+            },
+        );
+    }
+    Ok(VisaEntry {
+        visa,
+        metadata: record.metadata,
+        deadline,
+        node_states,
+    })
+}
+
+/// Serialize the components of a visa into a persistable `VisaRecord`.
+fn build_record(
+    visa: &Visa,
+    metadata: &VisaMetadata,
+    node_states: &HashMap<IpAddr, NodeState>,
+) -> Result<VisaRecord, StoreError> {
+    let blob = BASE64.encode(visa_to_capnp_bytes(visa)?);
+    let stored: HashMap<String, StoredNodeState> = node_states
+        .iter()
+        .map(|(addr, ns)| {
+            (
+                ZAddr::from(addr).to_string(),
+                StoredNodeState {
+                    state: ns.state,
+                    utime: gen_timestamp(),
+                    revoke_vinst: ns.revoke_vinst,
+                },
+            )
+        })
+        .collect();
+    Ok(VisaRecord {
+        blob,
+        metadata: metadata.clone(),
+        node_states: stored,
+    })
+}
+
+/// Encode a Visa to its capnp wire bytes.
+fn visa_to_capnp_bytes(visa: &Visa) -> Result<Vec<u8>, StoreError> {
+    let mut msg = capnp::message::Builder::new_default();
+    {
+        let mut visa_bldr = msg.init_root::<vsapi::visa::Builder>();
+        visa.write_to(&mut visa_bldr);
+    }
+    let mut words: Vec<u8> = Vec::new();
+    capnp::serialize::write_message(&mut words, &msg)?;
+    Ok(words)
+}
+
+/// Return the entry only if it is still live (`deadline` in the future).
+/// All reads go through this so expired entries read as absent.
+fn live_entry(inner: &VisaStoreInner, id: u64) -> Option<&VisaEntry> {
+    inner
+        .visas
+        .get(&id)
+        .filter(|e| remaining_secs(e.deadline) > 0)
+}
+
+/// Insert an entry and index all its nodes in `by_node`.
+fn insert_entry(inner: &mut VisaStoreInner, id: u64, entry: VisaEntry) {
+    let nodes: Vec<IpAddr> = entry.node_states.keys().copied().collect();
+    inner.visas.insert(id, entry);
+    for node in nodes {
+        inner.by_node.entry(node).or_default().insert(id);
+    }
+}
+
+/// Remove an entry and unindex all its nodes.
+fn remove_entry(inner: &mut VisaStoreInner, id: u64) {
+    if let Some(entry) = inner.visas.remove(&id) {
+        let nodes: Vec<IpAddr> = entry.node_states.keys().copied().collect();
+        for node in nodes {
+            unindex_node(inner, &node, id);
+        }
+    }
+}
+
+/// Drop `id` from the `by_node` row for `node`, removing the row if it empties.
+fn unindex_node(inner: &mut VisaStoreInner, node: &IpAddr, id: u64) {
+    if let Some(set) = inner.by_node.get_mut(node) {
+        set.remove(&id);
+        if set.is_empty() {
+            inner.by_node.remove(node);
+        }
     }
 }
 
@@ -494,25 +606,61 @@ fn seconds_until(t: SystemTime) -> u64 {
         .as_secs()
 }
 
-fn blob_key_for_visa(visa_id: u64) -> String {
-    format!("{KEY_VISAS}:{visa_id}:blob")
+// Remaining whole seconds until a tokio deadline, zero if reached.
+fn remaining_secs(deadline: Instant) -> u64 {
+    deadline.saturating_duration_since(Instant::now()).as_secs()
 }
 
 fn visa_key_for_visa(visa_id: u64) -> String {
     format!("{KEY_VISA}:{visa_id}")
 }
 
-fn node_visa_key_for_visa(node_addr: &IpAddr, visa_id: u64) -> String {
-    let zaddr = ZAddr::from(node_addr);
-    format!("{KEY_NODEVISA}:{zaddr}:{visa_id}")
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::db::DbConnection;
-    use crate::db::db_fake::FakeDb;
+    use crate::db::{FakeDb, FaultMode, ZAddr};
     use crate::test_helpers::{make_pdesc, make_visa};
+
+    /// Build a default no-path metadata for `node`.
+    fn md(node: IpAddr) -> VisaMetadata {
+        VisaMetadata::new(
+            node,
+            0,
+            0,
+            String::new(),
+            Direction::Forward,
+            None,
+            &make_pdesc(),
+        )
+    }
+
+    /// Read and JSON-decode the persisted VisaRecord for `id`.
+    async fn read_record(db: &FakeDb, id: u64) -> VisaRecord {
+        let raw = db.get(&visa_key_for_visa(id)).await.unwrap().unwrap();
+        serde_json::from_str(&raw).unwrap()
+    }
+
+    /// Assert the persisted VisaRecord for `id` matches the in-memory entry.
+    async fn assert_memory_matches_redis(repo: &VisaRepo, db: &FakeDb, id: u64) {
+        let record = read_record(db, id).await;
+        let store = repo.store.read().await;
+        let entry = store.visas.get(&id).unwrap();
+        assert_eq!(record.node_states.len(), entry.node_states.len());
+        for (addr, ns) in &entry.node_states {
+            let sns = record
+                .node_states
+                .get(&ZAddr::from(addr).to_string())
+                .expect("node missing from persisted record");
+            assert_eq!(sns.state, ns.state);
+            assert_eq!(sns.revoke_vinst, ns.revoke_vinst);
+        }
+        assert_eq!(
+            record.metadata.requesting_node,
+            entry.metadata.requesting_node
+        );
+    }
+
+    // --- retargeted behavioral tests ---
 
     #[tokio::test]
     async fn test_store_and_get_visas_by_state() {
@@ -521,26 +669,17 @@ mod test {
         let node_addr: IpAddr = "fd5a:5052::1".parse().unwrap();
         let visa = make_visa(42, Duration::from_secs(60));
 
-        let metadata = VisaMetadata::new(
-            node_addr,
-            0,
-            0,
-            String::new(),
-            Direction::Forward,
-            None,
-            &make_pdesc(),
-        );
-        repo.store_visa(&visa, metadata, NodeVisaState::PendingInstall)
+        repo.store_visa(&visa, md(node_addr), NodeVisaState::PendingInstall)
             .await
             .unwrap();
 
-        assert!(db.exists(&blob_key_for_visa(42)).await.unwrap());
-        assert!(db.exists(&visa_key_for_visa(42)).await.unwrap());
-        assert!(
-            db.exists(&node_visa_key_for_visa(&node_addr, 42))
-                .await
-                .unwrap()
-        );
+        // The single record persists the requesting node's state.
+        let record = read_record(&db, 42).await;
+        let sns = record
+            .node_states
+            .get(&ZAddr::from(&node_addr).to_string())
+            .unwrap();
+        assert_eq!(sns.state, NodeVisaState::PendingInstall);
 
         let pending = repo
             .get_visas_for_node_by_state(&node_addr, NodeVisaState::PendingInstall)
@@ -576,41 +715,34 @@ mod test {
             .update_node_visa_state(&node_addr, 99, NodeVisaState::Installed)
             .await
             .unwrap_err();
-        match err {
-            StoreError::NotFound(_) => {}
-            other => panic!("unexpected error: {:?}", other),
-        }
+        assert!(matches!(err, StoreError::NotFound(_)));
     }
 
     #[tokio::test]
-    async fn test_clear_node_state_only_removes_nodevisa() {
+    async fn test_clear_node_state_only_removes_node_from_record() {
         let db = Arc::new(FakeDb::new());
         let repo = VisaRepo::new(db.clone(), 1).await.unwrap();
         let node_addr: IpAddr = "fd5a:5052::3".parse().unwrap();
         let visa = make_visa(7, Duration::from_secs(60));
 
-        let metadata = VisaMetadata::new(
-            node_addr,
-            0,
-            0,
-            String::new(),
-            Direction::Forward,
-            None,
-            &make_pdesc(),
-        );
-        repo.store_visa(&visa, metadata, NodeVisaState::Installed)
+        repo.store_visa(&visa, md(node_addr), NodeVisaState::Installed)
             .await
             .unwrap();
 
         repo.clear_node_state(&node_addr).await.unwrap();
 
+        // The visa record still exists but no longer references the node.
+        let record = read_record(&db, 7).await;
         assert!(
-            !db.exists(&node_visa_key_for_visa(&node_addr, 7))
-                .await
-                .unwrap()
+            record
+                .node_states
+                .get(&ZAddr::from(&node_addr).to_string())
+                .is_none()
         );
-        assert!(db.exists(&blob_key_for_visa(7)).await.unwrap());
-        assert!(db.exists(&visa_key_for_visa(7)).await.unwrap());
+        // Memory agrees.
+        let store = repo.store.read().await;
+        assert!(store.visas.contains_key(&7));
+        assert!(!store.by_node.contains_key(&node_addr));
     }
 
     #[tokio::test]
@@ -621,23 +753,11 @@ mod test {
         let mut visa = make_visa(8, Duration::from_secs(1));
         visa.expires = SystemTime::now() - Duration::from_secs(1);
 
-        let metadata = VisaMetadata::new(
-            node_addr,
-            0,
-            0,
-            String::new(),
-            Direction::Forward,
-            None,
-            &make_pdesc(),
-        );
         let err = repo
-            .store_visa(&visa, metadata, NodeVisaState::PendingInstall)
+            .store_visa(&visa, md(node_addr), NodeVisaState::PendingInstall)
             .await
             .unwrap_err();
-        match err {
-            StoreError::InvalidData(_) => {}
-            other => panic!("unexpected error: {:?}", other),
-        }
+        assert!(matches!(err, StoreError::InvalidData(_)));
     }
 
     #[tokio::test(start_paused = true)]
@@ -647,16 +767,7 @@ mod test {
         let node_addr: IpAddr = "fd5a:5052::5".parse().unwrap();
         let visa = make_visa(9, Duration::from_secs(5));
 
-        let metadata = VisaMetadata::new(
-            node_addr,
-            0,
-            0,
-            String::new(),
-            Direction::Forward,
-            None,
-            &make_pdesc(),
-        );
-        repo.store_visa(&visa, metadata, NodeVisaState::PendingInstall)
+        repo.store_visa(&visa, md(node_addr), NodeVisaState::PendingInstall)
             .await
             .unwrap();
 
@@ -666,53 +777,7 @@ mod test {
             .update_node_visa_state(&node_addr, 9, NodeVisaState::Installed)
             .await
             .unwrap_err();
-        match err {
-            StoreError::NotFound(_) => {}
-            other => panic!("unexpected error: {:?}", other),
-        }
-    }
-
-    #[tokio::test]
-    async fn test_get_visas_skips_missing_blobs() {
-        let db = Arc::new(FakeDb::new());
-        let repo = VisaRepo::new(db.clone(), 1).await.unwrap();
-        let node_addr: IpAddr = "fd5a:5052::6".parse().unwrap();
-        let visa_a = make_visa(10, Duration::from_secs(60));
-        let visa_b = make_visa(11, Duration::from_secs(60));
-
-        let metadata_a = VisaMetadata::new(
-            node_addr,
-            0,
-            0,
-            String::new(),
-            Direction::Forward,
-            None,
-            &make_pdesc(),
-        );
-        repo.store_visa(&visa_a, metadata_a, NodeVisaState::PendingInstall)
-            .await
-            .unwrap();
-        let metadata_b = VisaMetadata::new(
-            node_addr,
-            0,
-            0,
-            String::new(),
-            Direction::Forward,
-            None,
-            &make_pdesc(),
-        );
-        repo.store_visa(&visa_b, metadata_b, NodeVisaState::PendingInstall)
-            .await
-            .unwrap();
-
-        db.del(&blob_key_for_visa(10)).await.unwrap();
-
-        let visas = repo
-            .get_visas_for_node_by_state(&node_addr, NodeVisaState::PendingInstall)
-            .await
-            .unwrap();
-        assert_eq!(visas.len(), 1);
-        assert_eq!(visas[0].issuer_id, 11);
+        assert!(matches!(err, StoreError::NotFound(_)));
     }
 
     #[tokio::test]
@@ -721,59 +786,15 @@ mod test {
         let repo = VisaRepo::new(db, 1).await.unwrap();
         let node_addr: IpAddr = "fd5a:5052::7".parse().unwrap();
 
-        let visa_a = make_visa(1, Duration::from_secs(60));
-        let visa_b = make_visa(5, Duration::from_secs(60));
-        let visa_c = make_visa(42, Duration::from_secs(60));
-
-        repo.store_visa(
-            &visa_a,
-            VisaMetadata::new(
-                node_addr,
-                0,
-                0,
-                String::new(),
-                Direction::Forward,
-                None,
-                &make_pdesc(),
-            ),
-            NodeVisaState::PendingInstall,
-        )
-        .await
-        .unwrap();
-        repo.store_visa(
-            &visa_b,
-            VisaMetadata::new(
-                node_addr,
-                0,
-                0,
-                String::new(),
-                Direction::Forward,
-                None,
-                &make_pdesc(),
-            ),
-            NodeVisaState::PendingInstall,
-        )
-        .await
-        .unwrap();
-        repo.store_visa(
-            &visa_c,
-            VisaMetadata::new(
-                node_addr,
-                0,
-                0,
-                String::new(),
-                Direction::Forward,
-                None,
-                &make_pdesc(),
-            ),
-            NodeVisaState::PendingInstall,
-        )
-        .await
-        .unwrap();
+        for id in [1u64, 5, 42] {
+            let visa = make_visa(id, Duration::from_secs(60));
+            repo.store_visa(&visa, md(node_addr), NodeVisaState::PendingInstall)
+                .await
+                .unwrap();
+        }
 
         let mut ids = repo.list_visa_ids().await.unwrap();
         ids.sort_unstable();
-
         assert_eq!(ids, vec![1, 5, 42]);
     }
 
@@ -784,16 +805,7 @@ mod test {
         let node_addr: IpAddr = "fd5a:5052::8".parse().unwrap();
         let visa = make_visa(77, Duration::from_secs(60));
 
-        let metadata = VisaMetadata::new(
-            node_addr,
-            0,
-            0,
-            String::new(),
-            Direction::Forward,
-            None,
-            &make_pdesc(),
-        );
-        repo.store_visa(&visa, metadata, NodeVisaState::PendingInstall)
+        repo.store_visa(&visa, md(node_addr), NodeVisaState::PendingInstall)
             .await
             .unwrap();
 
@@ -813,12 +825,8 @@ mod test {
     async fn test_get_visa_by_id_missing() {
         let db = Arc::new(FakeDb::new());
         let repo = VisaRepo::new(db, 1).await.unwrap();
-
         let err = repo.get_visa_by_id(1234).await.unwrap_err();
-        match err {
-            StoreError::NotFound(_) => {}
-            other => panic!("unexpected error: {:?}", other),
-        }
+        assert!(matches!(err, StoreError::NotFound(_)));
     }
 
     #[tokio::test]
@@ -828,16 +836,7 @@ mod test {
         let node_addr: IpAddr = "fd5a:5052::9".parse().unwrap();
         let visa = make_visa(88, Duration::from_secs(60));
 
-        let stored_metadata = VisaMetadata::new(
-            node_addr,
-            0,
-            0,
-            String::new(),
-            Direction::Forward,
-            None,
-            &make_pdesc(),
-        );
-        repo.store_visa(&visa, stored_metadata, NodeVisaState::PendingInstall)
+        repo.store_visa(&visa, md(node_addr), NodeVisaState::PendingInstall)
             .await
             .unwrap();
 
@@ -850,16 +849,11 @@ mod test {
     async fn test_get_visa_metadata_by_id_missing() {
         let db = Arc::new(FakeDb::new());
         let repo = VisaRepo::new(db, 1).await.unwrap();
-
         let err = repo.get_visa_metadata_by_id(999).await.unwrap_err();
-        match err {
-            StoreError::NotFound(_) => {}
-            other => panic!("unexpected error: {:?}", other),
-        }
+        assert!(matches!(err, StoreError::NotFound(_)));
     }
 
-    /// Verifies that a VisaMetadata with non-default values for all new fields
-    /// survives a serialize → deserialize round-trip with all fields intact.
+    /// A VisaMetadata with non-default values survives a serialize round-trip.
     #[test]
     fn test_visa_metadata_round_trip() {
         let node_addr: IpAddr = "fd5a:5052::10".parse().unwrap();
@@ -889,16 +883,11 @@ mod test {
         assert_eq!(decoded.checked_vinst, original.checked_vinst);
     }
 
-    /// Verifies that signal_msgs is preserved correctly when non-empty across
-    /// a serialize → deserialize round-trip.
+    /// signal_msgs is preserved when non-empty across a serialize round-trip.
     #[test]
     fn test_visa_metadata_signal_msgs_preserved() {
         let node_addr: IpAddr = "fd5a:5052::12".parse().unwrap();
-        let signals = vec![
-            "msg-1".to_string(),
-            "msg-2".to_string(),
-            "msg-3".to_string(),
-        ];
+        let signals = vec!["msg-1".to_string(), "msg-2".to_string()];
         let original = VisaMetadata {
             requesting_node: node_addr,
             ctime: SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_001),
@@ -911,19 +900,15 @@ mod test {
             path: None,
             five_tuple: make_pdesc().five_tuple,
         };
-
         let json = serde_json::to_string(&original).unwrap();
         let decoded: VisaMetadata = serde_json::from_str(&json).unwrap();
-
         assert_eq!(decoded.signal_msgs, signals);
     }
 
-    /// Verifies that Direction::Forward and Direction::Reverse each survive a
-    /// serialize → deserialize round-trip without being altered.
+    /// Both Direction variants survive a serialize round-trip.
     #[test]
     fn test_visa_metadata_direction_round_trip_both_variants() {
         let node_addr: IpAddr = "fd5a:5052::13".parse().unwrap();
-
         for direction in [Direction::Forward, Direction::Reverse] {
             let original = VisaMetadata {
                 requesting_node: node_addr,
@@ -943,13 +928,10 @@ mod test {
         }
     }
 
-    /// Stores a visa with a path and verifies that the requesting node gets the
-    /// caller-supplied nstate while every other node in the path gets PendingInstall.
     #[tokio::test]
     async fn test_store_visa_with_path_sets_path_nodes_pending() {
         let db = Arc::new(FakeDb::new());
         let repo = VisaRepo::new(db.clone(), 1).await.unwrap();
-
         let requesting: IpAddr = "fd5a:5052::30".parse().unwrap();
         let node_b: IpAddr = "fd5a:5052::31".parse().unwrap();
         let node_c: IpAddr = "fd5a:5052::32".parse().unwrap();
@@ -968,33 +950,31 @@ mod test {
             .await
             .unwrap();
 
-        let state_str = db
-            .hget(&node_visa_key_for_visa(&requesting, 100), "state")
-            .await
-            .unwrap()
-            .unwrap();
-        let state: NodeVisaState = serde_json::from_str(&state_str).unwrap();
-        assert_eq!(state, NodeVisaState::Installed);
-
-        for node in &[node_b, node_c] {
-            assert!(db.exists(&node_visa_key_for_visa(node, 100)).await.unwrap());
-            let state_str = db
-                .hget(&node_visa_key_for_visa(node, 100), "state")
-                .await
+        let record = read_record(&db, 100).await;
+        assert_eq!(
+            record
+                .node_states
+                .get(&ZAddr::from(&requesting).to_string())
                 .unwrap()
-                .unwrap();
-            let state: NodeVisaState = serde_json::from_str(&state_str).unwrap();
-            assert_eq!(state, NodeVisaState::PendingInstall);
+                .state,
+            NodeVisaState::Installed
+        );
+        for node in [node_b, node_c] {
+            assert_eq!(
+                record
+                    .node_states
+                    .get(&ZAddr::from(&node).to_string())
+                    .unwrap()
+                    .state,
+                NodeVisaState::PendingInstall
+            );
         }
     }
 
-    /// When the requesting node also appears in the path list its state must not be
-    /// overwritten with PendingInstall by the path-iteration loop.
     #[tokio::test]
     async fn test_store_visa_requesting_node_in_path_not_overwritten() {
         let db = Arc::new(FakeDb::new());
         let repo = VisaRepo::new(db.clone(), 1).await.unwrap();
-
         let requesting: IpAddr = "fd5a:5052::40".parse().unwrap();
         let other: IpAddr = "fd5a:5052::41".parse().unwrap();
         let visa = make_visa(101, Duration::from_secs(60));
@@ -1012,34 +992,30 @@ mod test {
             .await
             .unwrap();
 
-        let state_str = db
-            .hget(&node_visa_key_for_visa(&requesting, 101), "state")
-            .await
-            .unwrap()
-            .unwrap();
-        let state: NodeVisaState = serde_json::from_str(&state_str).unwrap();
+        let record = read_record(&db, 101).await;
         assert_eq!(
-            state,
+            record
+                .node_states
+                .get(&ZAddr::from(&requesting).to_string())
+                .unwrap()
+                .state,
             NodeVisaState::Installed,
             "requesting node state should not be overwritten"
         );
-
-        let state_str = db
-            .hget(&node_visa_key_for_visa(&other, 101), "state")
-            .await
-            .unwrap()
-            .unwrap();
-        let state: NodeVisaState = serde_json::from_str(&state_str).unwrap();
-        assert_eq!(state, NodeVisaState::PendingInstall);
+        assert_eq!(
+            record
+                .node_states
+                .get(&ZAddr::from(&other).to_string())
+                .unwrap()
+                .state,
+            NodeVisaState::PendingInstall
+        );
     }
 
-    /// Path nodes created by store_visa are discoverable through the standard
-    /// get_visa_ids_for_node_by_state query.
     #[tokio::test]
     async fn test_store_visa_path_nodes_queryable_by_state() {
         let db = Arc::new(FakeDb::new());
         let repo = VisaRepo::new(db.clone(), 1).await.unwrap();
-
         let requesting: IpAddr = "fd5a:5052::50".parse().unwrap();
         let path_node: IpAddr = "fd5a:5052::51".parse().unwrap();
         let visa = make_visa(102, Duration::from_secs(60));
@@ -1062,46 +1038,36 @@ mod test {
             .await
             .unwrap();
         assert_eq!(ids, vec![102]);
-
-        let installed = repo
-            .get_visa_ids_for_node_by_state(&path_node, NodeVisaState::Installed)
-            .await
-            .unwrap();
-        assert!(installed.is_empty());
+        assert!(
+            repo.get_visa_ids_for_node_by_state(&path_node, NodeVisaState::Installed)
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 
-    /// With no path, only the requesting node should receive a nodevisa entry.
     #[tokio::test]
-    async fn test_store_visa_no_path_only_requesting_node_gets_nodevisa() {
+    async fn test_store_visa_no_path_only_requesting_node_gets_state() {
         let db = Arc::new(FakeDb::new());
         let repo = VisaRepo::new(db.clone(), 1).await.unwrap();
-
         let requesting: IpAddr = "fd5a:5052::60".parse().unwrap();
         let unrelated: IpAddr = "fd5a:5052::61".parse().unwrap();
         let visa = make_visa(103, Duration::from_secs(60));
 
-        let metadata = VisaMetadata::new(
-            requesting,
-            0,
-            0,
-            String::new(),
-            Direction::Forward,
-            None,
-            &make_pdesc(),
-        );
-        repo.store_visa(&visa, metadata, NodeVisaState::PendingInstall)
+        repo.store_visa(&visa, md(requesting), NodeVisaState::PendingInstall)
             .await
             .unwrap();
 
+        let record = read_record(&db, 103).await;
         assert!(
-            db.exists(&node_visa_key_for_visa(&requesting, 103))
-                .await
-                .unwrap()
+            record
+                .node_states
+                .contains_key(&ZAddr::from(&requesting).to_string())
         );
         assert!(
-            !db.exists(&node_visa_key_for_visa(&unrelated, 103))
-                .await
-                .unwrap()
+            !record
+                .node_states
+                .contains_key(&ZAddr::from(&unrelated).to_string())
         );
     }
 
@@ -1112,31 +1078,11 @@ mod test {
         let node_addr: IpAddr = "fd5a:5052::20".parse().unwrap();
 
         let visa_a = make_visa(10, Duration::from_secs(60));
-        let visa_b = make_visa(11, Duration::from_secs(60));
-
-        let metadata_a = VisaMetadata::new(
-            node_addr,
-            0,
-            0,
-            String::new(),
-            Direction::Forward,
-            None,
-            &make_pdesc(),
-        );
-        repo.store_visa(&visa_a, metadata_a, NodeVisaState::PendingInstall)
+        repo.store_visa(&visa_a, md(node_addr), NodeVisaState::PendingInstall)
             .await
             .unwrap();
-
-        let metadata_b = VisaMetadata::new(
-            node_addr,
-            0,
-            0,
-            String::new(),
-            Direction::Forward,
-            None,
-            &make_pdesc(),
-        );
-        repo.store_visa(&visa_b, metadata_b, NodeVisaState::Installed)
+        let visa_b = make_visa(11, Duration::from_secs(60));
+        repo.store_visa(&visa_b, md(node_addr), NodeVisaState::Installed)
             .await
             .unwrap();
 
@@ -1144,24 +1090,339 @@ mod test {
             .get_visa_ids_for_node_by_state(&node_addr, NodeVisaState::PendingInstall)
             .await
             .unwrap();
-        let pending_len = repo
-            .get_count_visas_for_node_by_state(&node_addr, NodeVisaState::PendingInstall)
-            .await
-            .unwrap();
-        assert_eq!(pending_len, 1);
-        assert_eq!(pending_ids.len(), 1);
-        assert_eq!(pending_ids[0], 10);
+        assert_eq!(pending_ids, vec![10]);
+        assert_eq!(
+            repo.get_count_visas_for_node_by_state(&node_addr, NodeVisaState::PendingInstall)
+                .await
+                .unwrap(),
+            1
+        );
 
         let installed_ids = repo
             .get_visa_ids_for_node_by_state(&node_addr, NodeVisaState::Installed)
             .await
             .unwrap();
-        let installed_len = repo
-            .get_count_visas_for_node_by_state(&node_addr, NodeVisaState::PendingInstall)
+        assert_eq!(installed_ids, vec![11]);
+    }
+
+    // --- new store tests ---
+
+    /// Store visas via one repo, load a second repo on the same DB, and check
+    /// the ids, metadata, node states, and by_node index all round-trip.
+    #[tokio::test]
+    async fn test_state_load_round_trip() {
+        let db = Arc::new(FakeDb::new());
+        let repo1 = VisaRepo::new(db.clone(), 1).await.unwrap();
+        let req: IpAddr = "fd5a:5052::70".parse().unwrap();
+        let node_b: IpAddr = "fd5a:5052::71".parse().unwrap();
+
+        let visa = make_visa(200, Duration::from_secs(60));
+        let metadata = VisaMetadata::new(
+            req,
+            0,
+            0,
+            String::new(),
+            Direction::Forward,
+            Some(vec![req, node_b]),
+            &make_pdesc(),
+        );
+        repo1
+            .store_visa(&visa, metadata, NodeVisaState::Installed)
             .await
             .unwrap();
-        assert_eq!(installed_len, 1);
-        assert_eq!(installed_ids.len(), 1);
-        assert_eq!(installed_ids[0], 11);
+
+        let repo2 = VisaRepo::new(db.clone(), 1).await.unwrap();
+        let s1 = repo1.store.read().await;
+        let s2 = repo2.store.read().await;
+        assert_eq!(
+            s1.visas.keys().collect::<HashSet<_>>(),
+            s2.visas.keys().collect::<HashSet<_>>()
+        );
+        let e2 = s2.visas.get(&200).unwrap();
+        assert_eq!(e2.metadata.requesting_node, req);
+        assert_eq!(
+            e2.node_states.get(&req).unwrap().state,
+            NodeVisaState::Installed
+        );
+        assert_eq!(
+            e2.node_states.get(&node_b).unwrap().state,
+            NodeVisaState::PendingInstall
+        );
+        assert!(s2.by_node.get(&req).unwrap().contains(&200));
+        assert!(s2.by_node.get(&node_b).unwrap().contains(&200));
+    }
+
+    /// State load DELetes records it cannot use (undecodable, expired) rather than
+    /// silently skipping — a second state load then finds nothing.
+    #[tokio::test]
+    async fn test_state_load_deletes_broken_and_expired() {
+        let db = Arc::new(FakeDb::new());
+        let node: IpAddr = "fd5a:5052::80".parse().unwrap();
+
+        // Undecodable value at a visa key.
+        db.set_ex("visa:900", "not-a-json-record", 100)
+            .await
+            .unwrap();
+
+        // Expired record: a visa whose embedded expiry is already in the past,
+        // persisted with a still-live Redis TTL.
+        let mut visa = make_visa(901, Duration::from_secs(60));
+        visa.expires = SystemTime::now() - Duration::from_secs(10);
+        let node_states = HashMap::from([(
+            node,
+            NodeState {
+                state: NodeVisaState::Installed,
+                revoke_vinst: None,
+            },
+        )]);
+        let record = build_record(&visa, &md(node), &node_states).unwrap();
+        db.set_ex("visa:901", &serde_json::to_string(&record).unwrap(), 100)
+            .await
+            .unwrap();
+
+        let repo = VisaRepo::new(db.clone(), 1).await.unwrap();
+        assert!(repo.store.read().await.visas.is_empty());
+        assert!(!db.exists("visa:900").await.unwrap());
+        assert!(!db.exists("visa:901").await.unwrap());
+
+        // A second load has nothing to drop.
+        let repo2 = VisaRepo::new(db.clone(), 1).await.unwrap();
+        assert!(repo2.store.read().await.visas.is_empty());
+    }
+
+    /// After each mutator the persisted record matches the in-memory image.
+    #[tokio::test]
+    async fn test_write_through_matches_memory() {
+        let db = Arc::new(FakeDb::new());
+        let repo = VisaRepo::new(db.clone(), 1).await.unwrap();
+        let node: IpAddr = "fd5a:5052::90".parse().unwrap();
+        let visa = make_visa(300, Duration::from_secs(60));
+
+        repo.store_visa(&visa, md(node), NodeVisaState::PendingInstall)
+            .await
+            .unwrap();
+        assert_memory_matches_redis(&repo, &db, 300).await;
+
+        repo.update_node_visa_state(&node, 300, NodeVisaState::Installed)
+            .await
+            .unwrap();
+        assert_memory_matches_redis(&repo, &db, 300).await;
+    }
+
+    /// Reject-mode set_ex: the write fails and nothing is applied anywhere.
+    #[tokio::test]
+    async fn test_store_visa_reject_mode_leaves_nothing() {
+        let db = Arc::new(FakeDb::new());
+        let repo = VisaRepo::new(db.clone(), 1).await.unwrap();
+        let node: IpAddr = "fd5a:5052::91".parse().unwrap();
+        let visa = make_visa(400, Duration::from_secs(60));
+
+        db.set_set_ex_fault(FaultMode::Reject);
+        let err = repo
+            .store_visa(&visa, md(node), NodeVisaState::PendingInstall)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, StoreError::Redis(_)));
+
+        assert!(!db.exists("visa:400").await.unwrap());
+        assert!(repo.store.read().await.visas.is_empty());
+    }
+
+    /// Ambiguous store_visa: set_ex applies but errors → the compensating DEL
+    /// removes the orphan key; no memory entry either.
+    #[tokio::test]
+    async fn test_store_visa_apply_then_error_compensating_del() {
+        let db = Arc::new(FakeDb::new());
+        let repo = VisaRepo::new(db.clone(), 1).await.unwrap();
+        let node: IpAddr = "fd5a:5052::92".parse().unwrap();
+        let visa = make_visa(401, Duration::from_secs(60));
+
+        db.set_set_ex_fault(FaultMode::ApplyThenError);
+        let err = repo
+            .store_visa(&visa, md(node), NodeVisaState::PendingInstall)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, StoreError::Redis(_)));
+
+        assert!(!db.exists("visa:401").await.unwrap());
+        assert!(repo.store.read().await.visas.is_empty());
+    }
+
+    /// Ambiguous store_visa where the compensating DEL also fails: the key
+    /// survives and a later reload resurrects it (documented residual).
+    #[tokio::test]
+    async fn test_store_visa_apply_then_error_del_also_fails_resurrects() {
+        let db = Arc::new(FakeDb::new());
+        let repo = VisaRepo::new(db.clone(), 1).await.unwrap();
+        let node: IpAddr = "fd5a:5052::93".parse().unwrap();
+        let visa = make_visa(402, Duration::from_secs(60));
+
+        db.set_set_ex_fault(FaultMode::ApplyThenError);
+        db.set_del_fault(FaultMode::Reject);
+        repo.store_visa(&visa, md(node), NodeVisaState::PendingInstall)
+            .await
+            .unwrap_err();
+
+        assert!(db.exists("visa:402").await.unwrap());
+        assert!(repo.store.read().await.visas.is_empty());
+
+        // Reset faults and reload — the orphan comes back.
+        db.set_set_ex_fault(FaultMode::None);
+        db.set_del_fault(FaultMode::None);
+        let repo2 = VisaRepo::new(db.clone(), 1).await.unwrap();
+        assert!(repo2.store.read().await.visas.contains_key(&402));
+    }
+
+    /// Ambiguous record rewrite: Redis takes the new state, memory keeps the old
+    /// and the caller errors; the next successful mutation converges both.
+    #[tokio::test]
+    async fn test_record_rewrite_apply_then_error_converges() {
+        let db = Arc::new(FakeDb::new());
+        let repo = VisaRepo::new(db.clone(), 1).await.unwrap();
+        let node: IpAddr = "fd5a:5052::94".parse().unwrap();
+        let visa = make_visa(403, Duration::from_secs(60));
+        repo.store_visa(&visa, md(node), NodeVisaState::PendingInstall)
+            .await
+            .unwrap();
+
+        db.set_set_ex_fault(FaultMode::ApplyThenError);
+        repo.update_node_visa_state(&node, 403, NodeVisaState::Installed)
+            .await
+            .unwrap_err();
+
+        // Memory kept the old state; Redis diverged to the new one.
+        {
+            let store = repo.store.read().await;
+            assert_eq!(
+                store
+                    .visas
+                    .get(&403)
+                    .unwrap()
+                    .node_states
+                    .get(&node)
+                    .unwrap()
+                    .state,
+                NodeVisaState::PendingInstall
+            );
+        }
+        let record = read_record(&db, 403).await;
+        assert_eq!(
+            record
+                .node_states
+                .get(&ZAddr::from(&node).to_string())
+                .unwrap()
+                .state,
+            NodeVisaState::Installed
+        );
+
+        // A clean mutation converges both.
+        db.set_set_ex_fault(FaultMode::None);
+        repo.update_node_visa_state(&node, 403, NodeVisaState::Installed)
+            .await
+            .unwrap();
+        assert_memory_matches_redis(&repo, &db, 403).await;
+    }
+
+    /// Ambiguous DEL (remove path): Redis drops the key but errors → memory keeps
+    /// the entry; a subsequent rewrite recreates the key with a (finite) TTL.
+    #[tokio::test(start_paused = true)]
+    async fn test_del_apply_then_error_recreated_with_ttl() {
+        let db = Arc::new(FakeDb::new());
+        let repo = VisaRepo::new(db.clone(), 1).await.unwrap();
+        let node: IpAddr = "fd5a:5052::95".parse().unwrap();
+        let visa = make_visa(404, Duration::from_secs(60));
+        repo.store_visa(&visa, md(node), NodeVisaState::PendingInstall)
+            .await
+            .unwrap();
+
+        db.set_del_fault(FaultMode::ApplyThenError);
+        repo.clean_up(404).await.unwrap_err();
+        // Redis key gone, memory keeps the entry.
+        assert!(!db.exists("visa:404").await.unwrap());
+        assert!(repo.store.read().await.visas.contains_key(&404));
+
+        // A rewrite recreates the key.
+        db.set_del_fault(FaultMode::None);
+        repo.update_node_visa_state(&node, 404, NodeVisaState::Installed)
+            .await
+            .unwrap();
+        assert!(db.exists("visa:404").await.unwrap());
+
+        // The recreated key has a finite TTL: advancing past expiry removes it.
+        tokio::time::advance(Duration::from_secs(61)).await;
+        assert!(!db.exists("visa:404").await.unwrap());
+    }
+
+    /// by_node index stays consistent through store / clear_node_state / remove.
+    #[tokio::test]
+    async fn test_by_node_index_consistency() {
+        let db = Arc::new(FakeDb::new());
+        let repo = VisaRepo::new(db.clone(), 1).await.unwrap();
+        let req: IpAddr = "fd5a:5052::a0".parse().unwrap();
+        let node_b: IpAddr = "fd5a:5052::a1".parse().unwrap();
+        let node_c: IpAddr = "fd5a:5052::a2".parse().unwrap();
+        let visa = make_visa(500, Duration::from_secs(60));
+        let metadata = VisaMetadata::new(
+            req,
+            0,
+            0,
+            String::new(),
+            Direction::Forward,
+            Some(vec![req, node_b, node_c]),
+            &make_pdesc(),
+        );
+        repo.store_visa(&visa, metadata, NodeVisaState::PendingInstall)
+            .await
+            .unwrap();
+
+        {
+            let store = repo.store.read().await;
+            for n in [req, node_b, node_c] {
+                assert!(store.by_node.get(&n).unwrap().contains(&500));
+            }
+        }
+
+        repo.clear_node_state(&node_b).await.unwrap();
+        {
+            let store = repo.store.read().await;
+            assert!(!store.by_node.contains_key(&node_b));
+            assert!(store.by_node.get(&req).unwrap().contains(&500));
+            assert!(store.by_node.get(&node_c).unwrap().contains(&500));
+        }
+
+        repo.clean_up(500).await.unwrap();
+        {
+            let store = repo.store.read().await;
+            assert!(store.visas.is_empty());
+            assert!(store.by_node.is_empty());
+        }
+    }
+
+    /// Expired entries are invisible to reads before purge; purge_expired drops
+    /// them and their index rows.
+    #[tokio::test(start_paused = true)]
+    async fn test_expired_invisible_then_purged() {
+        let db = Arc::new(FakeDb::new());
+        let repo = VisaRepo::new(db.clone(), 1).await.unwrap();
+        let node: IpAddr = "fd5a:5052::b0".parse().unwrap();
+        let visa = make_visa(600, Duration::from_secs(5));
+        repo.store_visa(&visa, md(node), NodeVisaState::PendingInstall)
+            .await
+            .unwrap();
+
+        tokio::time::advance(Duration::from_secs(6)).await;
+
+        // Invisible to reads, but still resident until purge.
+        assert!(repo.list_visa_ids().await.unwrap().is_empty());
+        assert!(matches!(
+            repo.get_visa_by_id(600).await.unwrap_err(),
+            StoreError::NotFound(_)
+        ));
+        assert!(repo.store.read().await.visas.contains_key(&600));
+
+        repo.purge_expired().await.unwrap();
+        let store = repo.store.read().await;
+        assert!(store.visas.is_empty());
+        assert!(store.by_node.is_empty());
     }
 }

--- a/vs/src/db/visa.rs
+++ b/vs/src/db/visa.rs
@@ -33,7 +33,7 @@ use serde_with::{TimestampSeconds, serde_as};
 use zpr::vsapi_types::{PacketDesc, Visa, VsapiFiveTuple};
 use zpr::write_to::WriteTo;
 
-use crate::db::{DbConnection, ZAddr, gen_timestamp};
+use crate::db::{DbConnection, DbOp, ZAddr, gen_timestamp};
 use crate::error::StoreError;
 use crate::logging::targets::DB;
 
@@ -252,11 +252,25 @@ impl VisaRepo {
             writes
         };
 
-        // Redis first.
+        // Redis first, as one atomic pipeline: all rewrites land or none do, so a
+        // mid-flight failure can no longer half-clear Redis while memory keeps the
+        // node (SetBin + Expire per record, matching set_ex semantics).
+        let mut ops = Vec::new();
         for (id, json) in &writes {
             if let Some((json, ttl)) = json {
-                self.db.set_ex(&visa_key_for_visa(*id), json, *ttl).await?;
+                let key = visa_key_for_visa(*id);
+                ops.push(DbOp::SetBin {
+                    key: key.clone(),
+                    value: json.clone().into_bytes(),
+                });
+                ops.push(DbOp::Expire {
+                    key,
+                    seconds: *ttl as i64,
+                });
             }
+        }
+        if !ops.is_empty() {
+            self.db.atomic_pipeline(&ops).await?;
         }
 
         // Memory second. A concurrent purge may have dropped an entry during the
@@ -814,6 +828,47 @@ mod test {
         let store = repo.store.read().unwrap();
         assert!(store.visas.contains_key(&7));
         assert!(!store.by_node.contains_key(&node_addr));
+    }
+
+    /// Regression for the partial-clear divergence (issue #1): a failed Redis
+    /// write must leave Redis and memory consistent. The atomic pipeline rejects
+    /// as a whole, so nothing is cleared on either side — no half-cleared state.
+    #[tokio::test]
+    async fn test_clear_node_state_write_failure_stays_consistent() {
+        let db = Arc::new(FakeDb::new());
+        let repo = VisaRepo::new(db.clone(), 1).await.unwrap();
+        let node_addr: IpAddr = "fd5a:5052::30".parse().unwrap();
+
+        // One node referenced by two visas.
+        for id in [70u64, 71] {
+            let visa = make_visa(id, Duration::from_secs(60));
+            repo.store_visa(&visa, md(node_addr), NodeVisaState::Installed)
+                .await
+                .unwrap();
+        }
+
+        // The clear's pipeline fails atomically.
+        db.set_set_ex_fault(FaultMode::Reject);
+        assert!(repo.clear_node_state(&node_addr).await.is_err());
+
+        // Redis kept the node on both records (pipeline applied nothing)...
+        db.set_set_ex_fault(FaultMode::None);
+        let node_str = ZAddr::from(&node_addr).to_string();
+        for id in [70u64, 71] {
+            assert!(
+                read_record(&db, id)
+                    .await
+                    .node_states
+                    .contains_key(&node_str),
+                "Redis record {id} should be untouched",
+            );
+        }
+
+        // ...and so did memory: the two agree, no divergence.
+        let store = repo.store.read().unwrap();
+        assert!(store.by_node.contains_key(&node_addr));
+        assert!(store.visas[&70].node_states.contains_key(&node_addr));
+        assert!(store.visas[&71].node_states.contains_key(&node_addr));
     }
 
     #[tokio::test]

--- a/vs/src/db_worker.rs
+++ b/vs/src/db_worker.rs
@@ -1,19 +1,30 @@
+//! Background worker for keeping the visa service database lock alive.
+//!
+//! The service uses a shared database-backed lock to make sure only one visa
+//! service instance is active at a time. This worker renews that lock while the
+//! process runs and terminates the process if the lock is lost or too close to
+//! expiry, preventing split-brain behavior where two instances might issue or
+//! mutate visas concurrently.
+
 use std::process;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::Instant;
 use tracing::{error, trace, warn};
 
-use crate::assembly::Assembly;
 use crate::config;
-use crate::db::LockDescriptor;
+use crate::db::{DbConnection, LockDescriptor};
 
-pub async fn launch(asm: Arc<Assembly>, vslock: LockDescriptor) {
+/// Renew the DB instance lock on a timer, shutting the process down if the lock
+/// is lost or renewal is failing so long that expiry is imminent. Takes the db
+/// handle directly (not the full Assembly) so it can be spawned immediately
+/// after lock acquisition, before the rest of startup.
+pub async fn launch(db: Arc<dyn DbConnection>, vslock: LockDescriptor) {
     let mut last_renewed = Instant::now();
     let mut delay = config::VALKEY_LOCK_REFRESH_SECS;
     loop {
         tokio::time::sleep(delay).await;
-        match asm.state_db.acquire_or_renew_lock(&vslock).await {
+        match db.acquire_or_renew_lock(&vslock).await {
             Ok(true) => {
                 last_renewed = Instant::now();
                 delay = config::VALKEY_LOCK_REFRESH_SECS;

--- a/vs/src/main.rs
+++ b/vs/src/main.rs
@@ -162,6 +162,8 @@ async fn main() -> std::process::ExitCode {
         None
     };
 
+    // NOTE: tasks spawned onto this LocalSet (spawn_local) are only queued; they
+    // do not start running until the LocalSet is driven by run_until below.
     let local_set = tokio::task::LocalSet::new();
     let _local_set_guard = local_set.enter();
 
@@ -211,8 +213,10 @@ async fn main() -> std::process::ExitCode {
 
     // Spawn lock renewal immediately after acquisition so it covers hydration
     // (VisaRepo::new) and the rest of startup — otherwise the lock runs on its
-    // un-renewed fuse (VALKEY_LOCK_TIMEOUT) through all of startup.
-    js.spawn_local(db_worker::launch(db_handle.clone(), vslock_desc));
+    // un-renewed fuse (VALKEY_LOCK_TIMEOUT) through all of startup. This must be
+    // a plain spawn (not spawn_local): LocalSet tasks aren't polled until
+    // run_until, which is only reached after hydration completes.
+    js.spawn(db_worker::launch(db_handle.clone(), vslock_desc));
 
     let counters = Arc::new(Counters::default());
 

--- a/vs/src/main.rs
+++ b/vs/src/main.rs
@@ -209,6 +209,11 @@ async fn main() -> std::process::ExitCode {
 
     let mut js = JoinSet::new();
 
+    // Spawn lock renewal immediately after acquisition so it covers hydration
+    // (VisaRepo::new) and the rest of startup — otherwise the lock runs on its
+    // un-renewed fuse (VALKEY_LOCK_TIMEOUT) through all of startup.
+    js.spawn_local(db_worker::launch(db_handle.clone(), vslock_desc));
+
     let counters = Arc::new(Counters::default());
 
     let (vreq_tx, vreq_rx) =
@@ -326,7 +331,6 @@ async fn main() -> std::process::ExitCode {
     }
 
     js.spawn_local(signal_worker::launch(asm.clone()));
-    js.spawn_local(db_worker::launch(asm.clone(), vslock_desc));
     js.spawn_local(event_mgr::launch(asm.clone(), event_rx));
 
     js.spawn_local(vsapi_worker::launch(
@@ -472,6 +476,8 @@ fn initialize_identity(
 }
 
 /// If we are starting with state in the DB, do any housekeeping needed to get in sync.
+///
+/// Loading of visa state happens in [db::VisaRepo::new].
 ///
 /// TODO: If we have state in the db, and we are loading a policy that differs from
 /// the saved "curent" policy, we may have visas that are not longer valid.

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -524,6 +524,12 @@ impl VisaMgr {
         Ok(())
     }
 
+    /// Drop expired visas from the in-memory store. Called by housekeeping.
+    pub async fn purge_expired_visas(&self) -> Result<(), ServiceError> {
+        self.repo.purge_expired().await?;
+        Ok(())
+    }
+
     /// Get all the visa IDs (non-expired).
     pub async fn list_all_visa_ids(&self) -> Result<Vec<u64>, ServiceError> {
         let visa_ids = self.repo.list_visa_ids().await?;

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -63,7 +63,7 @@ impl VisaMgr {
         mut visa: Visa,
         target_node: &IpAddr,
     ) -> Result<Visa, ServiceError> {
-        let md = self.repo.get_visa_metadata_by_id(visa.issuer_id).await?;
+        let md = self.repo.get_visa_metadata_by_id(visa.issuer_id)?;
 
         let Some(path) = md.path.as_ref() else {
             return Ok(visa);
@@ -199,8 +199,7 @@ impl VisaMgr {
     ) -> Result<Option<Visa>, ServiceError> {
         for visa in self
             .repo
-            .get_visas_for_node_by_state(node_addr, db::NodeVisaState::Installed)
-            .await?
+            .get_visas_for_node_by_state(node_addr, db::NodeVisaState::Installed)?
         {
             if visa.dock_pep.is_none() {
                 warn!(target: VISA, "found visa in store with no dock_pep ID={}", visa.issuer_id);
@@ -424,8 +423,7 @@ impl VisaMgr {
     ) -> Result<Vec<Visa>, ServiceError> {
         let visas = self
             .repo
-            .get_visas_for_node_by_state(node_addr, db::NodeVisaState::PendingInstall)
-            .await?;
+            .get_visas_for_node_by_state(node_addr, db::NodeVisaState::PendingInstall)?;
         Ok(visas)
     }
 
@@ -435,8 +433,7 @@ impl VisaMgr {
     ) -> Result<Vec<u64>, ServiceError> {
         let visa_ids = self
             .repo
-            .get_visa_ids_for_node_by_state(node_addr, db::NodeVisaState::PendingInstall)
-            .await?;
+            .get_visa_ids_for_node_by_state(node_addr, db::NodeVisaState::PendingInstall)?;
         Ok(visa_ids)
     }
 
@@ -446,8 +443,7 @@ impl VisaMgr {
     ) -> Result<Vec<u64>, ServiceError> {
         let visa_ids = self
             .repo
-            .get_visa_ids_for_node_by_state(node_addr, db::NodeVisaState::Installed)
-            .await?;
+            .get_visa_ids_for_node_by_state(node_addr, db::NodeVisaState::Installed)?;
         Ok(visa_ids)
     }
 
@@ -457,8 +453,7 @@ impl VisaMgr {
     ) -> Result<u32, ServiceError> {
         let pending_revokes = self
             .repo
-            .get_count_visas_for_node_by_state(node_addr, db::NodeVisaState::PendingInstall)
-            .await?;
+            .get_count_visas_for_node_by_state(node_addr, db::NodeVisaState::PendingInstall)?;
         Ok(pending_revokes)
     }
 
@@ -468,8 +463,7 @@ impl VisaMgr {
     ) -> Result<u32, ServiceError> {
         let pending_revokes = self
             .repo
-            .get_count_visas_for_node_by_state(node_addr, db::NodeVisaState::PendingRevoke)
-            .await?;
+            .get_count_visas_for_node_by_state(node_addr, db::NodeVisaState::PendingRevoke)?;
         Ok(pending_revokes)
     }
 
@@ -525,14 +519,14 @@ impl VisaMgr {
     }
 
     /// Drop expired visas from the in-memory store. Called by housekeeping.
-    pub async fn purge_expired_visas(&self) -> Result<(), ServiceError> {
-        self.repo.purge_expired().await?;
+    pub fn purge_expired_visas(&self) -> Result<(), ServiceError> {
+        self.repo.purge_expired()?;
         Ok(())
     }
 
     /// Get all the visa IDs (non-expired).
     pub async fn list_all_visa_ids(&self) -> Result<Vec<u64>, ServiceError> {
-        let visa_ids = self.repo.list_visa_ids().await?;
+        let visa_ids = self.repo.list_visa_ids()?;
         Ok(visa_ids)
     }
 
@@ -542,8 +536,8 @@ impl VisaMgr {
         &self,
         visa_id: u64,
     ) -> Result<Option<VisaWithMetadata>, ServiceError> {
-        match self.repo.get_visa_by_id(visa_id).await {
-            Ok(visa) => match self.repo.get_visa_metadata_by_id(visa_id).await {
+        match self.repo.get_visa_by_id(visa_id) {
+            Ok(visa) => match self.repo.get_visa_metadata_by_id(visa_id) {
                 Ok(md) => Ok(Some(VisaWithMetadata { visa, metadata: md })),
                 Err(StoreError::NotFound(_)) => Ok(None),
                 Err(e) => Err(ServiceError::from(e)),
@@ -560,7 +554,7 @@ impl VisaMgr {
         &self,
         visa_id: u64,
     ) -> Result<Option<VisaMetadata>, ServiceError> {
-        match self.repo.get_visa_metadata_by_id(visa_id).await {
+        match self.repo.get_visa_metadata_by_id(visa_id) {
             Ok(md) => Ok(Some(md)),
             Err(StoreError::NotFound(_)) => Ok(None),
             Err(e) => Err(ServiceError::from(e)),
@@ -1074,7 +1068,6 @@ mod tests {
             .visa_mgr
             .repo
             .get_visa_metadata_by_id(visawmd.visa.issuer_id)
-            .await
             .unwrap();
         assert_eq!(metadata.path, Some(vec![src, mid, dst]));
     }

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -297,6 +297,11 @@ async fn do_housekeeping(
         send_topology(state, asm, node_addr, vss_handle).await;
     }
 
+    // Drop any expired visas from the in-memory store before working the queues.
+    if let Err(e) = asm.visa_mgr.purge_expired_visas().await {
+        warn!(target: VSS, "failed to purge expired visas: {e}");
+    }
+
     send_pending_visas(asm, node_addr, vss_handle).await;
 
     // TODO: Check for pending visa revocations.

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -298,7 +298,7 @@ async fn do_housekeeping(
     }
 
     // Drop any expired visas from the in-memory store before working the queues.
-    if let Err(e) = asm.visa_mgr.purge_expired_visas().await {
+    if let Err(e) = asm.visa_mgr.purge_expired_visas() {
         warn!(target: VSS, "failed to purge expired visas: {e}");
     }
 


### PR DESCRIPTION
This is the thrid PR on the string of changes leading to "recheck all visas on policy update".

Without changing behavior of the VisaRepo (`vs/src/db/visa.rs`) this converts it to a write-through system. The visas are now in memory and redis is only used on writes for persistence.  Eventually all the busy db repos (eg, actor) will work this way.  With the upcoming "check all visas with policy update" this means we can avoid slow redis `SCAN`s, etc.  A lot of complexity has been removed from the visa repo since we don't need a bunch of redis indexes for queries.  Now we just write one redis entry per visa, though the entries have more stuff in them.

 ## What changed

  ### `vs/src/db/visa.rs` (the bulk — ~1475 lines churned)
  - New in-memory model: `VisaStoreInner` holds `VisaEntry` records indexed by visa ID and by node, guarded behind the repo. Redis blobs (`VisaRecord` / `StoredNodeState`, Cap'n Proto encoded) become the persistent backing.
  - Reads (`get_visa_by_id`, `list_visa_ids`, `get_*_for_node_by_state`, etc.) serve from memory; mutations (`store_visa`, `update_node_visa_state`, `clear_node_state`) write through to Redis.
  - **Startup hydration**: `VisaRepo::new` now calls `restore_from_state` to rebuild memory from Redis on boot (`decode_record`, `build_record`, `visa_to_capnp_bytes` helpers).
  - New `purge_expired()` drops expired visas from memory (deadline-based, using `remaining_secs`).
  - Helper refactor: `live_entry` / `insert_entry` / `remove_entry` / `unindex_node` replace the old flat key-builder approach.

  ### Supporting wiring
  - **`db_worker.rs`** — decoupled from `Assembly`; `launch` now takes `Arc<dyn DbConnection>` directly. Added module doc explaining the single-instance lock and split-brain prevention.
  - **`main.rs`** — lock-renewal worker now spawned **immediately after lock acquisition**, before hydration/assembly, so the whole startup runs under a renewed lock instead of the un-renewed timeout fuse.
  - **`vss_worker.rs`** + **`visa_mgr.rs`** — housekeeping loop calls new `purge_expired_visas()` each pass.
  - **`db/mod.rs`** — exposed `FaultMode` for tests; dropped now-unneeded `#[allow(dead_code)]` on trait methods that are now live (`set_bin`, `set_ex`).
  - **`db_fake.rs`** — fault-injection support for testing the write-through/recovery paths.
  - **`Cargo.toml`** — bumped `zpr` common dep `v0.19.1 → v0.19.2` (the visa-expiry millisecond round-trip fix).


