### PR TITLE
fix the auth services stuff in event manager

### DIFF
--- a/vs/Makefile
+++ b/vs/Makefile
@@ -9,6 +9,6 @@ test: build
 	cargo test --verbose
 
 check:
-	cargo fmt --check && cargo rustc --bins -- -D warnings
+	cargo fmt --check && RUSTFLAGS="-D warnings" cargo build --bins
 
 .DEFAULT_GOAL := all

--- a/vs/src/event_mgr.rs
+++ b/vs/src/event_mgr.rs
@@ -3,7 +3,6 @@
 //! are not able to report back success/failure to the "caller".
 
 use futures::stream::{self, StreamExt};
-use std::collections::HashSet;
 use std::net::IpAddr;
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -23,6 +22,10 @@ pub enum VsEvent {
     /// Use when we get a signal from remote that actor is disconnected/disconnecting.
     /// EventManager takes care of state updates.
     ActorLeaves(IpAddr, DisconnectReason),
+
+    /// The set of authorized services may have changed (an auth-service provider
+    /// joined or left). Handler re-pushes the current auth-services list to all nodes.
+    AuthServiceChange,
 
     /// Indicates that policy has been successfully updated. Pass the new `vinst`.
     PolicyUpdated(u64),
@@ -61,6 +64,11 @@ pub async fn launch(asm: Arc<Assembly>, mut event_rx: mpsc::Receiver<VsEvent>) {
                     error!(target: EVENT, "failed to handle actor leave event: {}", e);
                 }
             }
+            VsEvent::AuthServiceChange => {
+                if let Err(e) = handle_auth_service_change(&asm).await {
+                    error!(target: EVENT, "failed to handle auth service change event: {}", e);
+                }
+            }
             VsEvent::PolicyUpdated(vinst) => {
                 if let Err(e) = handle_policy_updated(&asm, vinst).await {
                     error!(target: EVENT, "failed to handle policy updated event: {}", e);
@@ -71,67 +79,50 @@ pub async fn launch(asm: Arc<Assembly>, mut event_rx: mpsc::Receiver<VsEvent>) {
     info!(target: EVENT, "event manager shutting down");
 }
 
-// Maybe will call into topology routines from here eventually.
-async fn handle_actor_joins(asm: &Arc<Assembly>, actor_addr: IpAddr) -> Result<(), ServiceError> {
+// Reserved for future topology handling on actor join. Auth-service propagation now
+// happens via an `AuthServiceChange` event emitted at the join call site (see
+// `record_auth_change_if_provider`).
+async fn handle_actor_joins(_asm: &Arc<Assembly>, actor_addr: IpAddr) -> Result<(), ServiceError> {
     info!(target: EVENT, "actor joined: {}", actor_addr);
-    let has_auth_services = match asm
-        .actor_mgr
-        .has_auth_services(asm.clone(), &actor_addr)
-        .await
-    {
-        Ok(v) => v,
-        Err(e) => {
-            error!(target: EVENT, "actor_mgr.has_auth_services failed: {}", e);
-            false
-        }
-    };
-
-    if has_auth_services {
-        //let service_list =
-        match asm.actor_mgr.get_auth_services_list(asm.clone()).await {
-            Ok(svcs) => set_services_all_nodes(&asm, &svcs).await?,
-            Err(e) => {
-                error!(
-                    target: EVENT,
-                    "actor_mgr.get_auth_services_list failed: {}", e
-                );
-            }
-        }
-    }
     Ok(())
 }
 
-// TODO: Not sure I love this idea of having these wide ranging functions in the 'event_mgr'.
-// Things could get quite messy.
-//
-// The goal is somewhere to centralize high level logic that imapacts all sorts of areas in the
-// visa service.
+// Reserved for future topology handling on actor leave. Auth-service propagation now
+// happens via an `AuthServiceChange` event emitted at the leave call site, which must
+// detect the change *before* the disconnect removes the actor from the state DB.
 async fn handle_actor_leaves(
-    asm: &Arc<Assembly>,
+    _asm: &Arc<Assembly>,
     actor_addr: IpAddr,
     _reason: DisconnectReason,
 ) -> Result<(), ServiceError> {
     info!(target: EVENT, "actor left: {}", actor_addr);
-
-    let prev_auth_services: HashSet<ServiceDescriptor> = HashSet::from_iter(
-        asm.actor_mgr
-            .get_auth_services_list(asm.clone())
-            .await
-            .unwrap_or_default(),
-    );
-
-    if !prev_auth_services.is_empty() {
-        let new_auth_services: HashSet<ServiceDescriptor> =
-            HashSet::from_iter(asm.actor_mgr.get_auth_services_list(asm.clone()).await?); // will error out on DB error
-
-        // If there is a difference between previous and new authorized services, we need to update nodes.
-        if prev_auth_services != new_auth_services {
-            set_services_all_nodes(&asm, &new_auth_services.iter().cloned().collect::<Vec<_>>())
-                .await?;
-        }
-    }
-
     Ok(())
+}
+
+// Re-push the current authorized-services list to all connected nodes. Triggered by
+// `AuthServiceChange` when an auth-service provider has joined or left, so nodes always
+// see the up-to-date list.
+async fn handle_auth_service_change(asm: &Arc<Assembly>) -> Result<(), ServiceError> {
+    let auth_services = asm.actor_mgr.get_auth_services_list(asm.clone()).await?;
+    set_services_all_nodes(asm, &auth_services).await
+}
+
+/// Record an `AuthServiceChange` event, logging on failure. Call when the authorized
+/// service set may have changed so the current list gets re-pushed to all nodes.
+pub async fn record_auth_service_change(asm: &Arc<Assembly>) {
+    if let Err(e) = asm.event_mgr.record_event(VsEvent::AuthServiceChange).await {
+        error!(target: EVENT, "failed to record AuthServiceChange event: {}", e);
+    }
+}
+
+/// If `addr` provides an auth service (per current policy and DB state), record an
+/// `AuthServiceChange` event. Must be called while the actor is still present in the DB.
+pub async fn record_auth_change_if_provider(asm: &Arc<Assembly>, addr: &IpAddr) {
+    match asm.actor_mgr.has_auth_services(asm.clone(), addr).await {
+        Ok(true) => record_auth_service_change(asm).await,
+        Ok(false) => {}
+        Err(e) => error!(target: EVENT, "has_auth_services check failed for {}: {}", addr, e),
+    }
 }
 
 /// Helper to use the VSS on all connected nodes to update the auth services list.

--- a/vs/src/event_mgr.rs
+++ b/vs/src/event_mgr.rs
@@ -79,17 +79,13 @@ pub async fn launch(asm: Arc<Assembly>, mut event_rx: mpsc::Receiver<VsEvent>) {
     info!(target: EVENT, "event manager shutting down");
 }
 
-// Reserved for future topology handling on actor join. Auth-service propagation now
-// happens via an `AuthServiceChange` event emitted at the join call site (see
-// `record_auth_change_if_provider`).
+/// TODO: Does not do anything yet.
 async fn handle_actor_joins(_asm: &Arc<Assembly>, actor_addr: IpAddr) -> Result<(), ServiceError> {
     info!(target: EVENT, "actor joined: {}", actor_addr);
     Ok(())
 }
 
-// Reserved for future topology handling on actor leave. Auth-service propagation now
-// happens via an `AuthServiceChange` event emitted at the leave call site, which must
-// detect the change *before* the disconnect removes the actor from the state DB.
+/// TODO: Does not do anything yet.
 async fn handle_actor_leaves(
     _asm: &Arc<Assembly>,
     actor_addr: IpAddr,

--- a/vs/src/vsapi_worker.rs
+++ b/vs/src/vsapi_worker.rs
@@ -23,7 +23,7 @@ use crate::assembly::Assembly;
 use crate::config;
 use crate::counters::CounterType;
 use crate::error::ServiceError;
-use crate::event_mgr::VsEvent;
+use crate::event_mgr::{self, VsEvent};
 use crate::logging::targets::API;
 use crate::net_mgr;
 use crate::topology_mgr::{AddLinkedNodeError, TopologyMgr};
@@ -1065,6 +1065,9 @@ impl vsapi::v_s_handle::Server for VSHandleImpl {
         if let Err(e) = self.asm.event_mgr.record_event(evt).await {
             warn!(target: API, "failed to record actor joins event for adapter {:?}: {}", actor.get_cn(), e);
         }
+        // If this actor provides an auth service, the authorized-services list grew and
+        // nodes must be updated. Detect it now while the actor is still in the DB.
+        event_mgr::record_auth_change_if_provider(&self.asm, &actor_addr).await;
 
         // If a node just connected, the next thing it will try to do is open a connection
         // to VSAPI. We do not generate a visa since we currently have no mechanism to
@@ -1128,6 +1131,17 @@ impl vsapi::v_s_handle::Server for VSHandleImpl {
             self.node.get_cn(), zpr_addr, reason
         );
 
+        // Check whether this actor provides an auth service *before* the disconnect
+        // removes it from the state DB; if so, we emit AuthServiceChange afterwards so
+        // nodes drop it from their authorized-services list.
+        let was_auth_provider = matches!(
+            self.asm
+                .actor_mgr
+                .has_auth_services(self.asm.clone(), &zpr_addr)
+                .await,
+            Ok(true)
+        );
+
         // The disconnect call updates our state database.
         match self
             .asm
@@ -1151,6 +1165,9 @@ impl vsapi::v_s_handle::Server for VSHandleImpl {
         let evt = VsEvent::ActorLeaves(zpr_addr, reason);
         if let Err(e) = self.asm.event_mgr.record_event(evt).await {
             warn!(target: API, "failed to record actor leaves event for {}: {}", zpr_addr, e);
+        }
+        if was_auth_provider {
+            event_mgr::record_auth_service_change(&self.asm).await;
         }
         let mut res_builder = resp.get().init_res();
         res_builder.set_ok(());

--- a/vs/src/vsapi_worker.rs
+++ b/vs/src/vsapi_worker.rs
@@ -802,6 +802,10 @@ impl vsapi::v_s_gate::Server for VSGateImpl {
         }
         self.asm.counters.incr(CounterType::NodeConnectionsSuccess);
 
+        // If this node provides an auth service, the authorized-services list grew and
+        // nodes must be updated. Detect it now while the actor is still in the DB.
+        event_mgr::record_auth_change_if_provider(&self.asm, &node_zpr_addr).await;
+
         let vs_handle: vsapi::v_s_handle::Client =
             capnp_rpc::new_client(VSHandleImpl::new(self.asm.clone(), node_actor));
         let mut res_builder = results.get().init_res();


### PR DESCRIPTION
While fixing something else I noticed that the actor-leaves event handler was buggy and not doing anything useful.  I've left that in there as just a logger, but added a new event that is fired when the auth-services list changes.