### PR TITLE
supress test dead_code errors

### DIFF
--- a/vs/src/db/db_fake.rs
+++ b/vs/src/db/db_fake.rs
@@ -59,6 +59,7 @@ impl Entry {
     }
 }
 
+#[allow(dead_code)]
 impl FakeDb {
     async fn exists_with_lock(&self, key: &str) -> DbResult<bool> {
         if let Some(entry) = self.store.get(key) {

--- a/vs/src/main.rs
+++ b/vs/src/main.rs
@@ -1,3 +1,8 @@
+// Code reachable only from the runtime `main` path looks unused when the bin
+// is compiled as a test harness (which replaces `main`). Suppress that noise;
+// real dead-code detection still applies to normal/release builds.
+#![cfg_attr(test, allow(dead_code))]
+
 use clap::Parser;
 use std::fs;
 use std::net::{IpAddr, SocketAddr};


### PR DESCRIPTION
Latest rust started flagging all these dead code warnings.  All were related to test harness.