### PR TITLE
Mk/visa sweep on visa write thru : Check active visas when policy is updated

### DIFF
--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -707,45 +707,24 @@ async fn get_related_visas(
     }
     debug!(target: ADMIN, "GET /admin/actors/{}/visas", cn);
 
-    // TODO: Waiting on another PR which reworks how the visa_mgr stores visas, once that is in
-    // place we will add appropriate index for this query. Currently this needs to look at
-    // every visa.
-
     let (actor_addr, visa_mgr) = match resolve_actor_addr(&state, &cn, false).await {
         Ok(pair) => pair,
         Err(code) => return (code, Json(Vec::<ListEntry>::new())),
     };
 
-    let mut related_visas: Vec<ListEntry> = Vec::new();
-
-    let visa_ids = match visa_mgr.list_all_visa_ids().await {
-        Ok(ids) => ids,
+    match visa_mgr.get_visa_ids_for_actors(&[actor_addr]).await {
+        Ok(ids) => (
+            StatusCode::OK,
+            Json(ids.into_iter().map(|id| ListEntry { id }).collect()),
+        ),
         Err(e) => {
-            error!(target: ADMIN, "list_all_visa_ids failed: {e}");
-            return (
+            error!(target: ADMIN, "get_visa_ids_for_actors failed: {e}");
+            (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(Vec::<ListEntry>::new()),
-            );
-        }
-    };
-    for visa_id in visa_ids {
-        // Only the five-tuple is needed here, so fetch the visa without its metadata.
-        match visa_mgr.get_visa_by_id(visa_id).await {
-            Ok(Some(visa)) => {
-                if let Some(ftup) = visa.five_tuple() {
-                    if ftup.source_addr == actor_addr || ftup.dest_addr == actor_addr {
-                        related_visas.push(ListEntry { id: visa_id });
-                    }
-                }
-            }
-            Ok(None) => {}
-            Err(e) => {
-                warn!(target: ADMIN, "error getting visa with id {}: {}", visa_id, e);
-            }
+            )
         }
     }
-
-    (StatusCode::OK, Json(related_visas))
 }
 
 /// List of visa IDs

--- a/vs/src/assembly.rs
+++ b/vs/src/assembly.rs
@@ -66,7 +66,8 @@ pub mod tests {
 
     use zpr::policy::v1;
 
-    fn make_policy(created: &str, version: u64, metadata: Option<&str>) -> Vec<u8> {
+    // "pub" as this is used in some other tests too.
+    pub fn make_policy(created: &str, version: u64, metadata: Option<&str>) -> Vec<u8> {
         let mut msg = capnp::message::Builder::new_default();
         {
             let mut policy_bldr = msg.init_root::<v1::policy::Builder>();

--- a/vs/src/db/visa.rs
+++ b/vs/src/db/visa.rs
@@ -505,6 +505,42 @@ impl VisaRepo {
         Ok(true)
     }
 
+    /// Mark every node of a live visa `PendingRevoke`, unconditionally (no vinst
+    /// gate, no `checked_vinst` bump). For actor/node departure: the visa is
+    /// invalid regardless of policy, so leave each node's `revoke_vinst`
+    /// untouched -- a fresh revoke keeps `None`, which `record_allow_verdict`'s
+    /// `rv < vinst` test can never cancel, so a later allow cannot resurrect it.
+    /// No-ops (`Ok(false)`) when the visa is absent/expired.
+    pub async fn mark_visa_revoked(&self, visa_id: u64) -> Result<bool, StoreError> {
+        // INVARIANT A: backing held for the whole write.
+        let _backing = self.inner.backing.lock().await;
+
+        let (json, ttl, new_states) = {
+            let store = self.inner.store.read().unwrap();
+            let Some(entry) = live_entry(&store, visa_id) else {
+                return Ok(false);
+            };
+            let ttl = remaining_secs(entry.deadline);
+            let mut new_states = entry.node_states.clone();
+            for ns in new_states.values_mut() {
+                ns.state = NodeVisaState::PendingRevoke; // revoke_vinst left as-is
+            }
+            let record = build_record(&entry.visa, &entry.metadata, &new_states)?;
+            (serde_json::to_string(&record)?, ttl, new_states)
+        };
+        // Redis first.
+        self.inner
+            .db
+            .set_ex(&visa_key_for_visa(visa_id), &json, ttl)
+            .await?;
+        // Memory second. A purge during the I/O gap means the visa expired;
+        // skipping the apply is correct.
+        if let Some(entry) = self.inner.store.write().unwrap().visas.get_mut(&visa_id) {
+            entry.node_states = new_states;
+        }
+        Ok(true)
+    }
+
     /// Compare-and-swap one node's state: apply `new` only if the node is
     /// currently in `expected`. Not-found/expired or state mismatch -> `Ok(false)`.
     pub async fn transition_node_visa_state(
@@ -647,6 +683,23 @@ impl VisaRepo {
             }
         }
         Ok(ids.into_iter().collect())
+    }
+
+    /// All live visa IDs referencing this node, in any per-node state.
+    /// O(matched visas), not O(all visas).
+    pub fn get_all_visa_ids_for_node(&self, node_addr: &IpAddr) -> Result<Vec<u64>, StoreError> {
+        let store = self.inner.store.read().unwrap();
+        let ids = store
+            .by_node
+            .get(node_addr)
+            .map(|set| {
+                set.iter()
+                    .copied()
+                    .filter(|&id| live_entry(&store, id).is_some())
+                    .collect()
+            })
+            .unwrap_or_default();
+        Ok(ids)
     }
 
     /// Count the visas for a node that are in the given state.
@@ -2121,5 +2174,35 @@ mod test {
             repo.get_visa_ids_for_actors(&[actor, actor]).unwrap(),
             vec![220]
         );
+    }
+
+    /// `mark_visa_revoked` flips every node PendingRevoke (leaving revoke_vinst
+    /// untouched), keeps Redis and memory in agreement, and no-ops on a missing
+    /// id.
+    #[tokio::test]
+    async fn test_mark_visa_revoked_write_through() {
+        let db = Arc::new(FakeDb::new());
+        let repo = VisaRepo::new(db.clone(), 1).await.unwrap();
+        let req: IpAddr = "fd5a:5052::f0".parse().unwrap();
+        let b: IpAddr = "fd5a:5052::f1".parse().unwrap();
+        let c: IpAddr = "fd5a:5052::f2".parse().unwrap();
+        store_three_node(&repo, 800, req, b, c, 5).await;
+
+        assert!(repo.mark_visa_revoked(800).await.unwrap());
+        {
+            let store = repo.inner.store.read().unwrap();
+            let e = store.visas.get(&800).unwrap();
+            for n in [req, b, c] {
+                let ns = e.node_states.get(&n).unwrap();
+                assert_eq!(ns.state, NodeVisaState::PendingRevoke);
+                assert_eq!(ns.revoke_vinst, None); // no vinst stamp
+            }
+            // checked_vinst untouched (not a policy event).
+            assert_eq!(e.metadata.checked_vinst, 5);
+        }
+        assert_memory_matches_redis(&repo, &db, 800).await;
+
+        // Missing id is a no-op.
+        assert!(!repo.mark_visa_revoked(999).await.unwrap());
     }
 }

--- a/vs/src/db/visa.rs
+++ b/vs/src/db/visa.rs
@@ -96,7 +96,7 @@ struct VisaRecord {
 #[derive(Debug, Clone)]
 struct NodeState {
     state: NodeVisaState,
-    revoke_vinst: Option<u64>, // TODO: will be stamped with a policy `vinst` when marked PendingRevoke
+    revoke_vinst: Option<u64>, // policy `vinst` stamped when the node was marked PendingRevoke
 }
 
 /// In-memory, authoritative copy of one visa.
@@ -219,11 +219,10 @@ impl VisaRepo {
     /// Remove all references to a visa: DEL the Redis key, then drop it from
     /// memory (Redis first so memory never claims state persistence lacks).
     ///
-    /// TODO: Will be used by future `remove_visa` function.
-    #[allow(dead_code)]
-    async fn clean_up(&self, visa_id: u64) -> Result<(), StoreError> {
+    pub async fn remove_visa(&self, visa_id: u64) -> Result<(), StoreError> {
         // INVARIANT A: backing held for the whole write.
         let _backing = self.inner.backing.lock().await;
+
         let key = visa_key_for_visa(visa_id);
         // Redis first. On an ApplyThenError-style ambiguous DEL we still return
         // the error and keep the memory entry; a later rewrite recreates the key.
@@ -439,6 +438,224 @@ impl VisaRepo {
 
         debug!(target: DB, "updated nodevisa state node={node_addr} visa={visa_id} -> {new_state:?}");
         Ok(())
+    }
+
+    /// Snapshot of `(visa_id, metadata)` for all live entries, cloned under the
+    /// read lock. Used by policy-update sweep (when new policy installed).
+    pub async fn list_visa_metadata(&self) -> Vec<(u64, VisaMetadata)> {
+        let store = self.inner.store.read().unwrap();
+        store
+            .visas
+            .iter()
+            .filter(|(_, e)| remaining_secs(e.deadline) > 0)
+            .map(|(id, e)| (*id, e.metadata.clone()))
+            .collect()
+    }
+
+    /// Apply an allow verdict at policy generation `vinst`. This happens after a policy
+    /// update and we are checking all existing visas.
+    ///
+    /// No-ops (`Ok(false)`) when the visa is absent/expired or `vinst` is not
+    /// newer than `checked_vinst` (never lowered). Otherwise bumps
+    /// `checked_vinst` and cancels any queued revoke whose stamp predates
+    /// `vinst` (`PendingRevoke -> PendingInstall`, stamp cleared) in one rewrite.
+    pub async fn record_allow_verdict(&self, visa_id: u64, vinst: u64) -> Result<bool, StoreError> {
+        // INVARIANT A: backing held for the whole write.
+        let _backing = self.inner.backing.lock().await;
+
+        // Snapshot + decide under a short read guard, then drop it for the Redis
+        // I/O. INVARIANT B: backing blocks other writers, so the entry can't
+        // change between this check and the apply below.
+        let (json, ttl, new_metadata, new_states) = {
+            let store = self.inner.store.read().unwrap();
+            let Some(entry) = live_entry(&store, visa_id) else {
+                return Ok(false);
+            };
+            if vinst <= entry.metadata.checked_vinst {
+                return Ok(false);
+            }
+            let ttl = remaining_secs(entry.deadline);
+            let mut new_metadata = entry.metadata.clone();
+            new_metadata.checked_vinst = vinst;
+            let mut new_states = entry.node_states.clone();
+            for ns in new_states.values_mut() {
+                if ns.state == NodeVisaState::PendingRevoke
+                    && ns.revoke_vinst.is_some_and(|rv| rv < vinst)
+                {
+                    // Was marked for revocation but now is allowed, flip it.
+                    ns.state = NodeVisaState::PendingInstall;
+                    ns.revoke_vinst = None;
+                }
+            }
+            let record = build_record(&entry.visa, &new_metadata, &new_states)?;
+            (
+                serde_json::to_string(&record)?,
+                ttl,
+                new_metadata,
+                new_states,
+            )
+        };
+        // Redis first.
+        self.inner
+            .db
+            .set_ex(&visa_key_for_visa(visa_id), &json, ttl)
+            .await?;
+        // Memory second. If purge_expired dropped the entry during the set_ex
+        // gap the visa expired mid-update; skipping the apply is correct.
+        if let Some(entry) = self.inner.store.write().unwrap().visas.get_mut(&visa_id) {
+            entry.metadata = new_metadata;
+            entry.node_states = new_states;
+        }
+        debug!(target: DB, "recorded allow verdict visa={visa_id} vinst={vinst}");
+        Ok(true)
+    }
+
+    /// Apply a deny verdict at policy generation `vinst`. This happens after a
+    /// policy update and we are checking all existing visas.
+    ///
+    /// No-ops (`Ok(false)`) when the visa is absent/expired or `vinst` is not
+    /// newer than `checked_vinst`. Otherwise marks every node `PendingRevoke`,
+    /// stamping `revoke_vinst = vinst` only where it exceeds the existing stamp
+    /// (a revoke decision overwrites `PendingInstall`/`Installed` freely). One
+    /// rewrite. `checked_vinst` is not bumped (only allow bumps it).
+    pub async fn record_deny_verdict(&self, visa_id: u64, vinst: u64) -> Result<bool, StoreError> {
+        // INVARIANT A: backing held for the whole write.
+        let _backing = self.inner.backing.lock().await;
+
+        // Snapshot + decide under a short read guard, then drop it for the Redis
+        // I/O. INVARIANT B: backing blocks other writers, so the entry can't
+        // change between this check and the apply below.
+        let (json, ttl, new_states) = {
+            let store = self.inner.store.read().unwrap();
+            let Some(entry) = live_entry(&store, visa_id) else {
+                return Ok(false);
+            };
+            if vinst <= entry.metadata.checked_vinst {
+                return Ok(false);
+            }
+            let ttl = remaining_secs(entry.deadline);
+            let mut new_states = entry.node_states.clone();
+            for ns in new_states.values_mut() {
+                ns.state = NodeVisaState::PendingRevoke;
+                if ns.revoke_vinst.is_none_or(|rv| vinst > rv) {
+                    ns.revoke_vinst = Some(vinst); // still revoked!
+                }
+            }
+            let record = build_record(&entry.visa, &entry.metadata, &new_states)?;
+            (serde_json::to_string(&record)?, ttl, new_states)
+        };
+        // Redis first.
+        self.inner
+            .db
+            .set_ex(&visa_key_for_visa(visa_id), &json, ttl)
+            .await?;
+        // Memory second. If purge_expired dropped the entry during the set_ex
+        // gap the visa expired mid-update; skipping the apply is correct.
+        if let Some(entry) = self.inner.store.write().unwrap().visas.get_mut(&visa_id) {
+            entry.node_states = new_states;
+        }
+        Ok(true)
+    }
+
+    /// Compare-and-swap one node's state: apply `new` only if the node is
+    /// currently in `expected`. Not-found/expired or state mismatch -> `Ok(false)`.
+    pub async fn transition_node_visa_state(
+        &self,
+        node_addr: IpAddr,
+        visa_id: u64,
+        expected: NodeVisaState,
+        new: NodeVisaState,
+    ) -> Result<bool, StoreError> {
+        // INVARIANT A: backing held for the whole write.
+        let _backing = self.inner.backing.lock().await;
+
+        // Snapshot + CAS-check under a short read guard, then drop it for the
+        // Redis I/O. INVARIANT B: backing blocks other writers, so the entry
+        // can't change between this check and the apply below.
+        let (json, ttl, new_states) = {
+            let store = self.inner.store.read().unwrap();
+            let Some(entry) = live_entry(&store, visa_id) else {
+                return Ok(false);
+            };
+            if entry
+                .node_states
+                .get(&node_addr)
+                .is_none_or(|ns| ns.state != expected)
+            {
+                return Ok(false);
+            }
+            let ttl = remaining_secs(entry.deadline);
+            let mut new_states = entry.node_states.clone();
+            new_states.get_mut(&node_addr).unwrap().state = new;
+            let record = build_record(&entry.visa, &entry.metadata, &new_states)?;
+            (serde_json::to_string(&record)?, ttl, new_states)
+        };
+        // Redis first.
+        self.inner
+            .db
+            .set_ex(&visa_key_for_visa(visa_id), &json, ttl)
+            .await?;
+        // Memory second. If purge_expired dropped the entry during the set_ex
+        // gap the visa expired mid-update; skipping the apply is correct.
+        if let Some(entry) = self.inner.store.write().unwrap().visas.get_mut(&visa_id) {
+            entry.node_states = new_states;
+        }
+        debug!(target: DB, "transitioned node={node_addr} visa={visa_id} {expected:?} -> {new:?}");
+        Ok(true)
+    }
+
+    /// Conditional teardown: drop `node_addr` from the visa's `node_states` (and
+    /// the `by_node` index) only if its state is `PendingRevoke`. Rewrites the
+    /// record. Returns true if node was removed.
+    pub async fn remove_node_if_pending_revoke(
+        &self,
+        node_addr: IpAddr,
+        visa_id: u64,
+    ) -> Result<bool, StoreError> {
+        // INVARIANT A: backing held for the whole write.
+        let _backing = self.inner.backing.lock().await;
+
+        // Snapshot + check under a short read guard, then drop it for the Redis
+        // I/O. INVARIANT B: backing blocks other writers, so the entry can't
+        // change between this check and the apply below.
+        let (json, ttl, new_states) = {
+            let store = self.inner.store.read().unwrap();
+            let Some(entry) = live_entry(&store, visa_id) else {
+                return Ok(false);
+            };
+            if entry
+                .node_states
+                .get(&node_addr)
+                .is_none_or(|ns| ns.state != NodeVisaState::PendingRevoke)
+            {
+                return Ok(false);
+            }
+            let ttl = remaining_secs(entry.deadline);
+            let mut new_states = entry.node_states.clone();
+            new_states.remove(&node_addr);
+            let record = build_record(&entry.visa, &entry.metadata, &new_states)?;
+            (serde_json::to_string(&record)?, ttl, new_states)
+        };
+        // Redis first.
+        self.inner
+            .db
+            .set_ex(&visa_key_for_visa(visa_id), &json, ttl)
+            .await?;
+        // Memory second. If purge_expired dropped the entry during the set_ex
+        // gap the visa expired mid-update; skipping the apply is correct.
+        let mut store = self.inner.store.write().unwrap();
+        if let Some(entry) = store.visas.get_mut(&visa_id) {
+            entry.node_states = new_states;
+        }
+        unindex_node(&mut store, &node_addr, visa_id);
+        debug!(target: DB, "removed pending-revoke node={node_addr} from visa={visa_id}");
+        Ok(true)
+    }
+
+    /// Whether a given live visa still references any node.
+    pub async fn visa_has_node_refs(&self, visa_id: u64) -> bool {
+        let store = self.inner.store.read().unwrap();
+        live_entry(&store, visa_id).is_some_and(|e| !e.node_states.is_empty())
     }
 
     /// All visas for a node in the given state (blobs cloned from memory).
@@ -823,9 +1040,16 @@ mod test {
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].issuer_id, 42);
 
-        repo.update_node_visa_state(&node_addr, 42, NodeVisaState::Installed)
+        assert!(
+            repo.transition_node_visa_state(
+                node_addr,
+                42,
+                NodeVisaState::PendingInstall,
+                NodeVisaState::Installed
+            )
             .await
-            .unwrap();
+            .unwrap()
+        );
         let pending = repo
             .get_visas_for_node_by_state(&node_addr, NodeVisaState::PendingInstall)
             .unwrap();
@@ -939,26 +1163,6 @@ mod test {
         // Not written
         let store = repo.inner.store.read().unwrap();
         assert!(!store.visas.contains_key(&8));
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn test_update_node_visa_state_after_expiry() {
-        let db = Arc::new(FakeDb::new());
-        let repo = VisaRepo::new(db, 1).await.unwrap();
-        let node_addr: IpAddr = "fd5a:5052::5".parse().unwrap();
-        let visa = make_visa(9, Duration::from_secs(5));
-
-        repo.store_visa(&visa, md(node_addr), NodeVisaState::PendingInstall)
-            .await
-            .unwrap();
-
-        tokio::time::advance(Duration::from_secs(6)).await;
-
-        let err = repo
-            .update_node_visa_state(&node_addr, 9, NodeVisaState::Installed)
-            .await
-            .unwrap_err();
-        assert!(matches!(err, StoreError::NotFound(_)));
     }
 
     #[tokio::test]
@@ -1385,9 +1589,16 @@ mod test {
             .unwrap();
         assert_memory_matches_redis(&repo, &db, 300).await;
 
-        repo.update_node_visa_state(&node, 300, NodeVisaState::Installed)
+        assert!(
+            repo.transition_node_visa_state(
+                node,
+                300,
+                NodeVisaState::PendingInstall,
+                NodeVisaState::Installed
+            )
             .await
-            .unwrap();
+            .unwrap()
+        );
         assert_memory_matches_redis(&repo, &db, 300).await;
     }
 
@@ -1468,9 +1679,14 @@ mod test {
             .unwrap();
 
         db.set_set_ex_fault(FaultMode::ApplyThenError);
-        repo.update_node_visa_state(&node, 403, NodeVisaState::Installed)
-            .await
-            .unwrap_err();
+        repo.transition_node_visa_state(
+            node,
+            403,
+            NodeVisaState::PendingInstall,
+            NodeVisaState::Installed,
+        )
+        .await
+        .unwrap_err();
 
         // Memory kept the old state; Redis diverged to the new one.
         {
@@ -1499,9 +1715,16 @@ mod test {
 
         // A clean mutation converges both.
         db.set_set_ex_fault(FaultMode::None);
-        repo.update_node_visa_state(&node, 403, NodeVisaState::Installed)
+        assert!(
+            repo.transition_node_visa_state(
+                node,
+                403,
+                NodeVisaState::PendingInstall,
+                NodeVisaState::Installed
+            )
             .await
-            .unwrap();
+            .unwrap()
+        );
         assert_memory_matches_redis(&repo, &db, 403).await;
     }
 
@@ -1518,16 +1741,23 @@ mod test {
             .unwrap();
 
         db.set_del_fault(FaultMode::ApplyThenError);
-        repo.clean_up(404).await.unwrap_err();
+        repo.remove_visa(404).await.unwrap_err();
         // Redis key gone, memory keeps the entry.
         assert!(!db.exists("visa:404").await.unwrap());
         assert!(repo.inner.store.read().unwrap().visas.contains_key(&404));
 
         // A rewrite recreates the key.
         db.set_del_fault(FaultMode::None);
-        repo.update_node_visa_state(&node, 404, NodeVisaState::Installed)
+        assert!(
+            repo.transition_node_visa_state(
+                node,
+                404,
+                NodeVisaState::PendingInstall,
+                NodeVisaState::Installed
+            )
             .await
-            .unwrap();
+            .unwrap()
+        );
         assert!(db.exists("visa:404").await.unwrap());
 
         // The recreated key has a finite TTL: advancing past expiry removes it.
@@ -1572,7 +1802,7 @@ mod test {
             assert!(store.by_node.get(&node_c).unwrap().contains(&500));
         }
 
-        repo.clean_up(500).await.unwrap();
+        repo.remove_visa(500).await.unwrap();
         {
             let store = repo.inner.store.read().unwrap();
             assert!(store.visas.is_empty());
@@ -1606,5 +1836,241 @@ mod test {
         let store = repo.inner.store.read().unwrap();
         assert!(store.visas.is_empty());
         assert!(store.by_node.is_empty());
+    }
+
+    // --- Visa "sweep" (from policy update) / teardown tests ---
+
+    /// Store a three-node visa (requesting + two path nodes): requesting node is
+    /// `Installed`, path nodes `PendingInstall`. `vinst` seeds created/checked.
+    async fn store_three_node(
+        repo: &VisaRepo,
+        id: u64,
+        req: IpAddr,
+        b: IpAddr,
+        c: IpAddr,
+        vinst: u64,
+    ) {
+        let metadata = VisaMetadata::new(
+            req,
+            0,
+            vinst,
+            String::new(),
+            Direction::Forward,
+            Some(vec![req, b, c]),
+            &make_pdesc(),
+        );
+        let visa = make_visa(id, Duration::from_secs(60));
+        repo.store_visa(&visa, metadata, NodeVisaState::Installed)
+            .await
+            .unwrap();
+    }
+
+    /// An allow verdict cancels a queued revoke on every holder node
+    /// (`PendingRevoke -> PendingInstall`, stamp cleared) and bumps checked_vinst.
+    #[tokio::test]
+    async fn test_record_allow_cancels_queued_revokes() {
+        let db = Arc::new(FakeDb::new());
+        let repo = VisaRepo::new(db.clone(), 1).await.unwrap();
+        let req: IpAddr = "fd5a:5052::c0".parse().unwrap();
+        let b: IpAddr = "fd5a:5052::c1".parse().unwrap();
+        let c: IpAddr = "fd5a:5052::c2".parse().unwrap();
+        store_three_node(&repo, 700, req, b, c, 5).await;
+
+        // Deny at 6 marks all nodes PendingRevoke (stamp 6).
+        assert!(repo.record_deny_verdict(700, 6).await.unwrap());
+        // Allow at 7 cancels them (6 < 7) and bumps checked_vinst.
+        assert!(repo.record_allow_verdict(700, 7).await.unwrap());
+
+        let store = repo.inner.store.read().unwrap();
+        let e = store.visas.get(&700).unwrap();
+        for n in [req, b, c] {
+            let ns = e.node_states.get(&n).unwrap();
+            assert_eq!(ns.state, NodeVisaState::PendingInstall);
+            assert_eq!(ns.revoke_vinst, None);
+        }
+        assert_eq!(e.metadata.checked_vinst, 7);
+    }
+
+    /// Stale verdicts no-op at the store boundary: checked_vinst is never lowered,
+    /// a stale revoke is not stamped, and a stale allow cannot cancel a newer revoke.
+    #[tokio::test]
+    async fn test_verdict_stale_guards() {
+        let db = Arc::new(FakeDb::new());
+        let repo = VisaRepo::new(db.clone(), 1).await.unwrap();
+        let node: IpAddr = "fd5a:5052::d0".parse().unwrap();
+        let metadata = VisaMetadata::new(
+            node,
+            0,
+            5,
+            String::new(),
+            Direction::Forward,
+            None,
+            &make_pdesc(),
+        );
+        let visa = make_visa(710, Duration::from_secs(60));
+        repo.store_visa(&visa, metadata, NodeVisaState::Installed)
+            .await
+            .unwrap();
+
+        // Allow at 6 bumps checked to 6.
+        assert!(repo.record_allow_verdict(710, 6).await.unwrap());
+        // Not-newer allow (6) and stale deny (5) both no-op.
+        assert!(!repo.record_allow_verdict(710, 6).await.unwrap());
+        assert!(!repo.record_deny_verdict(710, 5).await.unwrap());
+        {
+            let store = repo.inner.store.read().unwrap();
+            let e = store.visas.get(&710).unwrap();
+            assert_eq!(e.metadata.checked_vinst, 6);
+            assert_eq!(
+                e.node_states.get(&node).unwrap().state,
+                NodeVisaState::Installed
+            );
+        }
+
+        // Deny at 7 stamps PendingRevoke; a stale allow (6) does not cancel it.
+        assert!(repo.record_deny_verdict(710, 7).await.unwrap());
+        assert!(!repo.record_allow_verdict(710, 6).await.unwrap());
+        let store = repo.inner.store.read().unwrap();
+        let ns = store
+            .visas
+            .get(&710)
+            .unwrap()
+            .node_states
+            .get(&node)
+            .unwrap();
+        assert_eq!(ns.state, NodeVisaState::PendingRevoke);
+        assert_eq!(ns.revoke_vinst, Some(7));
+    }
+
+    /// CAS transition applies only when the current state matches `expected`;
+    /// conditional teardown fires only on `PendingRevoke`.
+    #[tokio::test]
+    async fn test_transition_cas_and_conditional_teardown() {
+        let db = Arc::new(FakeDb::new());
+        let repo = VisaRepo::new(db.clone(), 1).await.unwrap();
+        let node: IpAddr = "fd5a:5052::e0".parse().unwrap();
+        let visa = make_visa(720, Duration::from_secs(60));
+        repo.store_visa(&visa, md(node), NodeVisaState::PendingInstall)
+            .await
+            .unwrap();
+
+        // CAS PendingInstall -> Installed succeeds, then a repeat misses.
+        assert!(
+            repo.transition_node_visa_state(
+                node,
+                720,
+                NodeVisaState::PendingInstall,
+                NodeVisaState::Installed
+            )
+            .await
+            .unwrap()
+        );
+        assert!(
+            !repo
+                .transition_node_visa_state(
+                    node,
+                    720,
+                    NodeVisaState::PendingInstall,
+                    NodeVisaState::Installed
+                )
+                .await
+                .unwrap()
+        );
+
+        // Not PendingRevoke → teardown misses.
+        assert!(!repo.remove_node_if_pending_revoke(node, 720).await.unwrap());
+
+        // Deny → PendingRevoke, then teardown fires and clears the ref + index.
+        assert!(repo.record_deny_verdict(720, 1).await.unwrap());
+        assert!(repo.remove_node_if_pending_revoke(node, 720).await.unwrap());
+        assert!(!repo.visa_has_node_refs(720).await);
+        let store = repo.inner.store.read().unwrap();
+        assert!(!store.by_node.contains_key(&node));
+        assert!(store.visas.get(&720).unwrap().node_states.is_empty());
+    }
+
+    /// Expired visas are invisible to every Phase 2 method (before purge).
+    #[tokio::test(start_paused = true)]
+    async fn test_phase2_methods_ignore_expired() {
+        let db = Arc::new(FakeDb::new());
+        let repo = VisaRepo::new(db.clone(), 1).await.unwrap();
+        let node: IpAddr = "fd5a:5052::f0".parse().unwrap();
+        let visa = make_visa(730, Duration::from_secs(5));
+        repo.store_visa(&visa, md(node), NodeVisaState::Installed)
+            .await
+            .unwrap();
+
+        tokio::time::advance(Duration::from_secs(6)).await;
+
+        assert!(!repo.visa_has_node_refs(730).await);
+        assert!(
+            !repo
+                .transition_node_visa_state(
+                    node,
+                    730,
+                    NodeVisaState::Installed,
+                    NodeVisaState::PendingRevoke
+                )
+                .await
+                .unwrap()
+        );
+        assert!(!repo.record_allow_verdict(730, 99).await.unwrap());
+        assert!(!repo.record_deny_verdict(730, 99).await.unwrap());
+        assert!(repo.list_visa_metadata().await.is_empty());
+        // Still resident until purge.
+        assert!(repo.inner.store.read().unwrap().visas.contains_key(&730));
+    }
+
+    /// Verdict mutators write through (record matches memory) and a second repo
+    /// hydrated from the same DB reproduces states and revoke_vinst stamps.
+    #[tokio::test]
+    async fn test_verdict_write_through_and_hydration() {
+        let db = Arc::new(FakeDb::new());
+        let repo = VisaRepo::new(db.clone(), 1).await.unwrap();
+        let req: IpAddr = "fd5a:5052::1a0".parse().unwrap();
+        let b: IpAddr = "fd5a:5052::1a1".parse().unwrap();
+        let c: IpAddr = "fd5a:5052::1a2".parse().unwrap();
+        store_three_node(&repo, 740, req, b, c, 0).await;
+
+        assert!(repo.record_deny_verdict(740, 3).await.unwrap());
+        assert_memory_matches_redis(&repo, &db, 740).await;
+        assert!(repo.remove_node_if_pending_revoke(b, 740).await.unwrap());
+        assert_memory_matches_redis(&repo, &db, 740).await;
+
+        let repo2 = VisaRepo::new(db.clone(), 1).await.unwrap();
+        let store = repo2.inner.store.read().unwrap();
+        let e = store.visas.get(&740).unwrap();
+        assert!(e.node_states.get(&b).is_none());
+        for n in [req, c] {
+            let ns = e.node_states.get(&n).unwrap();
+            assert_eq!(ns.state, NodeVisaState::PendingRevoke);
+            assert_eq!(ns.revoke_vinst, Some(3));
+        }
+    }
+
+    /// Reject-mode fault on a verdict rewrite → error returned, memory unchanged.
+    #[tokio::test]
+    async fn test_verdict_reject_fault_leaves_memory() {
+        let db = Arc::new(FakeDb::new());
+        let repo = VisaRepo::new(db.clone(), 1).await.unwrap();
+        let node: IpAddr = "fd5a:5052::1b0".parse().unwrap();
+        let visa = make_visa(750, Duration::from_secs(60));
+        repo.store_visa(&visa, md(node), NodeVisaState::Installed)
+            .await
+            .unwrap();
+
+        db.set_set_ex_fault(FaultMode::Reject);
+        let err = repo.record_deny_verdict(750, 5).await.unwrap_err();
+        assert!(matches!(err, StoreError::Redis(_)));
+
+        // Memory untouched: still Installed, checked_vinst still 0.
+        db.set_set_ex_fault(FaultMode::None);
+        let store = repo.inner.store.read().unwrap();
+        let e = store.visas.get(&750).unwrap();
+        assert_eq!(
+            e.node_states.get(&node).unwrap().state,
+            NodeVisaState::Installed
+        );
+        assert_eq!(e.metadata.checked_vinst, 0);
     }
 }

--- a/vs/src/db/visa.rs
+++ b/vs/src/db/visa.rs
@@ -119,13 +119,14 @@ struct VisaEntry {
 
 /// The in-memory store guarded by a single `RwLock`.
 ///
-/// INVARIANT C: `visas` and `by_node` must be updated under the same `store`
-/// write guard; a reader must never see one without the other. Today the single
-/// `store` lock gives this for free (both live behind one guard).
+/// INVARIANT C: `visas`, `by_node`, and `by_actor` must be updated under the
+/// same `store` write guard; a reader must never see one without the others.
+/// Today the single `store` lock gives this for free (all live behind one guard).
 #[derive(Default)]
 struct VisaStoreInner {
     visas: HashMap<u64, VisaEntry>,
     by_node: HashMap<IpAddr, HashSet<u64>>, // secondary index for per-node queries
+    by_actor: HashMap<IpAddr, HashSet<u64>>, // five-tuple src/dst endpoints
 }
 
 /// Cheap cloneable handle. `VisaRepo` owns the in-memory store, so it cannot be
@@ -629,6 +630,25 @@ impl VisaRepo {
         Ok(ids)
     }
 
+    /// Live visa IDs having any of `actor_addrs` as a five-tuple endpoint.
+    /// O(matched visas), not O(all visas). Returns `Result` for signature
+    /// consistency with the `get_*` query family though it never errors.
+    pub fn get_visa_ids_for_actors(&self, actor_addrs: &[IpAddr]) -> Result<Vec<u64>, StoreError> {
+        let store = self.inner.store.read().unwrap();
+        // HashSet: a src/dst pair or overlapping input addrs can hit one id twice.
+        let mut ids = HashSet::new();
+        for addr in actor_addrs {
+            if let Some(set) = store.by_actor.get(addr) {
+                ids.extend(
+                    set.iter()
+                        .copied()
+                        .filter(|&id| live_entry(&store, id).is_some()),
+                );
+            }
+        }
+        Ok(ids.into_iter().collect())
+    }
+
     /// Count the visas for a node that are in the given state.
     pub fn get_count_visas_for_node_by_state(
         &self,
@@ -870,33 +890,50 @@ fn for_each_node_visa_in_state<F: FnMut(u64, &VisaEntry)>(
     }
 }
 
-/// Insert an entry and index all its nodes in `by_node`.
+/// Insert an entry and index it in `by_node` (path nodes) and `by_actor`
+/// (five-tuple endpoints).
 fn insert_entry(inner: &mut VisaStoreInner, id: u64, entry: VisaEntry) {
     let nodes: Vec<IpAddr> = entry.node_states.keys().copied().collect();
+    let ft = &entry.metadata.five_tuple;
+    let actors = [ft.source_addr, ft.dest_addr];
     inner.visas.insert(id, entry);
     for node in nodes {
         inner.by_node.entry(node).or_default().insert(id);
     }
+    for actor in actors {
+        inner.by_actor.entry(actor).or_default().insert(id);
+    }
 }
 
-/// Remove an entry and unindex all its nodes.
+/// Remove an entry and unindex it from both `by_node` and `by_actor`.
 fn remove_entry(inner: &mut VisaStoreInner, id: u64) {
     if let Some(entry) = inner.visas.remove(&id) {
+        let ft = &entry.metadata.five_tuple;
+        for actor in [ft.source_addr, ft.dest_addr] {
+            unindex(&mut inner.by_actor, &actor, id);
+        }
         let nodes: Vec<IpAddr> = entry.node_states.keys().copied().collect();
         for node in nodes {
-            unindex_node(inner, &node, id);
+            unindex(&mut inner.by_node, &node, id);
         }
     }
 }
 
-/// Drop `id` from the `by_node` row for `node`, removing the row if it empties.
-fn unindex_node(inner: &mut VisaStoreInner, node: &IpAddr, id: u64) {
-    if let Some(set) = inner.by_node.get_mut(node) {
+/// Drop `id` from `index[key]`, removing the row if it empties.
+fn unindex(index: &mut HashMap<IpAddr, HashSet<u64>>, key: &IpAddr, id: u64) {
+    if let Some(set) = index.get_mut(key) {
         set.remove(&id);
         if set.is_empty() {
-            inner.by_node.remove(node);
+            index.remove(key);
         }
     }
+}
+
+/// Drop `id` from the `by_node` row for `node`. Thin wrapper over `unindex` so
+/// the state-mutation call sites (`clear_node_state`, `remove_node_if_pending_revoke`)
+/// don't churn.
+fn unindex_node(inner: &mut VisaStoreInner, node: &IpAddr, id: u64) {
+    unindex(&mut inner.by_node, node, id);
 }
 
 // Get number of seconds until the given SystemTime or zero if in the past.
@@ -2006,5 +2043,83 @@ mod test {
             NodeVisaState::Installed
         );
         assert_eq!(e.metadata.checked_vinst, 0);
+    }
+
+    /// Build metadata whose five-tuple uses the given src/dst endpoint strings.
+    fn md_ft(node: IpAddr, src: &str, dst: &str) -> VisaMetadata {
+        let pdesc = PacketDesc::new_tcp(src, dst, 1234, 443).unwrap();
+        VisaMetadata::new(node, 0, 0, String::new(), Direction::Forward, None, &pdesc)
+    }
+
+    /// Two visas sharing the same endpoints both resolve for either endpoint;
+    /// removing one leaves the other resolvable and the removed id gone.
+    #[tokio::test]
+    async fn test_get_visa_ids_for_actors_shared_endpoint() {
+        let db = Arc::new(FakeDb::new());
+        let repo = VisaRepo::new(db, 1).await.unwrap();
+        let node: IpAddr = "fd5a:5052::100".parse().unwrap();
+        // md() five-tuple endpoints are ::10 (src) and ::20 (dst).
+        let src: IpAddr = "fd5a:5052::10".parse().unwrap();
+        let dst: IpAddr = "fd5a:5052::20".parse().unwrap();
+
+        for id in [200u64, 201] {
+            let visa = make_visa(id, Duration::from_secs(60));
+            repo.store_visa(&visa, md(node), NodeVisaState::Installed)
+                .await
+                .unwrap();
+        }
+
+        for actor in [src, dst] {
+            let mut ids = repo.get_visa_ids_for_actors(&[actor]).unwrap();
+            ids.sort_unstable();
+            assert_eq!(ids, vec![200, 201]);
+        }
+
+        repo.remove_visa(200).await.unwrap();
+        assert_eq!(repo.get_visa_ids_for_actors(&[src]).unwrap(), vec![201]);
+    }
+
+    /// An expired entry still sitting in `by_actor` (purge not yet run) is
+    /// filtered out of the query by the liveness check.
+    #[tokio::test(start_paused = true)]
+    async fn test_get_visa_ids_for_actors_filters_expired() {
+        let db = Arc::new(FakeDb::new());
+        let repo = VisaRepo::new(db, 1).await.unwrap();
+        let node: IpAddr = "fd5a:5052::101".parse().unwrap();
+        let src: IpAddr = "fd5a:5052::10".parse().unwrap();
+        let visa = make_visa(210, Duration::from_secs(60));
+        repo.store_visa(&visa, md(node), NodeVisaState::Installed)
+            .await
+            .unwrap();
+
+        assert_eq!(repo.get_visa_ids_for_actors(&[src]).unwrap(), vec![210]);
+
+        // Age past expiry without running purge; the id lingers in by_actor.
+        tokio::time::advance(Duration::from_secs(61)).await;
+        assert!(repo.get_visa_ids_for_actors(&[src]).unwrap().is_empty());
+    }
+
+    /// When one actor is both src and dst of a visa, it resolves to a single id
+    /// (no duplicate from the two by_actor rows collapsing to one).
+    #[tokio::test]
+    async fn test_get_visa_ids_for_actors_dedup() {
+        let db = Arc::new(FakeDb::new());
+        let repo = VisaRepo::new(db, 1).await.unwrap();
+        let node: IpAddr = "fd5a:5052::102".parse().unwrap();
+        let actor: IpAddr = "fd5a:5052::10".parse().unwrap();
+        let visa = make_visa(220, Duration::from_secs(60));
+        repo.store_visa(
+            &visa,
+            md_ft(node, "fd5a:5052::10", "fd5a:5052::10"),
+            NodeVisaState::Installed,
+        )
+        .await
+        .unwrap();
+
+        // Same actor passed twice as well: still exactly one id.
+        assert_eq!(
+            repo.get_visa_ids_for_actors(&[actor, actor]).unwrap(),
+            vec![220]
+        );
     }
 }

--- a/vs/src/db/visa.rs
+++ b/vs/src/db/visa.rs
@@ -387,59 +387,6 @@ impl VisaRepo {
         Ok(())
     }
 
-    /// Update the state for the given node/visa. Rewrites the record with the
-    /// remaining TTL (Redis first, memory second).
-    pub async fn update_node_visa_state(
-        &self,
-        node_addr: &IpAddr,
-        visa_id: u64,
-        new_state: NodeVisaState,
-    ) -> Result<(), StoreError> {
-        // INVARIANT A: backing held for the whole write.
-        let _backing = self.inner.backing.lock().await;
-
-        // Snapshot + build the record under a short read guard, run the
-        // not-found / ttl==0 checks, then drop the guard for the Redis I/O.
-        //
-        // INVARIANT B: safe to drop the read guard — backing blocks other
-        // writers, so this entry can't change under us before the apply.
-        let (json, ttl, new_states) = {
-            let store = self.inner.store.read().unwrap();
-            let entry = live_entry(&store, visa_id).ok_or_else(|| {
-                StoreError::NotFound(format!("node-visa record not found: {node_addr} {visa_id}"))
-            })?;
-            if !entry.node_states.contains_key(node_addr) {
-                return Err(StoreError::NotFound(format!(
-                    "node-visa record not found: {node_addr} {visa_id}"
-                )));
-            }
-            let ttl = remaining_secs(entry.deadline);
-            if ttl == 0 {
-                return Err(StoreError::NotFound(format!(
-                    "node-visa record not found: {node_addr} {visa_id}"
-                )));
-            }
-            let mut new_states = entry.node_states.clone();
-            new_states.get_mut(node_addr).unwrap().state = new_state;
-            let record = build_record(&entry.visa, &entry.metadata, &new_states)?;
-            (serde_json::to_string(&record)?, ttl, new_states)
-        };
-
-        // Redis first.
-        self.inner
-            .db
-            .set_ex(&visa_key_for_visa(visa_id), &json, ttl)
-            .await?;
-        // Memory second. If purge_expired dropped the entry during the set_ex
-        // gap the visa expired mid-update; skipping the apply is correct.
-        if let Some(entry) = self.inner.store.write().unwrap().visas.get_mut(&visa_id) {
-            entry.node_states = new_states;
-        }
-
-        debug!(target: DB, "updated nodevisa state node={node_addr} visa={visa_id} -> {new_state:?}");
-        Ok(())
-    }
-
     /// Snapshot of `(visa_id, metadata)` for all live entries, cloned under the
     /// read lock. Used by policy-update sweep (when new policy installed).
     pub async fn list_visa_metadata(&self) -> Vec<(u64, VisaMetadata)> {
@@ -1060,19 +1007,6 @@ mod test {
             .unwrap();
         assert_eq!(installed.len(), 1);
         assert_eq!(installed[0].issuer_id, 42);
-    }
-
-    #[tokio::test]
-    async fn test_update_node_visa_state_missing() {
-        let db = Arc::new(FakeDb::new());
-        let repo = VisaRepo::new(db, 1).await.unwrap();
-        let node_addr: IpAddr = "fd5a:5052::2".parse().unwrap();
-
-        let err = repo
-            .update_node_visa_state(&node_addr, 99, NodeVisaState::Installed)
-            .await
-            .unwrap_err();
-        assert!(matches!(err, StoreError::NotFound(_)));
     }
 
     /// clear_node_state drops the node from a visa's states and the by_node

--- a/vs/src/event_mgr.rs
+++ b/vs/src/event_mgr.rs
@@ -357,16 +357,24 @@ async fn revalidate_visas_against_policy(asm: &Arc<Assembly>, psnap: &PolicySnap
                 skipped_unresolved += 1;
                 debug!(target: EVENT, "visa sweep: visa {visa_id} actor unresolved, skipping");
             }
-            Ok(Some(true)) => match asm
-                .visa_mgr
-                .record_allow_verdict(visa_id, target_vinst)
-                .await
-            {
-                Ok(_) => allowed += 1,
-                Err(e) => {
-                    warn!(target: EVENT, "visa sweep: failed to record allow for visa {visa_id}: {e}")
+            Ok(Some(true)) => {
+                // Allowed. Only apply while target_vinst is still the live policy;
+                // otherwise an older sweep could cancel a newer revoke verdict.
+                if asm.policy_mgr.get_current_snapshot().vinst() != target_vinst {
+                    skipped_stale += 1;
+                    continue;
                 }
-            },
+                match asm
+                    .visa_mgr
+                    .record_allow_verdict(visa_id, target_vinst)
+                    .await
+                {
+                    Ok(_) => allowed += 1,
+                    Err(e) => {
+                        warn!(target: EVENT, "visa sweep: failed to record allow for visa {visa_id}: {e}")
+                    }
+                }
+            }
             Ok(Some(false)) => {
                 // Denied. Only apply while target_vinst is still the live policy;
                 // otherwise a newer sweep is coming and will make the decision.

--- a/vs/src/event_mgr.rs
+++ b/vs/src/event_mgr.rs
@@ -19,6 +19,7 @@ use crate::assembly::Assembly;
 use crate::error::ServiceError;
 use crate::logging::targets::EVENT;
 use crate::policy_mgr::PolicySnapshot;
+use crate::visa_mgr::VisaRecheck;
 
 pub enum VsEvent {
     /// Use _after_ actor has been authenticated and the datastore updated.
@@ -353,11 +354,11 @@ async fn revalidate_visas_against_policy(asm: &Arc<Assembly>, psnap: &PolicySnap
             .recheck_visa_allowed(asm, &metadata, psnap)
             .await
         {
-            Ok(None) => {
+            Ok(VisaRecheck::SkipUnresolvedActor) => {
                 skipped_unresolved += 1;
                 debug!(target: EVENT, "visa sweep: visa {visa_id} actor unresolved, skipping");
             }
-            Ok(Some(true)) => {
+            Ok(VisaRecheck::AllowSameRoute) => {
                 // Allowed. Only apply while target_vinst is still the live policy;
                 // otherwise an older sweep could cancel a newer revoke verdict.
                 if asm.policy_mgr.get_current_snapshot().vinst() != target_vinst {
@@ -375,9 +376,10 @@ async fn revalidate_visas_against_policy(asm: &Arc<Assembly>, psnap: &PolicySnap
                     }
                 }
             }
-            Ok(Some(false)) => {
-                // Denied. Only apply while target_vinst is still the live policy;
-                // otherwise a newer sweep is coming and will make the decision.
+            Ok(VisaRecheck::Revoke) => {
+                // Denied, or allowed but rerouted. Only apply while target_vinst
+                // is still the live policy; otherwise a newer sweep is coming and
+                // will make the decision.
                 if asm.policy_mgr.get_current_snapshot().vinst() != target_vinst {
                     skipped_stale += 1;
                     continue;

--- a/vs/src/event_mgr.rs
+++ b/vs/src/event_mgr.rs
@@ -344,9 +344,11 @@ async fn revalidate_visas_against_policy(asm: &Arc<Assembly>, psnap: &PolicySnap
     let mut revoked = 0u32;
     let mut skipped_stale = 0u32;
     let mut skipped_unresolved = 0u32;
+    let mut skipped_current = 0u32;
 
     for (visa_id, metadata) in snapshot {
         if metadata.checked_vinst >= target_vinst {
+            skipped_current += 1;
             continue;
         }
         match asm
@@ -405,7 +407,7 @@ async fn revalidate_visas_against_policy(asm: &Arc<Assembly>, psnap: &PolicySnap
     // actual revocations happen asynchronously in VSS housekeeping.
     info!(
         target: EVENT,
-        "visa sweep vinst={target_vinst}: total={total} allowed={allowed} revoked={revoked} skipped_stale={skipped_stale} skipped_unresolved={skipped_unresolved}"
+        "visa sweep vinst={target_vinst}: total={total} allowed={allowed} revoked={revoked} skipped_stale={skipped_stale} skipped_unresolved={skipped_unresolved} skipped_current={skipped_current}"
     );
 }
 

--- a/vs/src/event_mgr.rs
+++ b/vs/src/event_mgr.rs
@@ -162,19 +162,12 @@ async fn set_services_all_nodes(
 
 async fn handle_policy_updated(asm: &Arc<Assembly>, vinst: u64) -> Result<(), ServiceError> {
     /*
-
     https://github.com/org-zpr/zpr-visaservice/issues/219
 
 
     When we get here we have already updated policy.
 
-    - are there any existing visas that need to be revoked.
-       - do we have the 5-tuple or whatever so that we can check them? NO, this is a TODO.
-
-    - check our existing topology.
-       - Are all the nodes and links still valid?
-
-    - request re-auth all nodes.
+    - TODO: request re-auth all nodes.
 
     - clear revocation list? May make more sense to keep it and make admin clear manually.
 
@@ -187,7 +180,6 @@ async fn handle_policy_updated(asm: &Arc<Assembly>, vinst: u64) -> Result<(), Se
     - all connected adapters.  Are they still allowed?
        - Well we could expire all the auth, but that seems drastic.
        - Instead we will have already killed visas. Probably ok to let them be connected but unable to do anything.
-
      */
 
     // Grab one consistent policy snapshot and use it for the entire synchronize-to-policy
@@ -265,6 +257,10 @@ async fn handle_policy_updated(asm: &Arc<Assembly>, vinst: u64) -> Result<(), Se
         }
     }
 
+    // Re-check existing visas against the new policy. Runs last so route checks
+    // and the nodes' own link state already reflect the updated topology.
+    revalidate_visas_against_policy(asm, &psnap).await;
+
     Ok(())
 }
 
@@ -328,18 +324,97 @@ async fn node_still_valid(asm: &Arc<Assembly>, ectx: &EvalContext, naddr: &IpAdd
     }
 }
 
+/// Sweep every live visa and re-evaluate it against the updated policy
+/// snapshot. Allowed visas get their `checked_vinst` bumped (and any queued
+/// revoke canceled); denied visas are marked `PendingRevoke` on all their nodes
+/// so VSS housekeeping revokes them.
+///
+/// A visa already checked at/after `target_vinst` is skipped. Visas whose
+/// actors can't be resolved are skipped (not revoked). A deny is only applied
+/// while `target_vinst` is still the live policy generation — otherwise a newer
+/// sweep is coming and will decide.
+async fn revalidate_visas_against_policy(asm: &Arc<Assembly>, psnap: &PolicySnapshot) {
+    let target_vinst = psnap.vinst();
+    let snapshot = asm.visa_mgr.list_visa_metadata().await;
+
+    // Some numbers for logging purposes.
+    let total = snapshot.len();
+    let mut allowed = 0u32;
+    let mut revoked = 0u32;
+    let mut skipped_stale = 0u32;
+    let mut skipped_unresolved = 0u32;
+
+    for (visa_id, metadata) in snapshot {
+        if metadata.checked_vinst >= target_vinst {
+            continue;
+        }
+        match asm
+            .visa_mgr
+            .recheck_visa_allowed(asm, &metadata, psnap)
+            .await
+        {
+            Ok(None) => {
+                skipped_unresolved += 1;
+                debug!(target: EVENT, "visa sweep: visa {visa_id} actor unresolved, skipping");
+            }
+            Ok(Some(true)) => match asm
+                .visa_mgr
+                .record_allow_verdict(visa_id, target_vinst)
+                .await
+            {
+                Ok(_) => allowed += 1,
+                Err(e) => {
+                    warn!(target: EVENT, "visa sweep: failed to record allow for visa {visa_id}: {e}")
+                }
+            },
+            Ok(Some(false)) => {
+                // Denied. Only apply while target_vinst is still the live policy;
+                // otherwise a newer sweep is coming and will make the decision.
+                if asm.policy_mgr.get_current_snapshot().vinst() != target_vinst {
+                    skipped_stale += 1;
+                    continue;
+                }
+                match asm
+                    .visa_mgr
+                    .record_deny_verdict(visa_id, target_vinst)
+                    .await
+                {
+                    Ok(_) => revoked += 1,
+                    Err(e) => {
+                        warn!(target: EVENT, "visa sweep: failed to record deny for visa {visa_id}: {e}")
+                    }
+                }
+            }
+            Err(e) => {
+                warn!(target: EVENT, "visa sweep: error re-checking visa {visa_id}: {e}");
+            }
+        }
+    }
+
+    // Note that this sweep just manipulates the desired state of the visas. The
+    // actual revocations happen asynchronously in VSS housekeeping.
+    info!(
+        target: EVENT,
+        "visa sweep vinst={target_vinst}: total={total} allowed={allowed} revoked={revoked} skipped_stale={skipped_stale} skipped_unresolved={skipped_unresolved}"
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use crate::assembly::tests::new_assembly_for_tests;
+    use crate::assembly::tests::{make_policy, new_assembly_for_tests};
     use crate::config;
-    use crate::test_helpers::{make_container_bytes, make_node_actor_defexp};
-
+    use crate::test_helpers::{
+        make_adapter_actor_defexp, make_container_bytes, make_node_actor_defexp,
+    };
     use libeval::attribute::{Attribute, key};
+    use libeval::eval_result::{Direction, Hit};
+    use libeval::route::{LinkId, Route};
     use std::time::Duration;
     use zpr::policy::v1 as capnp_policy;
     use zpr::policy_types::{JoinPolicy, PFlags, Scope, Service, ServiceType};
+    use zpr::vsapi_types::PacketDesc;
     use zpr::write_to::WriteTo;
 
     /// Build a policy container whose single join policy marks connections as
@@ -510,5 +585,177 @@ mod tests {
         let (valid, invalid) = revalidate_nodes(&asm, &psnap).await.unwrap();
         assert!(valid.is_empty());
         assert!(invalid.is_empty());
+    }
+
+    /// Build an assembly with two docked adapters (`::4000::a`/`::4000::b`) whose
+    /// nodes are in the topology. `with_link` controls whether a route exists.
+    /// The default (empty) policy denies everything (NoMatch), so with a route
+    /// present the eval still denies — either way the sweep sees a deny.
+    async fn build_sweep_asm(with_link: bool) -> (Arc<Assembly>, IpAddr) {
+        let asm = new_assembly_for_tests(None).await;
+        let node_a: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
+        let node_b: IpAddr = "fd5a:5052:3000::2".parse().unwrap();
+        asm.actor_mgr
+            .add_node(
+                &make_node_actor_defexp("fd5a:5052:3000::1", "na", "10.0.0.1:1"),
+                false,
+            )
+            .await
+            .unwrap();
+        asm.actor_mgr
+            .add_node(
+                &make_node_actor_defexp("fd5a:5052:3000::2", "nb", "10.0.0.2:2"),
+                false,
+            )
+            .await
+            .unwrap();
+        asm.topo_mgr.add_node(node_a).unwrap();
+        asm.topo_mgr.add_node(node_b).unwrap();
+        if with_link {
+            asm.topo_mgr
+                .add_link(node_a, node_b, LinkId("l".into()), vec![], 1)
+                .unwrap();
+        }
+        asm.actor_mgr
+            .add_adapter_via_node(
+                &make_adapter_actor_defexp("fd5a:5052:4000::a", "src"),
+                &node_a,
+            )
+            .await
+            .unwrap();
+        asm.actor_mgr
+            .add_adapter_via_node(
+                &make_adapter_actor_defexp("fd5a:5052:4000::b", "dst"),
+                &node_b,
+            )
+            .await
+            .unwrap();
+        (Arc::new(asm), node_a)
+    }
+
+    /// Create a single-node visa held (PendingInstall) by `req` for the given
+    /// five-tuple, seeded at `vinst`. Returns its id.
+    async fn create_sweep_visa(asm: &Arc<Assembly>, req: &IpAddr, vinst: u64) -> u64 {
+        let pdesc =
+            PacketDesc::new_tcp("fd5a:5052:4000::a", "fd5a:5052:4000::b", 1234, 80).unwrap();
+        let hit = Hit::new_no_signal(0, Direction::Forward);
+        let route = Route::new_direct((*req).into());
+        let vwmd = asm
+            .visa_mgr
+            .create_visa(asm, req, &pdesc, &hit, &route, "", 0, vinst)
+            .await
+            .unwrap();
+        vwmd.visa.issuer_id
+    }
+
+    /// A denied visa is marked PendingRevoke on its holder node (target policy
+    /// still live). Uses the no-route assembly so eval falls out as a deny.
+    #[tokio::test]
+    async fn test_sweep_denied_visa_marked_pending_revoke() {
+        let (asm, node_a) = build_sweep_asm(false).await;
+        let id = create_sweep_visa(&asm, &node_a, 0).await;
+
+        let psnap = asm.policy_mgr.get_current_snapshot();
+        assert!(
+            psnap.vinst() > 0,
+            "target must exceed the visa's checked_vinst"
+        );
+        revalidate_visas_against_policy(&asm, &psnap).await;
+
+        let revoke_ids = asm
+            .visa_mgr
+            .get_pending_revoke_visa_ids_for_node(&node_a)
+            .await
+            .unwrap();
+        assert_eq!(revoke_ids, vec![id]);
+    }
+
+    /// A visa already checked at/after target_vinst is skipped before re-eval:
+    /// even on the deny (no-route) assembly it is NOT marked PendingRevoke.
+    #[tokio::test]
+    async fn test_sweep_skips_already_checked() {
+        let (asm, node_a) = build_sweep_asm(false).await;
+        let target = asm.policy_mgr.get_current_snapshot().vinst();
+        // checked_vinst == target, so the guard skips before recheck.
+        let id = create_sweep_visa(&asm, &node_a, target).await;
+
+        let psnap = asm.policy_mgr.get_current_snapshot();
+        revalidate_visas_against_policy(&asm, &psnap).await;
+
+        assert!(
+            asm.visa_mgr
+                .get_pending_revoke_visa_ids_for_node(&node_a)
+                .await
+                .unwrap()
+                .is_empty(),
+            "already-checked visa must not be re-evaluated/revoked"
+        );
+        let pending = asm
+            .visa_mgr
+            .get_pending_visa_ids_for_node(&node_a)
+            .await
+            .unwrap();
+        assert_eq!(pending, vec![id]);
+    }
+
+    /// An unresolvable actor leaves the visa untouched (skipped, not revoked).
+    #[tokio::test]
+    async fn test_sweep_unresolved_actor_leaves_visa_untouched() {
+        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let node: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
+        // Five-tuple addrs (::4000::a/b) have no actors in the DB → unresolved.
+        let id = create_sweep_visa(&asm, &node, 0).await;
+
+        let psnap = asm.policy_mgr.get_current_snapshot();
+        revalidate_visas_against_policy(&asm, &psnap).await;
+
+        // Still held as PendingInstall (untouched); nothing marked for revoke.
+        let pending = asm
+            .visa_mgr
+            .get_pending_visa_ids_for_node(&node)
+            .await
+            .unwrap();
+        assert_eq!(pending, vec![id]);
+        assert!(
+            asm.visa_mgr
+                .get_pending_revoke_visa_ids_for_node(&node)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    /// A deny whose target vinst is no longer the live policy generation is
+    /// skipped (a newer sweep is coming): no revoke is marked.
+    #[tokio::test]
+    async fn test_sweep_denied_but_stale_target_skips() {
+        let (asm, node_a) = build_sweep_asm(false).await;
+        let id = create_sweep_visa(&asm, &node_a, 0).await;
+
+        // Snapshot the current (stale) generation, then bump the live policy so
+        // get_current_snapshot().vinst() moves past the snapshot's vinst.
+        let stale_psnap = asm.policy_mgr.get_current_snapshot();
+        asm.policy_mgr
+            .update_policy_from_container_bytes(make_policy("2024-01-02T00:00:00Z", 2, Some("m")))
+            .await
+            .unwrap();
+        assert!(asm.policy_mgr.get_current_snapshot().vinst() > stale_psnap.vinst());
+
+        revalidate_visas_against_policy(&asm, &stale_psnap).await;
+
+        // No revoke marked; the visa stays PendingInstall.
+        assert!(
+            asm.visa_mgr
+                .get_pending_revoke_visa_ids_for_node(&node_a)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        let pending = asm
+            .visa_mgr
+            .get_pending_visa_ids_for_node(&node_a)
+            .await
+            .unwrap();
+        assert_eq!(pending, vec![id]);
     }
 }

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -14,6 +14,7 @@ use crate::packet::make_fivetuple_tcp;
 use crate::policy_mgr::PolicySnapshot;
 use crate::visareq_worker::{
     PolicyOutcome, VisaDecision, evaluate_against_policy, request_visa_wait_response,
+    route_for_allow,
 };
 
 use libeval::eval_result::{Direction, Hit};
@@ -41,6 +42,38 @@ enum VCtx {
     Ingress,
     Intermediary,
     Egress,
+}
+
+/// Outcome of re-checking an existing visa against a newer policy snapshot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VisaRecheck {
+    /// An actor could not be resolved; skip without bumping `checked_vinst`.
+    SkipUnresolvedActor,
+    /// Still allowed and the selected route is unchanged.
+    AllowSameRoute,
+    /// Denied, or allowed but the selected route changed -- revoke.
+    Revoke,
+}
+
+/// Canonical forward-order (ingress→…→egress) node path for `route`, or `None`
+/// for a direct route. Mirrors exactly what `create_visa` stores in
+/// `metadata.path` so a re-derived path can be compared against a stored one.
+/// `starting_node` is the visa's `requesting_node`; a reverse hit traverses
+/// from the forward-egress node, so we reverse to restore forward orientation.
+fn canonical_path(
+    asm: &Assembly,
+    starting_node: &IpAddr,
+    route: &Route,
+    direction: Direction,
+) -> Result<Option<Vec<IpAddr>>, ServiceError> {
+    if !matches!(route.kind, libeval::route::RouteKind::Multihop) {
+        return Ok(None);
+    }
+    let mut node_id_path = asm.topo_mgr.route_to_path(route, &NodeId(*starting_node))?;
+    if direction == Direction::Reverse {
+        node_id_path.reverse();
+    }
+    Ok(Some(node_id_path.into_iter().map(|id| id.into()).collect()))
 }
 
 impl VisaWithMetadata {
@@ -366,21 +399,7 @@ impl VisaMgr {
 
         let visa_id = self.repo.get_next_visa_id().await?;
 
-        let path: Option<Vec<IpAddr>> = if matches!(route.kind, libeval::route::RouteKind::Multihop)
-        {
-            let starting_node = NodeId(*requesting_node);
-            let mut node_id_path = asm.topo_mgr.route_to_path(route, &starting_node)?;
-            // Normalize to canonical forward order (ingress→…→egress) so that
-            // actualize_visa_for_target_node applies direction logic correctly.
-            // A reverse hit starts traversal from the forward-egress node, so reversing
-            // restores forward orientation.
-            if hit.direction == Direction::Reverse {
-                node_id_path.reverse();
-            }
-            Some(node_id_path.into_iter().map(|id| id.into()).collect())
-        } else {
-            None
-        };
+        let path = canonical_path(asm, requesting_node, route, hit.direction)?;
 
         let mut metadata = db::VisaMetadata::new(
             requesting_node.clone(),
@@ -571,15 +590,21 @@ impl VisaMgr {
     /// is removed by policy.
     ///
     /// ### returns
-    /// - `Ok(None)` = an actor could not be resolved (skip, don't bump)
-    /// - `Ok(Some(true))` = allowed
-    /// - `Ok(Some(false))` = denied (this already folds in an undocked endpoint or missing route)
+    /// - `SkipUnresolvedActor` = an actor could not be resolved (skip, don't bump)
+    /// - `AllowSameRoute` = still allowed on the same route
+    /// - `Revoke` = denied, or allowed but the selected route changed. Denial
+    ///   already folds in an undocked endpoint or missing route.
+    ///
+    /// A still-allowed visa whose newly-selected route differs from the stored
+    /// `metadata.path` is treated as a revoke: rather than migrate a single visa
+    /// id between paths in place, we revoke it and let the next actor comm
+    /// install a fresh visa on the current route.
     pub async fn recheck_visa_allowed(
         &self,
         asm: &Assembly,
         metadata: &VisaMetadata,
         psnap: &PolicySnapshot,
-    ) -> Result<Option<bool>, ServiceError> {
+    ) -> Result<VisaRecheck, ServiceError> {
         // TODO: comm_flags is not persisted; for now default to BiDirectional.
         let pkt = PacketDesc {
             five_tuple: metadata.five_tuple.clone(),
@@ -592,13 +617,31 @@ impl VisaMgr {
             asm.actor_mgr.get_actor_by_zpr_addr(&src_zpr).await,
             asm.actor_mgr.get_actor_by_zpr_addr(&dst_zpr).await,
         ) else {
-            return Ok(None);
+            return Ok(VisaRecheck::SkipUnresolvedActor);
         };
 
         let policy = psnap.policy_arc();
-        match evaluate_against_policy(asm, &src, &dst, &src_zpr, &dst_zpr, &pkt, &policy).await? {
-            PolicyOutcome::Allow { .. } => Ok(Some(true)),
-            PolicyOutcome::Deny(_) => Ok(Some(false)),
+        let (hits, default_route) =
+            match evaluate_against_policy(asm, &src, &dst, &src_zpr, &dst_zpr, &pkt, &policy)
+                .await?
+            {
+                PolicyOutcome::Allow {
+                    hits,
+                    default_route,
+                } => (hits, default_route),
+                PolicyOutcome::Deny(_) => return Ok(VisaRecheck::Revoke),
+            };
+
+        // Still allowed: revoke iff the newly-selected route differs from the
+        // stored path. Derive the new path exactly as create_visa did so the
+        // comparison is apples-to-apples.
+        let route = route_for_allow(&hits, default_route)?;
+        match canonical_path(asm, &metadata.requesting_node, &route, hits[0].direction) {
+            Ok(new_path) if new_path == metadata.path => Ok(VisaRecheck::AllowSameRoute),
+            Ok(_) => Ok(VisaRecheck::Revoke),
+            // The old requesting node is no longer on the new route (topology
+            // moved under us) -- the route definitely changed, so revoke.
+            Err(_) => Ok(VisaRecheck::Revoke),
         }
     }
 
@@ -1450,7 +1493,7 @@ mod tests {
         assert!(mgr.visa_has_node_refs(811).await);
     }
 
-    /// recheck_visa_allowed returns None (skip) when an actor cannot be resolved.
+    /// recheck_visa_allowed skips when an actor cannot be resolved.
     #[tokio::test]
     async fn test_recheck_visa_allowed_unresolved_actor_skips() {
         let asm = Arc::new(new_assembly_for_tests(None).await);
@@ -1469,10 +1512,10 @@ mod tests {
             .recheck_visa_allowed(&asm, &md, &psnap)
             .await
             .unwrap();
-        assert_eq!(res, None);
+        assert_eq!(res, VisaRecheck::SkipUnresolvedActor);
     }
 
-    /// recheck_visa_allowed returns Some(false) when both actors resolve and dock
+    /// recheck_visa_allowed returns Revoke when both actors resolve and dock
     /// but there is no route between their nodes (the sweep would revoke).
     #[tokio::test]
     async fn test_recheck_visa_allowed_no_route_denies() {
@@ -1526,7 +1569,73 @@ mod tests {
             .recheck_visa_allowed(&asm, &md, &psnap)
             .await
             .unwrap();
-        assert_eq!(res, Some(false));
+        assert_eq!(res, VisaRecheck::Revoke);
+    }
+
+    /// canonical_path returns None for a direct (same-node) route in either
+    /// direction -- a direct visa stores `path = None`, so recheck compares
+    /// None == None and stays AllowSameRoute.
+    #[tokio::test]
+    async fn test_canonical_path_direct_is_none() {
+        let asm = new_assembly_for_tests(None).await;
+        let a: IpAddr = "fd5a:5052::1".parse().unwrap();
+        asm.topo_mgr.add_node(a).unwrap();
+        let route = asm.topo_mgr.get_best_route(&a, &a).unwrap();
+        assert_eq!(
+            canonical_path(&asm, &a, &route, Direction::Forward).unwrap(),
+            None
+        );
+        assert_eq!(
+            canonical_path(&asm, &a, &route, Direction::Reverse).unwrap(),
+            None
+        );
+    }
+
+    /// canonical_path yields the forward node order from the requesting node, and
+    /// a reverse hit flips it -- both are deterministic in (requesting_node,
+    /// direction), which is exactly why a re-derived path compares equal to the
+    /// one create_visa stored (same helper, same inputs).
+    #[tokio::test]
+    async fn test_canonical_path_multihop_forward_and_reverse() {
+        let asm = new_assembly_for_tests(None).await;
+        let a: IpAddr = "fd5a:5052::1".parse().unwrap();
+        let b: IpAddr = "fd5a:5052::2".parse().unwrap();
+        let c: IpAddr = "fd5a:5052::3".parse().unwrap();
+        for n in [a, b, c] {
+            asm.topo_mgr.add_node(n).unwrap();
+        }
+        asm.topo_mgr
+            .add_link(a, b, LinkId("ab".into()), vec![], 1)
+            .unwrap();
+        asm.topo_mgr
+            .add_link(b, c, LinkId("bc".into()), vec![], 1)
+            .unwrap();
+        let route = asm.topo_mgr.get_best_route(&a, &c).unwrap();
+        assert_eq!(
+            canonical_path(&asm, &a, &route, Direction::Forward).unwrap(),
+            Some(vec![a, b, c])
+        );
+        assert_eq!(
+            canonical_path(&asm, &a, &route, Direction::Reverse).unwrap(),
+            Some(vec![c, b, a])
+        );
+    }
+
+    /// canonical_path errors when the visa's requesting node is no longer on the
+    /// route (topology moved under us); recheck maps that Err to Revoke.
+    #[tokio::test]
+    async fn test_canonical_path_bogus_start_errors() {
+        let asm = new_assembly_for_tests(None).await;
+        let a: IpAddr = "fd5a:5052::1".parse().unwrap();
+        let b: IpAddr = "fd5a:5052::2".parse().unwrap();
+        asm.topo_mgr.add_node(a).unwrap();
+        asm.topo_mgr.add_node(b).unwrap();
+        asm.topo_mgr
+            .add_link(a, b, LinkId("ab".into()), vec![], 1)
+            .unwrap();
+        let route = asm.topo_mgr.get_best_route(&a, &b).unwrap();
+        let bogus: IpAddr = "fd5a:5052::99".parse().unwrap();
+        assert!(canonical_path(&asm, &bogus, &route, Direction::Forward).is_err());
     }
 
     /// An adapter leaving while its node stays up: the visa on the live node is

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -566,6 +566,10 @@ impl VisaMgr {
     /// the packet from the stored five-tuple, resolves both actors, and
     /// delegates the eval to the shared `evaluate_against_policy` function.
     ///
+    /// Note that AAA-related visas are not re-evaluated by this function.
+    /// TODO: Possibly needs more thought for how to deal with cases where an auth service
+    /// is removed by policy.
+    ///
     /// ### returns
     /// - `Ok(None)` = an actor could not be resolved (skip, don't bump)
     /// - `Ok(Some(true))` = allowed
@@ -649,6 +653,14 @@ impl VisaMgr {
         Ok(visa_ids)
     }
 
+    /// Live visa IDs referencing any of the given actor endpoint addresses.
+    pub async fn get_visa_ids_for_actors(
+        &self,
+        actor_addrs: &[IpAddr],
+    ) -> Result<Vec<u64>, ServiceError> {
+        Ok(self.repo.get_visa_ids_for_actors(actor_addrs)?)
+    }
+
     /// Shorthand and slightly more race-condition safe way of calling `get_visa_by_id` and `get_visa_metadata_by_id`.
     /// Returns None if either the visa or the metadata is not found.
     pub async fn get_visa_with_metadata_by_id(
@@ -668,6 +680,7 @@ impl VisaMgr {
 
     /// Get just the visa (no metadata) using the visa ID.
     /// Returns None if not found.
+    #[allow(dead_code)]
     pub async fn get_visa_by_id(&self, visa_id: u64) -> Result<Option<Visa>, ServiceError> {
         match self.repo.get_visa_by_id(visa_id) {
             Ok(visa) => Ok(Some(visa)),

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -11,7 +11,10 @@ use crate::db::VisaMetadata;
 use crate::error::{ServiceError, StoreError};
 use crate::logging::targets::VISA;
 use crate::packet::make_fivetuple_tcp;
-use crate::visareq_worker::{VisaDecision, request_visa_wait_response};
+use crate::policy_mgr::PolicySnapshot;
+use crate::visareq_worker::{
+    PolicyOutcome, VisaDecision, evaluate_against_policy, request_visa_wait_response,
+};
 
 use libeval::eval_result::{Direction, Hit};
 use libeval::route::{NodeId, Route};
@@ -468,16 +471,131 @@ impl VisaMgr {
         Ok(pending_revokes)
     }
 
-    /// Register that visa `visa_id` has been installed on node at ZPR address `node_addr`.
+    /// Register that visa `visa_id` has been installed on node at ZPR address
+    /// `node_addr`.
+    ///
+    /// This is a CAS (Compare And Swap) `PendingInstall -> Installed`: if the
+    /// check-all-visas-due-to-new-policy sweep marked the node `PendingRevoke`
+    /// while the push RPC was in flight the transition misses and we leave the
+    /// state... so PendingRevoke wins, and housekeeping sends the revoke.
     pub async fn visa_installed(
         &self,
         visa_id: u64,
         node_addr: &IpAddr,
     ) -> Result<(), ServiceError> {
-        self.repo
-            .update_node_visa_state(node_addr, visa_id, db::NodeVisaState::Installed)
+        let applied = self
+            .repo
+            .transition_node_visa_state(
+                *node_addr,
+                visa_id,
+                db::NodeVisaState::PendingInstall,
+                db::NodeVisaState::Installed,
+            )
             .await?;
+        if !applied {
+            debug!(target: VISA, "visa {visa_id} install ack for node {node_addr} did not apply (not PendingInstall); leaving state");
+        }
         Ok(())
+    }
+
+    /// Snapshot of `(visa_id, metadata)` for all live visas — for the sweep.
+    pub async fn list_visa_metadata(&self) -> Vec<(u64, VisaMetadata)> {
+        self.repo.list_visa_metadata().await
+    }
+
+    /// Apply an allow verdict to a visa at policy generation `vinst`. See [db::VisaRepo::record_allow_verdict].
+    pub async fn record_allow_verdict(
+        &self,
+        visa_id: u64,
+        vinst: u64,
+    ) -> Result<bool, ServiceError> {
+        Ok(self.repo.record_allow_verdict(visa_id, vinst).await?)
+    }
+
+    /// Apply a deny verdict to a visa at policy generation `vinst`. See [db::VisaRepo::record_deny_verdict].
+    pub async fn record_deny_verdict(
+        &self,
+        visa_id: u64,
+        vinst: u64,
+    ) -> Result<bool, ServiceError> {
+        Ok(self.repo.record_deny_verdict(visa_id, vinst).await?)
+    }
+
+    /// Remove a visa entirely (Redis + memory). See [db::VisaRepo::remove_visa].
+    pub async fn remove_visa(&self, visa_id: u64) -> Result<(), ServiceError> {
+        self.repo.remove_visa(visa_id).await?;
+        Ok(())
+    }
+
+    /// Check whether a live visa still references any node.
+    pub async fn visa_has_node_refs(&self, visa_id: u64) -> bool {
+        self.repo.visa_has_node_refs(visa_id).await
+    }
+
+    /// The visa IDs for a node currently marked `PendingRevoke`.
+    pub async fn get_pending_revoke_visa_ids_for_node(
+        &self,
+        node_addr: &IpAddr,
+    ) -> Result<Vec<u64>, ServiceError> {
+        let ids = self
+            .repo
+            .get_visa_ids_for_node_by_state(node_addr, db::NodeVisaState::PendingRevoke)?;
+        Ok(ids)
+    }
+
+    /// Post-ack VSS revoke teardown, keeping the two-step ordering in one place: drop
+    /// the node from the record if it is still `PendingRevoke`, then remove the
+    /// whole visa once no node references remain.
+    pub async fn revoke_acked(&self, node_addr: IpAddr, visa_id: u64) {
+        if let Err(e) = self
+            .repo
+            .remove_node_if_pending_revoke(node_addr, visa_id)
+            .await
+        {
+            warn!(target: VISA, "error tearing down revoked node {node_addr} on visa {visa_id}: {e}");
+            return;
+        }
+        if !self.visa_has_node_refs(visa_id).await {
+            if let Err(e) = self.remove_visa(visa_id).await {
+                warn!(target: VISA, "error removing orphaned visa {visa_id}: {e}");
+            }
+        }
+    }
+
+    /// Re-evaluate an existing visa against the given policy snapshot. Rebuilds
+    /// the packet from the stored five-tuple, resolves both actors, and
+    /// delegates the eval to the shared `evaluate_against_policy` function.
+    ///
+    /// ### returns
+    /// - `Ok(None)` = an actor could not be resolved (skip, don't bump)
+    /// - `Ok(Some(true))` = allowed
+    /// - `Ok(Some(false))` = denied (this already folds in an undocked endpoint or missing route)
+    pub async fn recheck_visa_allowed(
+        &self,
+        asm: &Assembly,
+        metadata: &VisaMetadata,
+        psnap: &PolicySnapshot,
+    ) -> Result<Option<bool>, ServiceError> {
+        // TODO: comm_flags is not persisted; for now default to BiDirectional.
+        let pkt = PacketDesc {
+            five_tuple: metadata.five_tuple.clone(),
+            comm_flags: CommFlag::BiDirectional,
+        };
+        let src_zpr = metadata.five_tuple.source_addr;
+        let dst_zpr = metadata.five_tuple.dest_addr;
+
+        let (Ok(Some(src)), Ok(Some(dst))) = (
+            asm.actor_mgr.get_actor_by_zpr_addr(&src_zpr).await,
+            asm.actor_mgr.get_actor_by_zpr_addr(&dst_zpr).await,
+        ) else {
+            return Ok(None);
+        };
+
+        let policy = psnap.policy_arc();
+        match evaluate_against_policy(asm, &src, &dst, &src_zpr, &dst_zpr, &pkt, &policy).await? {
+            PolicyOutcome::Allow { .. } => Ok(Some(true)),
+            PolicyOutcome::Deny(_) => Ok(Some(false)),
+        }
     }
 
     /// Designed to be used to setup database in clean state as we prepare for a
@@ -614,7 +732,9 @@ mod tests {
     use super::*;
     use crate::db::{FakeDb, VisaRepo};
     use crate::packet::make_fivetuple_tcp;
-    use crate::test_helpers::{make_pdesc, make_visa};
+    use crate::test_helpers::{
+        make_adapter_actor_defexp, make_node_actor_defexp, make_pdesc, make_visa,
+    };
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -1207,5 +1327,147 @@ mod tests {
         // The egress node dst is not the target here, so this just confirms the visa
         // was created for the right endpoints.
         let _ = dst;
+    }
+
+    // --- Phase 2 manager tests ---
+
+    /// Store a single-node visa in the given state via the repo.
+    async fn store_node_visa(mgr: &VisaMgr, id: u64, node: IpAddr, state: db::NodeVisaState) {
+        let visa = make_visa(id, Duration::from_secs(60));
+        let md = db::VisaMetadata::new(
+            node,
+            0,
+            0,
+            String::new(),
+            Direction::Forward,
+            None,
+            &make_pdesc(),
+        );
+        mgr.repo.store_visa(&visa, md, state).await.unwrap();
+    }
+
+    /// visa_installed is a CAS: once the node is PendingRevoke (sweep denied it
+    /// mid-push), the install ack does not apply — PendingRevoke wins.
+    #[tokio::test]
+    async fn test_visa_installed_loses_to_pending_revoke() {
+        let mgr = make_mgr().await;
+        let node: IpAddr = NODE_ADDR.parse().unwrap();
+        store_node_visa(&mgr, 800, node, db::NodeVisaState::PendingInstall).await;
+        assert!(mgr.repo.record_deny_verdict(800, 1).await.unwrap());
+
+        mgr.visa_installed(800, &node).await.unwrap();
+
+        let revoke_ids = mgr
+            .repo
+            .get_visa_ids_for_node_by_state(&node, db::NodeVisaState::PendingRevoke)
+            .unwrap();
+        assert_eq!(revoke_ids, vec![800]);
+    }
+
+    /// revoke_acked drops the node ref and then removes the now-orphaned visa.
+    #[tokio::test]
+    async fn test_revoke_acked_removes_node_then_orphan_visa() {
+        let mgr = make_mgr().await;
+        let node: IpAddr = NODE_ADDR.parse().unwrap();
+        store_node_visa(&mgr, 810, node, db::NodeVisaState::Installed).await;
+        assert!(mgr.repo.record_deny_verdict(810, 1).await.unwrap());
+
+        mgr.revoke_acked(node, 810).await;
+
+        assert!(!mgr.visa_has_node_refs(810).await);
+        assert!(mgr.repo.get_visa_by_id(810).is_err());
+    }
+
+    /// revoke_acked misses when the node is not PendingRevoke (an allow verdict
+    /// canceled the revoke mid-RPC): the record survives.
+    #[tokio::test]
+    async fn test_revoke_acked_leaves_record_when_not_pending_revoke() {
+        let mgr = make_mgr().await;
+        let node: IpAddr = NODE_ADDR.parse().unwrap();
+        store_node_visa(&mgr, 811, node, db::NodeVisaState::Installed).await;
+
+        mgr.revoke_acked(node, 811).await;
+
+        assert!(mgr.repo.get_visa_by_id(811).is_ok());
+        assert!(mgr.visa_has_node_refs(811).await);
+    }
+
+    /// recheck_visa_allowed returns None (skip) when an actor cannot be resolved.
+    #[tokio::test]
+    async fn test_recheck_visa_allowed_unresolved_actor_skips() {
+        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let md = db::VisaMetadata::new(
+            "fd5a:5052::10".parse().unwrap(),
+            0,
+            0,
+            String::new(),
+            Direction::Forward,
+            None,
+            &make_pdesc(),
+        );
+        let psnap = asm.policy_mgr.get_current_snapshot();
+        let res = asm
+            .visa_mgr
+            .recheck_visa_allowed(&asm, &md, &psnap)
+            .await
+            .unwrap();
+        assert_eq!(res, None);
+    }
+
+    /// recheck_visa_allowed returns Some(false) when both actors resolve and dock
+    /// but there is no route between their nodes (the sweep would revoke).
+    #[tokio::test]
+    async fn test_recheck_visa_allowed_no_route_denies() {
+        let asm = new_assembly_for_tests(None).await;
+        let node_a: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
+        let node_b: IpAddr = "fd5a:5052:3000::2".parse().unwrap();
+        asm.actor_mgr
+            .add_node(
+                &make_node_actor_defexp("fd5a:5052:3000::1", "na", "10.0.0.1:1"),
+                false,
+            )
+            .await
+            .unwrap();
+        asm.actor_mgr
+            .add_node(
+                &make_node_actor_defexp("fd5a:5052:3000::2", "nb", "10.0.0.2:2"),
+                false,
+            )
+            .await
+            .unwrap();
+        asm.topo_mgr.add_node(node_a).unwrap();
+        asm.topo_mgr.add_node(node_b).unwrap();
+        // No link between the nodes → no route.
+
+        let src_adapter = make_adapter_actor_defexp("fd5a:5052:4000::a", "src");
+        let dst_adapter = make_adapter_actor_defexp("fd5a:5052:4000::b", "dst");
+        asm.actor_mgr
+            .add_adapter_via_node(&src_adapter, &node_a)
+            .await
+            .unwrap();
+        asm.actor_mgr
+            .add_adapter_via_node(&dst_adapter, &node_b)
+            .await
+            .unwrap();
+
+        let asm = Arc::new(asm);
+        let pdesc =
+            PacketDesc::new_tcp("fd5a:5052:4000::a", "fd5a:5052:4000::b", 1234, 443).unwrap();
+        let md = db::VisaMetadata::new(
+            node_a,
+            0,
+            0,
+            String::new(),
+            Direction::Forward,
+            None,
+            &pdesc,
+        );
+        let psnap = asm.policy_mgr.get_current_snapshot();
+        let res = asm
+            .visa_mgr
+            .recheck_visa_allowed(&asm, &md, &psnap)
+            .await
+            .unwrap();
+        assert_eq!(res, Some(false));
     }
 }

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -611,33 +611,78 @@ impl VisaMgr {
 
     /// Remove all visas tied to the given node -- assumes that `node_addr` has departed.
     ///
-    /// TODO: This probably needs a lock on the node address -- like we do not
-    /// want the same node to be reconnecting while we are doing this clean up.
+    /// The node is gone, so for every visa it participates in we mark all as
+    /// `PendingRevoke` (VSS housekeeping revokes the visa from the OTHER, live
+    /// nodes -- including where the departed node was only a multihop
+    /// intermediary), then force-drop the departed node's own refs (it can never
+    /// ack a revoke), then remove any visa left with no node refs.
     ///
-    /// TODO: Sometimes we want to keep track of visas installed on nodes so that
-    /// nodes could restart and we can then just push them state.  TBD.
+    /// TODO: This probably needs a lock on the node address -- we do not want the
+    /// same node reconnecting while this clean-up runs.
     ///
-    /// For each visa that is marked installed or pending-install on the node,
-    /// collect the ID.  Then wipe all the nodevisa records for the node.
-    ///
-    /// Now we have a bunch of visa IDs. For each ID, if the visa is installed
-    /// or pending on some other node, update the state on that node to pending-revoke
-    /// and then remove the visa:ID record.
-    ///
-    /// The housekeeping job will take care of updating the TODO lists and sending
-    /// the revocation messages out to the other nodes.
-    ///
+    /// TODO (reconnect-with-state): this wipes the node's visa state outright. We
+    /// have NOT yet worked out how that interacts with a node reconnecting and
+    /// expecting us to re-push its previously-installed visas rather than making
+    /// it re-request everything. When that story is settled this teardown likely
+    /// needs to preserve or snapshot state instead of dropping it. TBD.
     pub async fn remove_visas_for_node(&self, node_addr: &IpAddr) -> Result<(), ServiceError> {
-        info!(target: VISA, "TODO: remove visas for node {node_addr}");
+        // Capture the referencing visas before clear_node_state unindexes the node.
+        let ids = self.repo.get_all_visa_ids_for_node(node_addr)?;
+
+        // 1. Revoke each from the other nodes still holding it. Log-and-continue
+        //    so one failure can't strand the rest.
+        for &id in &ids {
+            if let Err(e) = self.repo.mark_visa_revoked(id).await {
+                warn!(target: VISA, "failed to mark visa {id} revoked for departed node {node_addr}: {e}");
+            }
+        }
+
+        // 2. Force-drop the departed node's own refs in one atomic pass (no RPC).
+        self.repo.clear_node_state(node_addr).await?;
+
+        // 3. Remove any visa now orphaned (no node refs) rather than wait for TTL.
+        for id in ids {
+            if !self.visa_has_node_refs(id).await {
+                if let Err(e) = self.remove_visa(id).await {
+                    warn!(target: VISA, "failed to remove orphaned visa {id}: {e}");
+                }
+            }
+        }
         Ok(())
     }
 
     /// Remove all visas tied to the listed actors, assumes the actors have departed.
+    ///
+    /// For each visa with a departed endpoint we mark every node `PendingRevoke`
+    /// so VSS housekeeping revokes it from the nodes still holding it, then
+    /// removes the visa on ack. A visa left with no node refs (its only node was
+    /// already cleared by `remove_visas_for_node`) is dropped here instead of
+    /// waiting for TTL.
+    ///
     pub async fn remove_visas_for_actors(
         &self,
-        _actor_addrs: &[IpAddr],
+        actor_addrs: &[IpAddr],
     ) -> Result<(), ServiceError> {
-        info!(target: VISA, "TODO: remove visas for actors now removed");
+        if actor_addrs.is_empty() {
+            return Ok(());
+        }
+        for id in self.get_visa_ids_for_actors(actor_addrs).await? {
+            // Log-and-continue: one failure must not strand the remaining visas.
+            match self.repo.mark_visa_revoked(id).await {
+                Ok(true) => {}
+                Ok(false) => continue, // vanished/expired between query and mark
+                Err(e) => {
+                    warn!(target: VISA, "failed to mark visa {id} revoked for departed actor: {e}");
+                    continue;
+                }
+            }
+            // No node left to revoke to (purely-local visa already cleared) -> drop now.
+            if !self.visa_has_node_refs(id).await {
+                if let Err(e) = self.remove_visa(id).await {
+                    warn!(target: VISA, "failed to remove orphaned visa {id}: {e}");
+                }
+            }
+        }
         Ok(())
     }
 
@@ -1482,5 +1527,125 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(res, Some(false));
+    }
+
+    /// An adapter leaving while its node stays up: the visa on the live node is
+    /// marked PendingRevoke and left in place (awaiting the revoke ack).
+    #[tokio::test]
+    async fn test_remove_visas_for_actors_marks_live_node_pending_revoke() {
+        let mgr = make_mgr().await;
+        let node: IpAddr = NODE_ADDR.parse().unwrap();
+        let src: IpAddr = SRC_ADDR.parse().unwrap();
+        store_node_visa(&mgr, 900, node, db::NodeVisaState::Installed).await;
+
+        mgr.remove_visas_for_actors(&[src]).await.unwrap();
+
+        let revoke_ids = mgr
+            .repo
+            .get_visa_ids_for_node_by_state(&node, db::NodeVisaState::PendingRevoke)
+            .unwrap();
+        assert_eq!(revoke_ids, vec![900]);
+        // Visa still present -- housekeeping removes it on ack.
+        assert!(mgr.repo.get_visa_by_id(900).is_ok());
+    }
+
+    /// A visa whose only node was already cleared (no refs left) is dropped
+    /// outright rather than waiting for TTL.
+    #[tokio::test]
+    async fn test_remove_visas_for_actors_drops_orphan() {
+        let mgr = make_mgr().await;
+        let node: IpAddr = NODE_ADDR.parse().unwrap();
+        let src: IpAddr = SRC_ADDR.parse().unwrap();
+        store_node_visa(&mgr, 910, node, db::NodeVisaState::Installed).await;
+        // Simulate remove_visas_for_node having cleared the node's only ref.
+        mgr.clear_node_state(&node).await.unwrap();
+        assert!(!mgr.visa_has_node_refs(910).await);
+
+        mgr.remove_visas_for_actors(&[src]).await.unwrap();
+
+        assert!(mgr.repo.get_visa_by_id(910).is_err());
+    }
+
+    /// Empty actor list, and an actor with no visas, are both no-ops.
+    #[tokio::test]
+    async fn test_remove_visas_for_actors_noops() {
+        let mgr = make_mgr().await;
+        mgr.remove_visas_for_actors(&[]).await.unwrap();
+        let unknown: IpAddr = "fd5a:5052::dead".parse().unwrap();
+        mgr.remove_visas_for_actors(&[unknown]).await.unwrap();
+    }
+
+    /// Store a visa across the path [a, b, c] (a is the requesting node, Installed;
+    /// b and c PendingInstall).
+    async fn store_multihop_visa(mgr: &VisaMgr, id: u64, a: IpAddr, b: IpAddr, c: IpAddr) {
+        let visa = make_visa(id, Duration::from_secs(60));
+        let md = db::VisaMetadata::new(
+            a,
+            0,
+            0,
+            String::new(),
+            Direction::Forward,
+            Some(vec![a, b, c]),
+            &make_pdesc(),
+        );
+        mgr.repo
+            .store_visa(&visa, md, db::NodeVisaState::Installed)
+            .await
+            .unwrap();
+    }
+
+    /// Multihop [A, B, C] visa; intermediary B departs. The visa's other nodes go
+    /// PendingRevoke, B is no longer referenced, and the visa survives (awaiting
+    /// the revoke acks from A and C).
+    #[tokio::test]
+    async fn test_remove_visas_for_node_multihop_revokes_others() {
+        let mgr = make_mgr().await;
+        let a: IpAddr = "fd5a:5052::a".parse().unwrap();
+        let b: IpAddr = "fd5a:5052::b".parse().unwrap();
+        let c: IpAddr = "fd5a:5052::c".parse().unwrap();
+        store_multihop_visa(&mgr, 1000, a, b, c).await;
+
+        mgr.remove_visas_for_node(&b).await.unwrap();
+
+        // B no longer referenced.
+        assert!(mgr.repo.get_all_visa_ids_for_node(&b).unwrap().is_empty());
+        // A and C queued for revoke.
+        for n in [a, c] {
+            assert_eq!(
+                mgr.repo
+                    .get_visa_ids_for_node_by_state(&n, db::NodeVisaState::PendingRevoke)
+                    .unwrap(),
+                vec![1000]
+            );
+        }
+        // Visa still present -- housekeeping removes it on ack.
+        assert!(mgr.repo.get_visa_by_id(1000).is_ok());
+    }
+
+    /// A visa referencing only the departed node is captured (snapshot before
+    /// clear) and removed outright once its sole ref is dropped.
+    #[tokio::test]
+    async fn test_remove_visas_for_node_drops_sole_ref_orphan() {
+        let mgr = make_mgr().await;
+        let node: IpAddr = NODE_ADDR.parse().unwrap();
+        store_node_visa(&mgr, 1010, node, db::NodeVisaState::Installed).await;
+
+        mgr.remove_visas_for_node(&node).await.unwrap();
+
+        assert!(
+            mgr.repo
+                .get_all_visa_ids_for_node(&node)
+                .unwrap()
+                .is_empty()
+        );
+        assert!(mgr.repo.get_visa_by_id(1010).is_err());
+    }
+
+    /// A node with no visas is a no-op.
+    #[tokio::test]
+    async fn test_remove_visas_for_node_noop() {
+        let mgr = make_mgr().await;
+        let node: IpAddr = "fd5a:5052::beef".parse().unwrap();
+        mgr.remove_visas_for_node(&node).await.unwrap();
     }
 }

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -50,6 +50,19 @@ pub enum VisaDecision {
     Deny(DenyCode),
 }
 
+/// Outcome of running resolved actors and a packet through policy (docking-node
+/// resolution, routing, and eval). Shared by the request path and the
+/// policy-update visa sweep so both run identical policy logic.
+pub(crate) enum PolicyOutcome {
+    // default_route: None => route came from the hit (NeedsRoute-allow);
+    // Some(best) => the AllowWithoutRoute case.
+    Allow {
+        hits: Vec<Hit>,
+        default_route: Option<Route>,
+    },
+    Deny(DenyCode),
+}
+
 /// The result is either a [Visa], or a regular denial, or there was an unexpected failure
 /// and you get a [ServiceError].
 pub type VisaRequestResult = Result<VisaDecision, ServiceError>;
@@ -224,108 +237,104 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
         return Ok(VisaDecision::Deny(DenyCode::DestNotFound));
     };
 
-    // Find the docking nodes for each actor. For AAA actors (unauthenticated adapters
-    // fabricated during anonymous auth), the docking node is looked up from the AAA table
-    // registered on the request side, rather than from the connection table.
-    let node_addr_a = match asm.actor_mgr.get_docking_node_for_actor(&source_actor) {
-        Some(node_addr) => node_addr,
-        None => match asm.actor_mgr.get_docking_node_for_aaa(source_zpr_addr) {
-            Some(node_addr) => node_addr,
-            None => {
-                warn!(target: VREQ,
-                    "visa request from {:?} denied: source actor {:?} is not docked to any node",
-                    job.requesting_node, source_actor
-                );
-                return Ok(VisaDecision::Deny(DenyCode::SourceNotFound));
-            }
-        },
+    // Docking-node resolution, routing, and policy eval all live in the shared
+    // core (used by the Phase 2 sweep too). Actor resolution above stays
+    // per-caller — the request path fabricates AAA and denies on missing.
+    let policy = asm.policy_mgr.get_current();
+    let outcome = evaluate_against_policy(
+        &asm,
+        &source_actor,
+        &dest_actor,
+        source_zpr_addr,
+        dest_zpr_addr,
+        &job.packet_desc,
+        &policy,
+    )
+    .await?;
+
+    match outcome {
+        PolicyOutcome::Allow {
+            hits,
+            default_route,
+        } => visa_from_allow(asm.clone(), job, &hits, &policy, default_route).await,
+        PolicyOutcome::Deny(code) => Ok(VisaDecision::Deny(code)),
+    }
+}
+
+/// Resolve an actor's docking node: the connection-table entry, falling back to
+/// the AAA table for fabricated anonymous actors. `None` means undocked.
+pub(crate) fn resolve_docking_node(
+    asm: &Assembly,
+    actor: &Actor,
+    zpr_addr: &IpAddr,
+) -> Option<IpAddr> {
+    asm.actor_mgr
+        .get_docking_node_for_actor(actor)
+        .or_else(|| asm.actor_mgr.get_docking_node_for_aaa(zpr_addr))
+}
+
+/// Shared policy-evaluation core: resolve both docking nodes, require a route,
+/// then run the actors and packet through the policy (handling `NeedsRoute` route
+/// evaluation). An undocked endpoint or no best route falls out as `Deny`.
+pub(crate) async fn evaluate_against_policy(
+    asm: &Assembly,
+    src: &Actor,
+    dst: &Actor,
+    src_zpr: &IpAddr,
+    dst_zpr: &IpAddr,
+    pkt: &PacketDesc,
+    policy: &Arc<Policy>,
+) -> Result<PolicyOutcome, ServiceError> {
+    // For AAA actors the docking node comes from the AAA table registered on the
+    // request side rather than the connection table.
+    let Some(node_addr_a) = resolve_docking_node(asm, src, src_zpr) else {
+        warn!(target: VREQ, "eval denied: source actor {src:?} is not docked to any node");
+        return Ok(PolicyOutcome::Deny(DenyCode::SourceNotFound));
     };
-    let node_addr_b = match asm.actor_mgr.get_docking_node_for_actor(&dest_actor) {
-        Some(node_addr) => node_addr,
-        None => match asm.actor_mgr.get_docking_node_for_aaa(dest_zpr_addr) {
-            Some(node_addr) => node_addr,
-            None => {
-                warn!(target: VREQ,
-                    "visa request from {:?} denied: dest actor {:?} is not docked to any node",
-                    job.requesting_node, dest_actor
-                );
-                return Ok(VisaDecision::Deny(DenyCode::DestNotFound));
-            }
-        },
+    let Some(node_addr_b) = resolve_docking_node(asm, dst, dst_zpr) else {
+        warn!(target: VREQ, "eval denied: dest actor {dst:?} is not docked to any node");
+        return Ok(PolicyOutcome::Deny(DenyCode::DestNotFound));
     };
 
     // When the evaluator does not care about the route, we use the "best" route.
     // And if there is no route at all then we don't bother evaluating.
     let Some(default_route) = asm.topo_mgr.get_best_route(&node_addr_a, &node_addr_b) else {
-        info!(target: VREQ,
-            "visa request from {:?} denied: no route between {:?} and {:?}",
-            job.requesting_node, node_addr_a, node_addr_b
-        );
-        return Ok(VisaDecision::Deny(DenyCode::NoRoute));
+        info!(target: VREQ, "eval denied: no route between {node_addr_a:?} and {node_addr_b:?}");
+        return Ok(PolicyOutcome::Deny(DenyCode::NoRoute));
     };
 
-    let policy = asm.policy_mgr.get_current();
     let ctx = EvalContext::new(policy.clone());
-    let decision = match ctx.eval_request(&source_actor, &dest_actor, &job.packet_desc) {
-        Ok(decision) => decision,
-        Err(e) => {
-            debug!(target: VREQ,
-                "error evaluating visa request from {:?}: {}",
-                job.requesting_node, e
-            );
-            return Err(e.into());
-        }
-    };
+    let decision = ctx.eval_request(src, dst, pkt)?;
 
     match decision {
         PartialEvalResult::Deny(FinalDeny::NoMatch(message)) => {
-            info!(target: VREQ,
-                "visa request from {:?} denied (no match): {}",
-                job.requesting_node, message
-            );
-            Ok(VisaDecision::Deny(DenyCode::NoMatch))
+            info!(target: VREQ, "eval denied (no match): {message}");
+            Ok(PolicyOutcome::Deny(DenyCode::NoMatch))
         }
-        PartialEvalResult::AllowWithoutRoute(hits) => {
-            visa_from_allow(asm.clone(), job, &hits, &policy, Some(default_route)).await
-        }
+        PartialEvalResult::AllowWithoutRoute(hits) => Ok(PolicyOutcome::Allow {
+            hits,
+            default_route: Some(default_route),
+        }),
         PartialEvalResult::Deny(FinalDeny::Deny(_hits)) => {
-            info!(target: VREQ,
-                "visa request from {:?} denied by policy",
-                job.requesting_node
-            );
-            Ok(VisaDecision::Deny(DenyCode::Denied))
+            info!(target: VREQ, "eval denied by policy");
+            Ok(PolicyOutcome::Deny(DenyCode::Denied))
         }
         PartialEvalResult::NeedsRoute(residual_evaluator) => {
             let hint = residual_evaluator.hint();
-            let routes = asm
-                .topo_mgr
-                .get_routes(source_zpr_addr, dest_zpr_addr, hint);
-
-            match residual_evaluator.eval_routes(&routes, &asm.topo_mgr) {
-                // TODO: Note that when we get a match using routes, the route it returned in the hit.
-                Ok(FinalEvalResult::Allow(hits)) => {
-                    visa_from_allow(asm.clone(), job, &hits, &policy, None).await
+            let routes = asm.topo_mgr.get_routes(src_zpr, dst_zpr, hint);
+            match residual_evaluator.eval_routes(&routes, &asm.topo_mgr)? {
+                // TODO: Note that when we get a match using routes, the route is returned in the hit.
+                FinalEvalResult::Allow(hits) => Ok(PolicyOutcome::Allow {
+                    hits,
+                    default_route: None,
+                }),
+                FinalEvalResult::Deny(_hits) => {
+                    info!(target: VREQ, "eval denied by policy with routes");
+                    Ok(PolicyOutcome::Deny(DenyCode::Denied))
                 }
-                Ok(FinalEvalResult::Deny(_hits)) => {
-                    info!(target: VREQ,
-                        "visa request from {:?} denied by policy with routes",
-                        job.requesting_node
-                    );
-                    Ok(VisaDecision::Deny(DenyCode::Denied))
-                }
-                Ok(FinalEvalResult::NoMatch(message)) => {
-                    info!(target: VREQ,
-                        "visa request from {:?} denied (no match using route): {}",
-                        job.requesting_node, message
-                    );
-                    Ok(VisaDecision::Deny(DenyCode::NoMatch))
-                }
-                Err(e) => {
-                    debug!(target: VREQ,
-                        "error evaluating route for visa request from {:?}: {}",
-                        job.requesting_node, e
-                    );
-                    return Err(e.into());
+                FinalEvalResult::NoMatch(message) => {
+                    info!(target: VREQ, "eval denied (no match using route): {message}");
+                    Ok(PolicyOutcome::Deny(DenyCode::NoMatch))
                 }
             }
         }

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -341,6 +341,23 @@ pub(crate) async fn evaluate_against_policy(
     }
 }
 
+/// Pick the route for an allow decision: the first hit's own route if it has
+/// one, else the supplied default route. Shared by the request path
+/// (`visa_from_allow`) and the sweep recheck so route selection stays identical.
+pub(crate) fn route_for_allow(
+    hits: &[Hit],
+    default_route: Option<Route>,
+) -> Result<Route, ServiceError> {
+    match hits[0].route.as_ref() {
+        Some(route) => Ok(route.clone()),
+        None => default_route.ok_or_else(|| {
+            ServiceError::Internal(
+                "policy allowed visa but no route in hit and no default route".into(),
+            )
+        }),
+    }
+}
+
 /// Fabricate an AAA actor for an anonymous endpoint at the given address.
 fn fabricate_aaa_actor(anon_addr: &IpAddr, expiration: SystemTime) -> Actor {
     let mut anon_actor = Actor::new();
@@ -394,14 +411,7 @@ async fn visa_from_allow(
         .unwrap_or("")
         .to_string();
 
-    let allowed_route: Route = match hits[0].route.as_ref() {
-        Some(route) => route.clone(),
-        None => default_route.ok_or_else(|| {
-            ServiceError::Internal(
-                "policy allowed visa but no route in hit and no default route".into(),
-            )
-        })?,
-    };
+    let allowed_route: Route = route_for_allow(hits, default_route)?;
 
     let visawmd = asm
         .visa_mgr

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -14,7 +14,7 @@ use tokio_util::compat::*;
 use tracing::{debug, error, info, trace, warn};
 
 use zpr::vsapi::v1;
-use zpr::vsapi_types::{ApiResponseError, Link, Param, ServiceDescriptor, Visa, pname};
+use zpr::vsapi_types::{ApiResponseError, Link, Param, ServiceDescriptor, Visa, VisaOp, pname};
 use zpr::write_to::WriteTo;
 
 use crate::assembly::Assembly;
@@ -149,8 +149,8 @@ pub async fn vss_worker_loop(
                                 asm.counters.incr(CounterType::VssErrors);
                             }
                         }
-                        VssCmd::RevokeVisasById(_visa_id, resp_tx) => {
-                            if let Err(e) = resp_tx.send(Err(VssSyncError::Internal("revoke-visas not implemented".to_string()))) {
+                        VssCmd::RevokeVisasById(visa_ids, resp_tx) => {
+                            if let Err(e) = resp_tx.send(vss_do_revoke_visas(&vss_handle, &visa_ids).await) {
                                 error!(target: VSS, "failed to send response for revoke-visas command: {:?}", e);
                                 asm.counters.incr(CounterType::VssErrors);
                             }
@@ -303,8 +303,8 @@ async fn do_housekeeping(
     }
 
     send_pending_visas(asm, node_addr, vss_handle).await;
+    send_pending_revokes(asm, node_addr, vss_handle).await;
 
-    // TODO: Check for pending visa revocations.
     // TODO: Check for pending authentication revocations.
 }
 
@@ -361,6 +361,46 @@ async fn send_pending_visas(
         }
         Err(e) => {
             warn!(target: VSS, "failed to get pending visas for node {}: {}", node_addr, e);
+        }
+    }
+}
+
+/// If there are visas pending revocation for this node, send the revokes over
+/// VSS and tear down the acked ones. Mirrors `send_pending_visas`.
+///
+/// No per-id staleness re-check is needed: allow verdicts cancel queued revokes
+/// under the same store lock that marks them, so a `PendingRevoke` with a newer
+/// allow cannot exist in memory.
+async fn send_pending_revokes(
+    asm: &Assembly,
+    node_addr: &IpAddr,
+    vss_handle: &v1::v_s_s_handle::Client,
+) {
+    let ids = match asm
+        .visa_mgr
+        .get_pending_revoke_visa_ids_for_node(node_addr)
+        .await
+    {
+        Ok(ids) => ids,
+        Err(e) => {
+            warn!(target: VSS, "failed to get pending-revoke visas for node {}: {}", node_addr, e);
+            return;
+        }
+    };
+    if ids.is_empty() {
+        return; // Nothing to revoke; skip the RPC.
+    }
+
+    match vss_do_revoke_visas(vss_handle, &ids).await {
+        Ok(processed) => {
+            // Tear down state for the acked ids (same prefix convention as install).
+            for &id in ids.iter().take(processed) {
+                asm.visa_mgr.revoke_acked(*node_addr, id).await;
+            }
+            debug!(target: VSS, "revoked {} of {} pending visas on node {}", processed, ids.len(), node_addr);
+        }
+        Err(e) => {
+            error!(target: VSS, "failed to revoke {} pending visas on node {}: {}", ids.len(), node_addr, e);
         }
     }
 }
@@ -527,21 +567,21 @@ fn check_ok_or_error(r: v1::ok_or_error::Reader<'_>) -> Result<(), VssSyncError>
     }
 }
 
-/// Performt he VSS push_visas call, returns the number of visas positively ack'd by node.
-/// Treats zero visas processed as an error.
-async fn vss_do_push_visas(
+/// Send a batch of visa ops (grants and/or revokes) via the VSS `push_visa_op`
+/// call. Returns the number of ops positively ack'd by the node. Treats zero
+/// ops processed as an error.
+async fn vss_do_visa_ops(
     vss_handle: &v1::v_s_s_handle::Client,
-    visas: &[Visa],
+    ops: &[VisaOp],
 ) -> Result<usize, VssSyncError> {
     let mut req = vss_handle.push_visa_op_request();
     let req_builder = req.get();
-    let mut ops_list_builder = req_builder.init_ops(visas.len() as u32);
+    let mut ops_list_builder = req_builder.init_ops(ops.len() as u32);
 
-    // A VisaOp is either a Grant or a Revoke; these are all GRANTs here.
-    for (i, visa) in visas.iter().enumerate() {
-        let op_builder = ops_list_builder.reborrow().get(i as u32);
-        let mut grant_builder = op_builder.init_grant();
-        visa.write_to(&mut grant_builder);
+    // Each VisaOp writes itself as either a Grant or a RevokeVisaId.
+    for (i, op) in ops.iter().enumerate() {
+        let mut op_builder = ops_list_builder.reborrow().get(i as u32);
+        op.write_to(&mut op_builder);
     }
 
     let push_response_rdr =
@@ -550,22 +590,40 @@ async fn vss_do_push_visas(
     // Response is an Ack struct (TODO: Add this to the vsapi types in zpr-common)
     let ack_response = push_response_rdr.get()?.get_ack()?;
     if ack_response.get_ok() {
-        // At least one visa was processed. In this case we return the number processed and
+        // At least one op was processed. In this case we return the number processed and
         // log the error (if any).
         let processed = ack_response.get_processed() as usize;
-        if processed < visas.len() {
+        if processed < ops.len() {
             let err_rdr = ack_response.get_error()?;
             let err_obj = ApiResponseError::try_from(err_rdr)?;
-            error!(target: VSS, "push-visas partially succeeded: {} of {} processed, error code={:?} msg={}",
-            processed, visas.len(), err_obj.code, err_obj.message);
+            error!(target: VSS, "visa-ops partially succeeded: {} of {} processed, error code={:?} msg={}",
+            processed, ops.len(), err_obj.code, err_obj.message);
         }
         return Ok(processed);
     } else {
-        // No visas were processed.  Return error or zero ?? Not sure.
+        // No ops were processed.  Return error or zero ?? Not sure.
         let err_rdr = ack_response.get_error()?;
         let err_obj = ApiResponseError::try_from(err_rdr)?;
         return Err(err_obj.into());
     }
+}
+
+/// Push visa grants to the node, returning the number positively ack'd.
+async fn vss_do_push_visas(
+    vss_handle: &v1::v_s_s_handle::Client,
+    visas: &[Visa],
+) -> Result<usize, VssSyncError> {
+    let ops: Vec<VisaOp> = visas.iter().cloned().map(VisaOp::Grant).collect();
+    vss_do_visa_ops(vss_handle, &ops).await
+}
+
+/// Revoke visas on the node by ID, returning the number positively ack'd.
+async fn vss_do_revoke_visas(
+    vss_handle: &v1::v_s_s_handle::Client,
+    ids: &[u64],
+) -> Result<usize, VssSyncError> {
+    let ops: Vec<VisaOp> = ids.iter().map(|id| VisaOp::RevokeVisaId(*id)).collect();
+    vss_do_visa_ops(vss_handle, &ops).await
 }
 
 async fn vss_do_set_services(


### PR DESCRIPTION
This is the fourth (AND FINAL!) PR in a sequence. This one actually does the check of live visas against a new policy, issuing revocations if any fail to evaluate.

After everything else, this is pretty straightforward.  Add a function in the event manager to sweep through the active visa list and re-evaluate the request using the new policy.  Some opportunistic refactoring since now there are two paths that need to evaluate a 5-tuple + policy.

While doing this also added:
- Implemented the code to actually remove visas when actors and nodes depart, which required...
- Adding a visa-by-actor/visa-by-node index to our in-memory visa store.


 ### Major changes

  - Adds **policy-update visa sweeping**. After policy/topology sync in `event_mgr`, the service now walks live visas, re-evaluates each stored five-tuple against the new policy snapshot, and records either allow or deny verdicts.

  - Adds **verdict state APIs** to `VisaRepo`. New store operations include `list_visa_metadata`, `record_allow_verdict`, `record_deny_verdict`, CAS-style `transition_node_visa_state`, conditional `remove_node_if_pending_revoke`, `visa_has_node_refs`, and public `remove_visa`.

  - Changes install ack behavior from simple state update to **compare-and-swap**: `PendingInstall -> Installed` only. If a policy sweep marked the visa `PendingRevoke` while the push was in flight, the install ack no longer overwrites the revoke.

  - Implements **pending revoke processing over VSS**. `vss_worker` now sends `VisaOp::RevokeVisaId` through the same `push_visa_op` path used for grants, processes pending revokes during housekeeping, and tears down acked visa/node state.

  - Refactors visa-request policy evaluation into a shared function. `visareq_worker::evaluate_against_policy` is now used by both normal visa requests and the sweep path, so rechecks follow the same docking-node, routing, and policy-eval logic.

  - Adds stale-sweep protections. Visas already checked at or after the target `vinst` are skipped; denied visas are only marked for revoke if the sweep’s `vinst` is still current; allow verdicts can cancel older queued revokes.

  - Adds test coverage around the new behavior: sweep deny/skip cases, unresolved actors, stale target policy, CAS install behavior, revoke ack teardown, verdict persistence/hydration, and expired visa handling.

  ### Review focus

  - State-machine semantics in `vs/src/db/visa.rs`
  - Sweep ordering and staleness checks in `vs/src/event_mgr.rs`
  - Whether the shared evaluation path in `vs/src/visareq_worker.rs` preserves request-path behavior exactly

