### PR TITLE
(248ts-stack) mk/248 01 attr service base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5248,8 +5248,8 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zpr"
-version = "0.20.0"
-source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.20.0#76b909ebce8d865b99fd6659ffda7b560423f120"
+version = "0.21.0"
+source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.21.0#b212ca1a81464ee0534161fe6c6c8fd27f6a5b80"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,5 @@ serde_with = { version = "3.18.0", default-features = false, features = ["std", 
 thiserror = "2.0.18"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.20"
-zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.20.0", features = ["vsapi", "policy"]}
+zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.21.0", features = ["vsapi", "policy"]}
 

--- a/libeval/src/actor.rs
+++ b/libeval/src/actor.rs
@@ -1,6 +1,8 @@
 use serde::Serialize;
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 use std::net::IpAddr;
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 use thiserror::Error;
 
 use crate::attribute::key;
@@ -25,20 +27,35 @@ pub enum Role {
 /// From the perspective of the evaluator, and actor is just a bunch of
 /// attributes and provided services.  The provided services is stored
 /// under the [Key::SERVICES] attribute key.
-#[derive(Debug, Default, Clone, Serialize, Hash)]
+#[derive(Debug, Default, Clone, Serialize)]
 pub struct Actor {
-    // Attributes associated with this actor.
-    attrs: Vec<Attribute>,
+    // Attributes associated with this actor, keyed by attribute key.
+    attrs: HashMap<String, Attribute>,
 
     // Once authenticated, an actor will have one or more identity attributes.
     // The names are kept here in order.
     identity_keys: Vec<String>,
 
-    // These are all pulled from the attributes vec if/when set.
+    // These are all pulled from the attributes map if/when set.
     cn: Option<String>,
     role: Role,
     provider: bool,
     zpr_addr: Option<IpAddr>,
+}
+
+/// Hand written because [HashMap] is not [Hash]. Attributes are hashed in key
+/// order so the result does not depend on insertion or map iteration order.
+impl Hash for Actor {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let mut attrs: Vec<&Attribute> = self.attrs.values().collect();
+        attrs.sort_by_key(|a| a.get_key());
+        attrs.hash(state);
+        self.identity_keys.hash(state);
+        self.cn.hash(state);
+        self.role.hash(state);
+        self.provider.hash(state);
+        self.zpr_addr.hash(state);
+    }
 }
 
 impl Actor {
@@ -47,7 +64,7 @@ impl Actor {
     }
 
     pub fn attrs_iter(&self) -> impl Iterator<Item = &Attribute> {
-        self.attrs.iter()
+        self.attrs.values()
     }
 
     pub fn identity_keys_iter(&self) -> impl Iterator<Item = &String> {
@@ -74,20 +91,22 @@ impl Actor {
     }
 
     /// Adds or replaces the attribute with name `key`.  Assumes a single value attribute.
+    /// Only used in tests.
+    #[cfg(test)]
     pub fn add_attr_from_parts(
         &mut self,
         key: &str,
         value: &str,
-        expires_in: Duration,
+        expires_in: std::time::Duration,
     ) -> Result<(), AttributeError> {
         self.add_attribute(Attribute::builder(key).expires_in(expires_in).value(value))
     }
 
     /// Adds or replaces the attribute on the actor.
     pub fn add_attribute(&mut self, attr: Attribute) -> Result<(), AttributeError> {
-        let key = attr.get_key();
+        let key = attr.get_key().to_string();
         let value = attr.get_value();
-        match key {
+        match key.as_str() {
             key::ZPR_ADDR => {
                 if let Ok(ip) = value[0].parse::<IpAddr>() {
                     self.zpr_addr = Some(ip);
@@ -112,12 +131,12 @@ impl Actor {
             },
             _ => (),
         }
-        self.attrs.push(attr);
+        self.attrs.insert(key, attr);
         Ok(())
     }
 
     pub fn get_attribute(&self, key: &str) -> Option<&Attribute> {
-        self.attrs.iter().find(|a| a.get_key() == key)
+        self.attrs.get(key)
     }
 
     /// If there are identity attributes, the values are copied and returned here
@@ -138,16 +157,29 @@ impl Actor {
 
     /// TODO: Figure out all the details of how we hold authentication data.
     ///
-    /// For now this looks at the identity keys and if any are found, return the
-    /// soonest expiration.
+    /// Returns the minimum expiration time from:
+    /// - [key::AUTHORITY] attribute, if present.
+    /// - any `identity` attributes, if present.
+    /// - ELSE: None.
     ///
     /// If there are no identity keys we assume there is no authentication and return None.
     pub fn get_authentication_expiration(&self) -> Option<SystemTime> {
-        self.identity_keys
+        let authority_expiration = self
+            .get_attribute(key::AUTHORITY)
+            .map(|attr| attr.get_expires());
+        let identity_expiration = self
+            .identity_keys
             .iter()
             .filter_map(|key| self.get_attribute(key))
             .map(|attr| attr.get_expires())
-            .min()
+            .min();
+
+        match (authority_expiration, identity_expiration) {
+            (Some(a), Some(i)) => Some(a.min(i)),
+            (Some(a), None) => Some(a),
+            (None, Some(i)) => Some(i),
+            (None, None) => None,
+        }
     }
 
     pub fn is_provider(&self) -> bool {
@@ -168,40 +200,35 @@ impl Actor {
 
     pub fn provides(&self, service_id: &str) -> bool {
         self.attrs
-            .iter()
-            .any(|a| a.get_key() == key::SERVICES && a.value_has(service_id))
+            .get(key::SERVICES)
+            .is_some_and(|a| a.value_has(service_id))
     }
 
     pub fn services_iter(&self) -> impl Iterator<Item = &str> {
         self.attrs
-            .iter()
-            .find(|a| a.get_key() == key::SERVICES)
+            .get(key::SERVICES)
             .into_iter()
             .flat_map(|attr| attr.get_value().iter().map(|s| s.as_str()))
     }
 
-    pub fn has_attribute_named(&self, key: &str) -> bool {
-        self.attrs.iter().any(|a| a.get_key() == key)
+    pub(crate) fn has_attribute_named(&self, key: &str) -> bool {
+        self.attrs.contains_key(key)
     }
 
-    pub fn has_attribute_value(&self, key: &str, value: &str) -> bool {
+    pub(crate) fn has_attribute_value(&self, key: &str, value: &str) -> bool {
         self.attrs
-            .iter()
-            .any(|a| a.get_key() == key && a.get_value_len() == 1 && a.get_value()[0] == value)
+            .get(key)
+            .is_some_and(|a| a.is_single_value(value))
     }
 
     /// TRUE if all attribute values are present.
-    pub fn has_attribute_values(&self, key: &str, values: &[String]) -> bool {
-        self.attrs
-            .iter()
-            .any(|a| a.get_key() == key && a.value_has_all(values))
+    pub(crate) fn has_attribute_values(&self, key: &str, values: &[String]) -> bool {
+        self.attrs.get(key).is_some_and(|a| a.value_has_all(values))
     }
 
     /// TRUE if any attribute value from `values` is present.
-    pub fn has_any_attribute_values(&self, key: &str, values: &[String]) -> bool {
-        self.attrs
-            .iter()
-            .any(|a| a.get_key() == key && a.value_has_any(values))
+    pub(crate) fn has_any_attribute_values(&self, key: &str, values: &[String]) -> bool {
+        self.attrs.get(key).is_some_and(|a| a.value_has_any(values))
     }
 }
 
@@ -397,7 +424,7 @@ mod tests {
         // Should have the new value
         assert_eq!(actor.role, Role::Node);
         assert!(actor.is_node());
-        assert_eq!(actor.attrs.len(), 2); // Both attributes are kept in the list
+        assert_eq!(actor.attrs.len(), 1); // Same key, so the second replaces the first
     }
 
     #[test]

--- a/libeval/src/attribute.rs
+++ b/libeval/src/attribute.rs
@@ -3,9 +3,13 @@ use std::time::{Duration, SystemTime};
 
 use thiserror::Error;
 
+/// Internally sourced attributes
+pub const SOURCE_ZPR: &str = "zpr";
+
 pub const ROLE_NODE: &str = "node";
 pub const ROLE_ADAPTER: &str = "adapter";
-const NEVER_EXPIRES: Duration = Duration::from_secs(60 * 60 * 60 * 24 * 365 * 100); // 100 years
+
+pub const NEVER_EXPIRES: Duration = Duration::from_secs(60 * 60 * 60 * 24 * 365 * 100); // 100 years
 
 pub mod key {
 
@@ -57,6 +61,7 @@ pub struct Attribute {
     key: String,
     value: Vec<String>,
     expires_at: SystemTime,
+    source: String,
 }
 
 /// TBD. Placeholder for that which is used to match link attributes based on policy.
@@ -66,19 +71,44 @@ pub struct Attribute {
 #[derive(Debug, Clone, Serialize, Hash, Eq, PartialEq)]
 pub struct AttrMatch {} // TODO
 
+/// A named attribute source. Use this to get a builder for a source.
+pub struct AttributeSource(String);
+
+impl AttributeSource {
+    pub fn new<S: Into<String>>(source: S) -> Self {
+        AttributeSource(source.into())
+    }
+
+    pub fn builder<S: Into<String>>(&self, key: S) -> AttributeBuilder {
+        AttributeBuilder::new_from_source(key.into(), self.0.clone())
+    }
+}
+
 pub struct AttributeBuilder {
     key: String,
     expires_at: SystemTime,
+    source: String,
 }
 
 /// Helper for building attributes.  Allows for addin an expiration time before setting value/values.
 impl AttributeBuilder {
-    /// Create a builder with the given attribute key and a default expiration
+    /// Create a builder for an internal/zpr attribute with given key and a default expiration
     /// in the far future.
     fn new(key: String) -> Self {
         AttributeBuilder {
             key,
             expires_at: SystemTime::now() + NEVER_EXPIRES,
+            source: SOURCE_ZPR.into(),
+        }
+    }
+
+    /// Create a builder for an attribute from the given `source` and with the
+    /// given attribute `key` and a default expiration in the far future.
+    fn new_from_source(key: String, source: String) -> Self {
+        AttributeBuilder {
+            key,
+            expires_at: SystemTime::now() + NEVER_EXPIRES,
+            source,
         }
     }
 
@@ -99,7 +129,12 @@ impl AttributeBuilder {
     where
         S: AsRef<str>,
     {
-        Attribute::new(self.key, std::iter::once(value), self.expires_at)
+        Attribute::new(
+            self.key,
+            std::iter::once(value),
+            self.expires_at,
+            self.source,
+        )
     }
 
     /// Finishes the build and returns an attribute with the given set of values.
@@ -108,7 +143,7 @@ impl AttributeBuilder {
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
     {
-        Attribute::new(self.key, values, self.expires_at)
+        Attribute::new(self.key, values, self.expires_at, self.source)
     }
 }
 
@@ -124,16 +159,17 @@ impl Attribute {
             .collect()
     }
 
-    /// Create a handy attribute builder initialized with the given key.
-    /// By default the attribute will expire in the far future unless you
-    /// set an expiration using the builder.  To finish the build use
-    /// [AttributeBuilder::value] or [AttributeBuilder::values] depending
-    /// on whether you want to create a single or multi-valued attribute.
+    /// Create a handy attribute builder for internal/zpr attributes initialized
+    /// with the given key. By default the attribute will expire in the far
+    /// future unless you set an expiration using the builder.  To finish the
+    /// build use [AttributeBuilder::value] or [AttributeBuilder::values]
+    /// depending on whether you want to create a single or multi-valued
+    /// attribute.
     pub fn builder<S: Into<String>>(key: S) -> AttributeBuilder {
         AttributeBuilder::new(key.into())
     }
 
-    pub fn new<I, S>(key: String, values: I, expires_at: SystemTime) -> Self
+    pub fn new<I, S>(key: String, values: I, expires_at: SystemTime, source: String) -> Self
     where
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
@@ -142,6 +178,7 @@ impl Attribute {
             key,
             value: Self::collect_values(values),
             expires_at,
+            source,
         }
     }
 
@@ -151,6 +188,10 @@ impl Attribute {
 
     pub fn get_value(&self) -> &[String] {
         &self.value
+    }
+
+    pub fn get_source(&self) -> &str {
+        &self.source
     }
 
     /// If this is a single valued attribute, return a reference to the single value.

--- a/libeval/src/eval.rs
+++ b/libeval/src/eval.rs
@@ -1,5 +1,5 @@
 use crate::actor::Actor;
-use crate::attribute::{Attribute, ROLE_ADAPTER, ROLE_NODE, key};
+use crate::attribute::{Attribute, NEVER_EXPIRES, ROLE_ADAPTER, ROLE_NODE, key};
 use crate::error::EvalError;
 use crate::eval_result::{Direction, FinalDeny, Hit, PartialEvalResult, Signal};
 use crate::joinpolicy::JFlag;
@@ -14,7 +14,6 @@ use enumset::EnumSet;
 use std::collections::HashSet;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
 use tracing::{debug, warn};
 
 use zpr::policy::v1 as policy_capnp;
@@ -203,7 +202,6 @@ impl EvalContext {
         &self,
         authenticated_claims: Option<&[Attribute]>,
         unauthenticated_claims: Option<&[Attribute]>,
-        expiration: Duration,
     ) -> Result<Actor, EvalError> {
         if authenticated_claims.is_none() {
             return Err(EvalError::AttributeMissing(
@@ -279,29 +277,27 @@ impl EvalContext {
 
         let role_attr = if flags.contains(JFlag::IsNode) {
             Attribute::builder(key::ROLE)
-                .expires_in(expiration)
+                .expires_in(NEVER_EXPIRES)
                 .value(ROLE_NODE)
         } else {
             Attribute::builder(key::ROLE)
-                .expires_in(expiration)
+                .expires_in(NEVER_EXPIRES)
                 .value(ROLE_ADAPTER)
         };
         actor.add_attribute(role_attr).unwrap();
 
         if !services.is_empty() {
             debug!(target: EVAL, "actor provides services: {:?}", services);
-            let svc_attr = Attribute::new(
-                key::SERVICES.into(),
-                &services.iter().cloned().collect::<Vec<String>>(),
-                SystemTime::now() + expiration,
-            );
+            let svc_attr = Attribute::builder(key::SERVICES)
+                .expires_in(NEVER_EXPIRES)
+                .values(services);
             actor.add_attribute(svc_attr).unwrap();
         }
 
         actor
             .add_attribute(
                 Attribute::builder(key::VINST)
-                    .expires_in(expiration)
+                    .expires_in(NEVER_EXPIRES)
                     .value(self.policy.get_vinst().to_string()),
             )
             .unwrap();
@@ -1009,7 +1005,6 @@ mod test {
             .approve_connection(
                 Some(authenticated_claims.as_slice()),
                 Some(unauthenticated_claims.as_slice()),
-                Duration::from_secs(1000),
             )
             .unwrap();
 
@@ -1037,7 +1032,6 @@ mod test {
         match ctx.approve_connection(
             Some(authenticated_claims.as_slice()),
             Some(unauthenticated_claims.as_slice()),
-            Duration::from_secs(1000),
         ) {
             Err(e) => panic!("expected connection approval to succeed, got {:?}", e),
             Ok(actor) => {
@@ -1064,7 +1058,6 @@ mod test {
             .approve_connection(
                 Some(authenticated_claims.as_slice()),
                 Some(unauthenticated_claims.as_slice()),
-                Duration::from_secs(1000),
             )
             .unwrap();
         assert!(actor.is_node());
@@ -1081,11 +1074,7 @@ mod test {
 
         let authenticated_claims = vec![Attribute::builder(key::CN).value("nobody.zpr.org")];
         let actor = ctx
-            .approve_connection(
-                Some(authenticated_claims.as_slice()),
-                None,
-                Duration::from_secs(1000),
-            )
+            .approve_connection(Some(authenticated_claims.as_slice()), None)
             .unwrap();
         assert!(!actor.is_node());
 

--- a/vs/src/actor_mgr.rs
+++ b/vs/src/actor_mgr.rs
@@ -149,6 +149,13 @@ impl ActorMgr {
         Ok(())
     }
 
+    // TODO: This probably updates too much ... all we really need is to update the attributes.
+    // Only call path is after running an attribute refresh in the visa request path.
+    pub async fn update_actor(&self, actor: &Actor) -> Result<(), ServiceError> {
+        self.actor_db.update_actor(actor).await?;
+        Ok(())
+    }
+
     /// Use [ActorMgr::remove_actor_by_zpr_addr] to remove actor records which apply to both nodes and adapters.
     /// Use this function here in addition to remove node state.
     ///

--- a/vs/src/assembly.rs
+++ b/vs/src/assembly.rs
@@ -12,6 +12,7 @@ use crate::event_mgr::EventMgr;
 use crate::net_mgr::NetMgr;
 use crate::policy_mgr::PolicyMgr;
 use crate::topology_mgr::TopologyMgr;
+use crate::trusted_services_mgr::TrustedServicesMgr;
 use crate::visa_mgr::VisaMgr;
 use crate::vss_mgr::VssMgr;
 
@@ -31,6 +32,7 @@ pub struct Assembly {
     pub event_mgr: EventMgr,
     pub admin_api_keys: Arc<ReloadableApiKeys>,
     pub topo_mgr: TopologyMgr,
+    pub ts_mgr: TrustedServicesMgr,
 }
 
 impl Assembly {
@@ -134,6 +136,7 @@ pub mod tests {
             event_mgr: EventMgr::new(event_tx),
             admin_api_keys: Arc::new(ReloadableApiKeys::default()),
             topo_mgr: TopologyMgr::new(LinkRepo::new(db_handle)),
+            ts_mgr: TrustedServicesMgr::new(),
         }
     }
 }

--- a/vs/src/config.rs
+++ b/vs/src/config.rs
@@ -27,7 +27,7 @@ pub const EVENT_QUEUE_DEPTH: usize = 1024;
 
 // We only load policy files built by this version or later.
 pub const POLICY_MIN_COMPILER_MAJOR: u32 = 0;
-pub const POLICY_MIN_COMPILER_MINOR: u32 = 13;
+pub const POLICY_MIN_COMPILER_MINOR: u32 = 14;
 pub const POLICY_MIN_COMPILER_PATCH: u32 = 0;
 
 /// Minimum policy compiler version this build will load.
@@ -52,7 +52,7 @@ pub const INITIAL_VISA_ID: u64 = 1000;
 pub const VALKEY_URI: &str = "redis://127.0.0.1:6379";
 
 /// Every THIS often we re-acquire the DB lock.
-pub const VALKEY_LOCK_REFRESH_SECS: Duration = Duration::from_secs(60);
+pub const VALKEY_LOCK_REFRESH_SECS: Duration = Duration::from_secs(30);
 
 /// We set the DB lock to expire after THIS long.
 pub const VALKEY_LOCK_TIMEOUT: Duration = Duration::from_secs(90);

--- a/vs/src/connection_control.rs
+++ b/vs/src/connection_control.rs
@@ -160,7 +160,7 @@ impl ConnectionControl {
         // We are the authority since we are checking RSA locally.
         authd_claims.push(
             Attribute::builder(key::AUTHORITY)
-                .expires(SystemTime::now() + config::DEFAULT_AUTH_EXPIRATION)
+                .expires_in(config::DEFAULT_AUTH_EXPIRATION)
                 .value(&self.authority),
         );
 
@@ -206,11 +206,7 @@ impl ConnectionControl {
             AuthBlob::SS(ssb) => match ssb.alg {
                 ChallengeAlg::RsaSha256Pkcs1v15 => {
                     // We are the authority since we are checking RSA locally.
-                    authd_claims.push(
-                        Attribute::builder(key::AUTHORITY)
-                            .expires(SystemTime::now() + config::DEFAULT_AUTH_EXPIRATION)
-                            .value(&self.authority),
-                    );
+                    authd_claims.push(Attribute::builder(key::AUTHORITY).value(&self.authority));
 
                     self.authenticate_zpr_entity_rsa(
                         asm,
@@ -248,9 +244,13 @@ impl ConnectionControl {
         let policy = asm.policy_mgr.get_current();
 
         // Ok checks out -- now run through policy.
-        let vs_actor = self
+        let mut vs_actor = self
             .authorize_connection(asm, &policy, &config::VS_CN, Vec::new(), authd_claims, 0)
             .await?;
+
+        // The `authorized_connection` call will add the default expiration on the authority key. We
+        // want to make vs not expire.
+        vs_actor.add_attribute(Attribute::builder(key::AUTHORITY).value(&self.authority))?;
 
         Ok(vs_actor)
     }
@@ -335,10 +335,16 @@ impl ConnectionControl {
     /// Use policy to authorize the connection request. Works for adapters and nodes.
     /// If successful you get an authorized Actor back.
     ///
+    /// Is able to use the api=file Trusted service to fetch additional attributes.
+    /// Eventually will query trusted services for additional actor attributes.
+    ///
     /// Does not alter our actor databases.
     /// May take an IP address.
     ///
     /// Caller should set ROLE in unauthd_claims before calling.
+    ///
+    /// This always adds the `key::AUTHORITY` key as an identity attribute with the default
+    /// auth expiration on it.
     async fn authorize_connection(
         &self,
         asm: Arc<Assembly>,
@@ -362,22 +368,47 @@ impl ConnectionControl {
         // There may in the future be additional network I/O in the next step
         // for example if VS needs to talk to attribute service.
 
+        // This function is POST authentication - so we already have some notion of an ID for this actor.
+
+        // TODO: Need to figure out what we are using for an ID. For now using CN (which comes from our RSA auth).
+        // TODO: But why don't we set CN as the identity attribute on the actor? Why mess with the JWT?
+        // TODO: We will need some formal way to pass an IDENTITY value to this function.
+
+        for ts_results in asm.ts_mgr.get_attributes_for_actor(endpoint_cn).await {
+            match ts_results {
+                Ok(ts_attrs) => {
+                    for attr in ts_attrs {
+                        authd_claims.push(attr);
+                    }
+                }
+                Err(e) => {
+                    error!(target: CC, "ts service attr lookup failed for actor {}: {}", endpoint_cn, e);
+                }
+            }
+        }
+
+        info!(target: CC, "XXX authorize_connection - consulting trusted services");
+
         let ectx = EvalContext::new(current_policy.clone());
 
         // TODO: Need to go in to eval and fix the approve_connection logic w/respect to the ROLE claim.
         // We won't know a priori if this is a node or adapter. Though sometimes we do know it's a node.
         // Anyway, best to let VS sort it out and do not do it in libeval.
-        let mut authd_actor = match ectx.approve_connection(
-            Some(&authd_claims),
-            Some(&unauthd_claims),
-            config::DEFAULT_AUTH_EXPIRATION,
-        ) {
-            Ok(actor) => actor,
-            Err(e) => {
-                info!(target: CC, "connection not approved for cn {}: {}", endpoint_cn, e);
-                return Err(e.into());
-            }
-        };
+        let mut authd_actor =
+            match ectx.approve_connection(Some(&authd_claims), Some(&unauthd_claims)) {
+                Ok(actor) => actor,
+                Err(e) => {
+                    info!(target: CC, "connection not approved for cn {}: {}", endpoint_cn, e);
+                    return Err(e.into());
+                }
+            };
+
+        authd_actor.add_attribute(
+            Attribute::builder(key::AUTHORITY)
+                .expires_in(config::DEFAULT_AUTH_EXPIRATION)
+                .value(&self.authority),
+        )?;
+        authd_actor.add_identity_key(usize::MAX, key::AUTHORITY)?;
 
         let actor_role = if authd_actor.is_node() {
             Role::Node
@@ -390,11 +421,8 @@ impl ConnectionControl {
         } else {
             match asm.net_mgr.get_next_zpr_addr(&actor_role) {
                 Ok(addr) => {
-                    authd_actor.add_attribute(
-                        Attribute::builder(key::ZPR_ADDR)
-                            .expires(SystemTime::now() + config::DEFAULT_AUTH_EXPIRATION)
-                            .value(addr.to_string()),
-                    )?;
+                    authd_actor
+                        .add_attribute(Attribute::builder(key::ZPR_ADDR).value(addr.to_string()))?;
                     info!(target: CC, "authorized adapter/{actor_role:?} cn {} assigned ZPR addr {}", endpoint_cn, addr);
                 }
                 Err(e) => {

--- a/vs/src/error.rs
+++ b/vs/src/error.rs
@@ -66,6 +66,12 @@ pub enum ServiceError {
 
     #[error("resolver error: {0}")]
     Resolver(#[from] ResolverError),
+
+    #[error("serialization/deserialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    #[error("trusted service not found: ID={0}")]
+    TrustedServiceNotFound(String),
 }
 
 #[derive(Debug, Error)]

--- a/vs/src/logging.rs
+++ b/vs/src/logging.rs
@@ -16,6 +16,7 @@ pub mod targets {
     pub const VSS: &str = "vss";
     pub const VREQ: &str = "vreq";
     pub const TOPO: &str = "topo";
+    pub const TS: &str = "ts";
 }
 
 pub enum Verbosity {

--- a/vs/src/main.rs
+++ b/vs/src/main.rs
@@ -35,6 +35,7 @@ mod policy_mgr;
 mod router;
 mod signal_worker;
 mod topology_mgr;
+mod trusted_services_mgr;
 mod visa_mgr;
 mod visareq_worker;
 mod vsapi_worker;
@@ -61,6 +62,7 @@ use crate::logging::targets::MAIN;
 use crate::net_mgr::NetMgr;
 use crate::policy_mgr::{PolicyMgr, SystemResolver};
 use crate::topology_mgr::TopologyMgr;
+use crate::trusted_services_mgr::TrustedServicesMgr;
 use crate::visa_mgr::VisaMgr;
 use crate::vss_mgr::VssMgr;
 
@@ -312,6 +314,7 @@ async fn main() -> std::process::ExitCode {
         event_mgr: EventMgr::new(event_tx),
         admin_api_keys: Arc::new(admin_api_keys),
         topo_mgr: TopologyMgr::new(db::LinkRepo::new(db_handle)),
+        ts_mgr: TrustedServicesMgr::new(),
     });
 
     // Rebuild the in-memory router topology from persisted state. This runs after

--- a/vs/src/trusted_services_mgr.rs
+++ b/vs/src/trusted_services_mgr.rs
@@ -1,0 +1,478 @@
+//! Trusted Services Manager
+//!
+//! Placeholder for eventual comprehensive management of the trusted services.
+
+use async_trait::async_trait;
+
+use arc_swap::ArcSwap;
+use futures::future::join_all;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::fs;
+
+use tracing::debug;
+
+use libeval::attribute::{Attribute, AttributeSource};
+
+use zpr::policy_types::AttrMapping;
+
+use crate::error::ServiceError;
+use crate::logging::targets::TS;
+
+/// Shortest TTL we are willing to stamp on an emitted attribute. When a store's cached
+/// data has less than this left, it refreshes early rather than hand a consumer something
+/// that expires almost immediately.
+const MIN_ATTRIBUTE_TTL: Duration = Duration::from_secs(60);
+
+/// Interface for trusted services that can provide attributes for actors.
+#[async_trait]
+pub trait TrustedServiceInterface: Send + Sync {
+    /// Must return attributes for the actor. If actor is unknown returns an empty vector.
+    /// TODO: Maybe better to return None. Maybe in future we want to know if actor is not found?
+    async fn get_attributes_for_actor(
+        &self,
+        actor_ident: &str,
+    ) -> Result<Vec<Attribute>, ServiceError>;
+
+    /// Drop any cached attribute data so the next lookup fetches fresh.
+    ///
+    /// A store that caches but forgets to override this would silently ignore
+    /// flushes. Implementors holding no cache should return `Ok(())`.
+    async fn flush(&self) -> Result<(), ServiceError>;
+
+    fn get_source_id(&self) -> &str;
+}
+
+/// Here we sketch out a manager for a bunch of interfaces to "trusted services" which
+/// are able to return attributes for actors. These will usually require a network
+/// request and so may be slow.
+///
+/// This manager needs to support a lot of concurrent reads and very infrequent updates of
+/// the underlying set of services.
+pub struct TrustedServicesMgr {
+    services: ArcSwap<Vec<Arc<dyn TrustedServiceInterface>>>,
+}
+
+impl TrustedServicesMgr {
+    /// Create a new TrustedServicesMgr instance with no services.
+    pub fn new() -> Self {
+        TrustedServicesMgr {
+            services: ArcSwap::new(Arc::new(Vec::new())),
+        }
+    }
+
+    /// Atomically replaces the whole service list.
+    pub fn update_services(&self, services: Vec<Arc<dyn TrustedServiceInterface>>) {
+        self.services.store(Arc::new(services));
+    }
+
+    /// Query all trusted services for attributes corresponding to the given actor.
+    /// Returns a vector of results from each service.
+    ///
+    /// Many decisions are TODO here. This currently just supports our local file "service".
+    pub async fn get_attributes_for_actor(
+        &self,
+        actor_ident: &str,
+    ) -> Vec<Result<Vec<Attribute>, ServiceError>> {
+        let snapshot = self.services.load_full(); // Arc<Vec<Arc<dyn ServiceInterface>>>
+
+        let futures = snapshot.iter().map(|svc| {
+            let svc = svc.clone(); // cheap Arc clone
+            async move { svc.get_attributes_for_actor(actor_ident).await }
+        });
+
+        join_all(futures).await
+    }
+
+    /// Query all trusted services for attributes corresponding to the given actor.
+    /// Returns a vector of results from each service.
+    ///
+    /// Many decisions are TODO here. This currently just supports our local file "service".
+    pub async fn get_attributes_from_source_for_actor(
+        &self,
+        source_ident: &str,
+        actor_ident: &str,
+    ) -> Vec<Result<Vec<Attribute>, ServiceError>> {
+        let snapshot = self.services.load_full(); // Arc<Vec<Arc<dyn ServiceInterface>>>
+
+        // TODO: Find the service with the matching ident and call get_attributes_for_actor on it...
+        if let Some(svc) = snapshot
+            .iter()
+            .find(|svc| svc.get_source_id() == source_ident)
+        {
+            let svc = svc.clone();
+            return vec![svc.get_attributes_for_actor(actor_ident).await];
+        }
+
+        vec![Err(ServiceError::TrustedServiceNotFound(
+            source_ident.to_string(),
+        ))]
+    }
+
+    /// Ask every trusted service to drop its cached attribute data, so the next lookup
+    /// fetches fresh. Returns one result per service.
+    pub async fn flush_all(&self) -> Vec<Result<(), ServiceError>> {
+        let snapshot = self.services.load_full();
+
+        // TODO: I do not want a failure of one service to stop the rest of the flusing. I'd like to log the error.
+
+        let futures = snapshot.iter().map(|svc| {
+            let svc = svc.clone(); // cheap Arc clone
+            async move { svc.flush().await }
+        });
+
+        join_all(futures).await
+    }
+}
+
+/// File based attributes encoded in JSON.
+/// This is a placeholder until we have a real attribute service and protocol.
+#[derive(Debug)]
+pub struct FileAttributeStore {
+    id: String,
+    mapper: AttributeMapper,
+    ttl: Duration,
+    fp: PathBuf,
+    snapshot: ArcSwap<Snapshot>,
+    /// Serializes concurrent reloads; reads remain lock-free via ArcSwap.
+    refresh_lock: tokio::sync::Mutex<()>,
+}
+
+/// Attribute data and the instant it goes stale, swapped as a unit so the two can
+/// never drift apart.
+#[derive(Debug)]
+struct Snapshot {
+    attributes: ActorAttributes,
+    expires_at: Instant,
+}
+
+impl Snapshot {
+    /// How much validity this snapshot has left; zero once it has expired.
+    /// Saturating because `Instant - Instant` panics on underflow.
+    fn remaining(&self) -> Duration {
+        self.expires_at.saturating_duration_since(Instant::now())
+    }
+}
+
+type ActorId = String;
+type AttributeName = String;
+type AttributeValue = String;
+
+#[derive(Debug, Deserialize, Clone)]
+struct ActorAttributes(BTreeMap<ActorId, BTreeMap<AttributeName, Vec<AttributeValue>>>);
+
+// ponytail: blocking read of a small local JSON file, at most once per `ttl` and always
+// under the refresh lock. Move to tokio::fs (or spawn_blocking, as actor_mgr.rs does) if
+// the file ever gets big enough to stall the runtime.
+fn load_actor_attributes_from_file(fp: &Path) -> Result<ActorAttributes, ServiceError> {
+    let contents = fs::read_to_string(fp)?;
+    let attributes = serde_json::from_str(&contents)?;
+    Ok(attributes)
+}
+
+impl FileAttributeStore {
+    /// Create new `FileAttributeStore` instance.
+    ///
+    /// `id` is written as the "source" of each attribute.
+    ///
+    /// `ttl` is used as the expiration time for the whole store -- it will be refreshed when the TTL runs out.
+    ///  And attribiutes from the store will get an expiration time based on the time remaining until the TTL.
+    ///
+    /// `fp` must point to an existing file containing the actor attributes list in JSON format.
+    ///
+    /// ## Errors
+    /// - `ServiceError::Param` if `ttl` is below [`MIN_ATTRIBUTE_TTL`]. A store that short
+    ///   would sit permanently below the refresh floor and reload on every single request.
+    pub fn new(
+        id: String,
+        mapper: AttributeMapper,
+        ttl: Duration,
+        fp: &Path,
+    ) -> Result<Self, ServiceError> {
+        if ttl < MIN_ATTRIBUTE_TTL {
+            return Err(ServiceError::Param(format!(
+                "trusted service '{id}' ttl {ttl:?} is below the minimum of {MIN_ATTRIBUTE_TTL:?}"
+            )));
+        }
+        let snapshot = Snapshot {
+            attributes: load_actor_attributes_from_file(fp)?,
+            expires_at: Instant::now() + ttl,
+        };
+        let store = FileAttributeStore {
+            id,
+            mapper,
+            ttl,
+            fp: fp.into(),
+            snapshot: ArcSwap::from_pointee(snapshot),
+            refresh_lock: tokio::sync::Mutex::new(()),
+        };
+        Ok(store)
+    }
+
+    /// The live snapshot, re-reading the source file first if the current one is at or
+    /// below the [`MIN_ATTRIBUTE_TTL`] floor.
+    ///
+    /// Only one caller does the reload; the rest wait on `refresh_lock` and re-check, so a
+    /// burst of concurrent requests against an expired store costs one file read, not N.
+    async fn live_snapshot(&self) -> Result<Arc<Snapshot>, ServiceError> {
+        let snapshot = self.snapshot.load_full();
+        if snapshot.remaining() >= MIN_ATTRIBUTE_TTL {
+            return Ok(snapshot);
+        }
+
+        let _guard = self.refresh_lock.lock().await;
+
+        // Re-check: another caller may have refreshed while we waited on the lock.
+        let snapshot = self.snapshot.load_full();
+        if snapshot.remaining() >= MIN_ATTRIBUTE_TTL {
+            return Ok(snapshot);
+        }
+
+        let fresh = Arc::new(Snapshot {
+            attributes: load_actor_attributes_from_file(&self.fp)?,
+            expires_at: Instant::now() + self.ttl,
+        });
+        self.snapshot.store(fresh.clone());
+        Ok(fresh)
+    }
+}
+
+#[async_trait]
+impl TrustedServiceInterface for FileAttributeStore {
+    fn get_source_id(&self) -> &str {
+        &self.id
+    }
+
+    /// Use the actor 'CN' to look up the corresponding attributes in the store.
+    async fn get_attributes_for_actor(
+        &self,
+        actor_ident: &str,
+    ) -> Result<Vec<Attribute>, ServiceError> {
+        // Reloads from file if the cached data is at or below the TTL floor.
+        let snapshot = self.live_snapshot().await?;
+
+        let Some(attributes) = snapshot.attributes.0.get(actor_ident) else {
+            // actor not found in the attribute store
+            debug!(target: TS, "{}: actor '{actor_ident}' not found in the attribute store", self.id);
+            return Ok(Vec::new());
+        };
+
+        // Add each attribute to the actor. Attribute lifetime is tied to the store's own
+        // freshness, and `live_snapshot` guarantees at least MIN_ATTRIBUTE_TTL of it.
+        let mut result = Vec::new();
+        let src_builder = AttributeSource::new(self.id.clone());
+        let remaining = snapshot.remaining();
+
+        for (name, values) in attributes {
+            if let Some((zpr_name, hint)) = self.mapper.map_attribute(name) {
+                let bldr = src_builder.builder(zpr_name).expires_in(remaining);
+                let attr = match hint {
+                    AttrHint::SingleValued => {
+                        bldr.value(values.first().cloned().unwrap_or_default())
+                    }
+                    AttrHint::MultiValued => bldr.values(values),
+                    AttrHint::Tag(tag_value) => bldr.value(tag_value),
+                };
+                result.push(attr);
+            }
+        }
+        Ok(result)
+    }
+
+    /// Expire the cached data in place so the next lookup re-reads the file. Reuses the
+    /// normal staleness path rather than carrying a separate "force reload" flag.
+    async fn flush(&self) -> Result<(), ServiceError> {
+        self.snapshot.rcu(|cur| Snapshot {
+            attributes: cur.attributes.clone(),
+            expires_at: Instant::now(),
+        });
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct AttributeMapper {
+    // Linear scan. A trusted service returns a handful of attributes; index it
+    // by service_attr_key if that ever stops being true.
+    pub mappings: Vec<AttrMapping>,
+}
+
+enum AttrHint {
+    /// Attribute is declared as single valued.
+    SingleValued,
+
+    /// Attribute is declared as multi valued.
+    MultiValued,
+
+    /// Attribute is declared as a tag.
+    Tag(String), // if a tag, this gets the value.
+}
+
+impl AttributeMapper {
+    /// Map the trusted service name of an attribute into the zpr name of an attribute.
+    /// If the `ts_key` presented is not in the mapping data, then None is returned.
+    ///
+    /// Tags are tricky since we need to parse the ZPR name and figure out the class
+    /// that the attribute belongs on (user, device, service, link).  Then the evaluator
+    /// uses a special key for tags: '<CLASS>.zpr.tag'.
+    ///
+    /// For example, a sample tag mapping is "lazy -> #user.lazy"
+    /// In that case this returns ("user.zpr.tag", AttrHint::Tag("lazy"))
+    ///
+    fn map_attribute(&self, ts_key: &str) -> Option<(String, AttrHint)> {
+        // `AttrMapping::attr` already carries the decoded RHS spec, so `zpl_key`/`zpl_value`
+        // handle the tag class translation ("#user.lazy" -> "user.zpr.tag" + "user.lazy").
+        let attr = &self
+            .mappings
+            .iter()
+            .find(|m| m.service_attr_key == ts_key)?
+            .attr;
+
+        let hint = if attr.is_tag() {
+            AttrHint::Tag(attr.zpl_value())
+        } else if attr.is_multi_valued() {
+            AttrHint::MultiValued
+        } else {
+            AttrHint::SingleValued
+        };
+        Some((attr.zpl_key(), hint))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zpr::policy_types::parse_attribute_mapping;
+
+    /// A mapper covering all three RHS spec forms: single, multi, and tag.
+    fn test_mapper() -> AttributeMapper {
+        AttributeMapper {
+            mappings: [
+                "color -> user.color",
+                "roles -> user.role{}",
+                "lazy -> #user.lazy",
+            ]
+            .iter()
+            .map(|m| parse_attribute_mapping(m).unwrap())
+            .collect(),
+        }
+    }
+
+    /// Each spec form must yield the right zpr key and hint, and an unmapped service key
+    /// must be dropped rather than passed through.
+    #[test]
+    fn test_map_attribute_covers_every_spec_form() {
+        let mapper = test_mapper();
+
+        let (key, hint) = mapper.map_attribute("color").unwrap();
+        assert_eq!(key, "user.color");
+        assert!(matches!(hint, AttrHint::SingleValued));
+
+        let (key, hint) = mapper.map_attribute("roles").unwrap();
+        assert_eq!(key, "user.role");
+        assert!(matches!(hint, AttrHint::MultiValued));
+
+        // A tag maps onto the evaluator's per-class tag key, carrying the tag as the value.
+        let (key, hint) = mapper.map_attribute("lazy").unwrap();
+        assert_eq!(key, "user.zpr.tag");
+        assert!(matches!(hint, AttrHint::Tag(t) if t == "user.lazy"));
+
+        assert!(mapper.map_attribute("not_in_the_mapping").is_none());
+    }
+
+    /// Write `contents` to a uniquely named file in the system temp dir and return the path.
+    /// Tests share a process, so a distinct `name` per test is enough to avoid collisions.
+    fn write_fixture(name: &str, contents: &str) -> PathBuf {
+        let fp = std::env::temp_dir().join(name);
+        fs::write(&fp, contents).unwrap();
+        fp
+    }
+
+    /// A ttl below the floor would leave the store permanently stale, reloading on every
+    /// request. Construction must reject it rather than let that happen at runtime.
+    #[test]
+    fn test_new_rejects_ttl_below_floor() {
+        let fp = write_fixture("vs-fas-short-ttl.json", "{}");
+        let result = FileAttributeStore::new(
+            "test".to_string(),
+            test_mapper(),
+            MIN_ATTRIBUTE_TTL - Duration::from_secs(1),
+            &fp,
+        );
+        assert!(matches!(result, Err(ServiceError::Param(_))));
+
+        // The same store with a ttl at the floor is accepted.
+        assert!(
+            FileAttributeStore::new("test".to_string(), test_mapper(), MIN_ATTRIBUTE_TTL, &fp)
+                .is_ok()
+        );
+        fs::remove_file(&fp).unwrap();
+    }
+
+    /// The core of the interior-mutability rework: an unexpired store keeps serving its
+    /// cached data even after the file changes underneath it, and `flush` makes the very
+    /// next read pick up the new contents.
+    #[tokio::test]
+    async fn test_flush_forces_reload_on_next_read() {
+        let fp = write_fixture("vs-fas-flush.json", r#"{"alice": {"color": ["red"]}}"#);
+        let store = FileAttributeStore::new(
+            "test".to_string(),
+            test_mapper(),
+            Duration::from_secs(3600),
+            &fp,
+        )
+        .unwrap();
+
+        let snapshot = store.live_snapshot().await.unwrap();
+        assert!(snapshot.attributes.0.contains_key("alice"));
+
+        // Change the file. The store is nowhere near its ttl, so it must not notice yet.
+        fs::write(&fp, r#"{"bob": {"color": ["blue"]}}"#).unwrap();
+        let snapshot = store.live_snapshot().await.unwrap();
+        assert!(snapshot.attributes.0.contains_key("alice"));
+        assert!(!snapshot.attributes.0.contains_key("bob"));
+
+        // After a flush the next read reloads.
+        store.flush().await.unwrap();
+        let snapshot = store.live_snapshot().await.unwrap();
+        assert!(snapshot.attributes.0.contains_key("bob"));
+        assert!(!snapshot.attributes.0.contains_key("alice"));
+
+        // A fresh reload resets the clock, so emitted attributes clear the floor again.
+        assert!(snapshot.remaining() >= MIN_ATTRIBUTE_TTL);
+
+        fs::remove_file(&fp).unwrap();
+    }
+
+    /// `flush_all` must reach every registered service.
+    #[tokio::test]
+    async fn test_manager_flush_all_reaches_every_service() {
+        let fp = write_fixture("vs-fas-flush-all.json", r#"{"alice": {"color": ["red"]}}"#);
+        let mgr = TrustedServicesMgr::new();
+        let store = Arc::new(
+            FileAttributeStore::new(
+                "test".to_string(),
+                test_mapper(),
+                Duration::from_secs(3600),
+                &fp,
+            )
+            .unwrap(),
+        );
+        mgr.update_services(vec![store.clone()]);
+
+        assert!(store.snapshot.load().remaining() >= MIN_ATTRIBUTE_TTL);
+
+        let results = mgr.flush_all().await;
+        assert_eq!(results.len(), 1);
+        assert!(results[0].is_ok());
+
+        // Flushed means expired: the cached data is now below the floor.
+        assert!(store.snapshot.load().remaining() < MIN_ATTRIBUTE_TTL);
+
+        fs::remove_file(&fp).unwrap();
+    }
+}

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -342,6 +342,11 @@ impl VisaMgr {
         policy_version: u64,
         vinst: u64,
     ) -> Result<VisaWithMetadata, ServiceError> {
+        // TODO: The visa expiration needs to be computed as watever is soonest:
+        //   - expiration of authentication of source actor
+        //   - expiration of authentication of destination actor
+        //   - expiration of any single attribute used to produce the visa (ie, a matching attribute)
+        //   - the system default maximum visa lifetime
         let expiration_time = std::time::SystemTime::now()
             .checked_add(config::DEFAULT_VISA_EXPIRATION)
             .ok_or_else(|| {

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -19,6 +19,7 @@
 //! Once we have a path, the visa is queued up for install on all the impacted nodes and
 //! returned to the caller.
 
+use std::collections::HashSet;
 use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
@@ -35,7 +36,7 @@ use libeval::route::Route;
 
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 use zpr::vsapi_types::{DenyCode, PacketDesc, Visa};
 
 use crate::assembly::Assembly;
@@ -215,27 +216,52 @@ async fn process_visa_request_job(asm: Arc<Assembly>, job: VisaRequestJob) {
 /// Run visa request.
 async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaRequestResult {
     let (source_actor, dest_actor) = get_actors(&asm, job).await?;
-    let (source_actor, dest_actor) =
+    let (mut source_actor, mut dest_actor) =
         match resolve_actors_or_deny(&asm, job, source_actor, dest_actor).await {
             Ok(actors) => actors,
             Err(decision) => return Ok(decision),
         };
 
     // Both actors must have addresses. Extract them here or return a fail.
-    let Some(source_zpr_addr) = source_actor.get_zpr_addr() else {
-        debug!(target: VREQ,
-            "visa request from {:?} denied: source actor {:?} has no ZPR address",
-            job.requesting_node, source_actor
-        );
-        return Ok(VisaDecision::Deny(DenyCode::SourceNotFound));
+    let source_zpr_addr = match source_actor.get_zpr_addr() {
+        Some(addr) => *addr,
+        None => {
+            debug!(target: VREQ,
+                "visa request from {:?} denied: source actor {:?} has no ZPR address",
+                job.requesting_node, source_actor
+            );
+            return Ok(VisaDecision::Deny(DenyCode::SourceNotFound));
+        }
     };
-    let Some(dest_zpr_addr) = dest_actor.get_zpr_addr() else {
-        debug!(target: VREQ,
-            "visa request from {:?} denied: dest actor {:?} has no ZPR address",
-            job.requesting_node, dest_actor
-        );
-        return Ok(VisaDecision::Deny(DenyCode::DestNotFound));
+    let dest_zpr_addr = match dest_actor.get_zpr_addr() {
+        Some(addr) => *addr,
+        None => {
+            debug!(target: VREQ,
+                "visa request from {:?} denied: dest actor {:?} has no ZPR address",
+                job.requesting_node, dest_actor
+            );
+            return Ok(VisaDecision::Deny(DenyCode::DestNotFound));
+        }
     };
+
+    // TODO: make sure libeval ignores expired attributes
+
+    // If necessary, refresh any expired attributes
+    // TODO: Can we parallize this?
+    if refresh_expired_attributes(&asm, &mut source_actor).await {
+        // write to store
+        if let Err(e) = asm.actor_mgr.update_actor(&source_actor).await {
+            error!(target: VREQ, "failed to update source actor after refreshing attributes: {}", e);
+            return Ok(VisaDecision::Deny(DenyCode::NoReason));
+        }
+    }
+    if refresh_expired_attributes(&asm, &mut dest_actor).await {
+        // write to store
+        if let Err(e) = asm.actor_mgr.update_actor(&dest_actor).await {
+            error!(target: VREQ, "failed to update dest actor after refreshing attributes: {}", e);
+            return Ok(VisaDecision::Deny(DenyCode::NoReason));
+        }
+    }
 
     // Docking-node resolution, routing, and policy eval all live in the shared
     // core (used by the Phase 2 sweep too). Actor resolution above stays
@@ -245,8 +271,8 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
         &asm,
         &source_actor,
         &dest_actor,
-        source_zpr_addr,
-        dest_zpr_addr,
+        &source_zpr_addr,
+        &dest_zpr_addr,
         &job.packet_desc,
         &policy,
     )
@@ -259,6 +285,47 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
         } => visa_from_allow(asm.clone(), job, &hits, &policy, default_route).await,
         PolicyOutcome::Deny(code) => Ok(VisaDecision::Deny(code)),
     }
+}
+
+/// Look for expired attributes and refresh them from the trusted service manager if possible.
+async fn refresh_expired_attributes(asm: &Assembly, actor: &mut Actor) -> bool {
+    let actor_ident = match actor.get_cn() {
+        Some(cn) => cn.to_string(),
+        None => return false,
+    };
+
+    let mut ts_sources = HashSet::new();
+    for attr in actor.attrs_iter() {
+        if attr.is_expired() {
+            ts_sources.insert(attr.get_source().to_string());
+        }
+    }
+    let mut updates = 0;
+    if !ts_sources.is_empty() {
+        for source in &ts_sources {
+            for ts_result in asm
+                .ts_mgr
+                .get_attributes_from_source_for_actor(source, &actor_ident)
+                .await
+            {
+                match ts_result {
+                    Ok(ts_attrs) => {
+                        for attr in ts_attrs {
+                            if let Err(e) = actor.add_attribute(attr) {
+                                warn!(target: VREQ, "failed to add attribute for actor {}: {}", actor_ident, e);
+                            } else {
+                                updates += 1;
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        warn!(target: VREQ, "ts service attr lookup failed for actor {}: {}", actor_ident, e);
+                    }
+                }
+            }
+        }
+    }
+    updates > 0 // TRUE if we have changed an attribute
 }
 
 /// Resolve an actor's docking node: the connection-table entry, falling back to
@@ -285,6 +352,20 @@ pub(crate) async fn evaluate_against_policy(
     pkt: &PacketDesc,
     policy: &Arc<Policy>,
 ) -> Result<PolicyOutcome, ServiceError> {
+    // If auth is expired it's a no.
+    if let Some(exp) = src.get_authentication_expiration() {
+        if exp < SystemTime::now() {
+            info!(target: VREQ, "eval denied: source actor authentication expired: {src:?}");
+            return Ok(PolicyOutcome::Deny(DenyCode::SourceAuthError));
+        }
+    }
+    if let Some(exp) = dst.get_authentication_expiration() {
+        if exp < SystemTime::now() {
+            info!(target: VREQ, "eval denied: dest actor authentication expired: {dst:?}");
+            return Ok(PolicyOutcome::Deny(DenyCode::DestAuthError));
+        }
+    }
+
     // For AAA actors the docking node comes from the AAA table registered on the
     // request side rather than the connection table.
     let Some(node_addr_a) = resolve_docking_node(asm, src, src_zpr) else {
@@ -361,21 +442,11 @@ pub(crate) fn route_for_allow(
 /// Fabricate an AAA actor for an anonymous endpoint at the given address.
 fn fabricate_aaa_actor(anon_addr: &IpAddr, expiration: SystemTime) -> Actor {
     let mut anon_actor = Actor::new();
-    let _ = anon_actor.add_attribute(
-        Attribute::builder(key::ZPR_ADDR)
-            .expires(expiration)
-            .value(anon_addr.to_string()),
-    );
-    let _ = anon_actor.add_attribute(
-        Attribute::builder(key::AUTHORITY)
-            .expires(expiration)
-            .value("vs_hack_anon_to_auth"),
-    );
-    let _ = anon_actor.add_attribute(
-        Attribute::builder(key::ROLE)
-            .expires(expiration)
-            .value(ROLE_ADAPTER),
-    );
+    let _ =
+        anon_actor.add_attribute(Attribute::builder(key::ZPR_ADDR).value(anon_addr.to_string()));
+    let _ =
+        anon_actor.add_attribute(Attribute::builder(key::AUTHORITY).value("vs_hack_anon_to_auth"));
+    let _ = anon_actor.add_attribute(Attribute::builder(key::ROLE).value(ROLE_ADAPTER));
     let _ = anon_actor.add_attribute(
         Attribute::builder(key::CN)
             .expires(expiration)

--- a/vs/src/vsapi_worker.rs
+++ b/vs/src/vsapi_worker.rs
@@ -1052,13 +1052,18 @@ impl vsapi::v_s_handle::Server for VSHandleImpl {
 
         let addr_attr = actor.get_attribute(key::ZPR_ADDR).unwrap();
         {
-            let expires_utc: DateTime<Utc> = addr_attr.get_expires().into();
+            let expires_val = if let Some(exp) = actor.get_authentication_expiration() {
+                let dt: DateTime<Utc> = exp.into();
+                dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+            } else {
+                "never".to_string()
+            };
             info!(
                 target: API,
                 "successfully authorized {} {:?} with address {actor_addr} (expires {})",
                 if actor.is_node() { "node" } else { "adapter" },
                 actor.get_cn(),
-                expires_utc.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+                expires_val
             );
         }
         let zpr_con = Connection::new(actor_addr, addr_attr.get_expires());

--- a/zpt/src/zmachine.rs
+++ b/zpt/src/zmachine.rs
@@ -247,11 +247,7 @@ impl ZMachine {
         };
 
         if let Some(ctx) = state.get_ctx() {
-            match ctx.approve_connection(
-                libeval_authd_claims,
-                libeval_unauthed_claims,
-                Duration::from_secs(3600),
-            ) {
+            match ctx.approve_connection(libeval_authd_claims, libeval_unauthed_claims) {
                 Ok(actor) => {
                     outfmt.write_connection_approved(&actor);
                 }


### PR DESCRIPTION
  - Adds a TrustedServicesMgr abstraction for querying multiple attribute providers concurrently.

  - Implements a file-backed JSON attribute store as the first provider.

  - Adds attribute provenance:
      - Every attribute now records its source.
      - Internally generated attributes use the source "zpr".
      - External attributes use the trusted service’s ID.

  - Changes actor attribute storage from a Vec to a HashMap keyed by attribute name:
      - Adding an attribute with the same key now replaces the previous value.
      - Attribute lookup becomes direct rather than a linear scan.

  - Integrates trusted attributes into authorization:
      - Connection authorization queries all registered trusted services before policy evaluation.
      - Returned attributes are included in the authenticated actor claims.

  - Adds lazy attribute refresh during visa requests:
      - Expired externally sourced attributes are re-fetched from their original provider.
      - Refreshed actors are written back to actor storage.

  - Tightens authentication-expiration behavior:
      - Actor authentication expiration is now the earliest expiration of the authority or identity attributes.
      - Visa evaluation rejects actors whose authentication has expired.
      - Internally assigned role, service, address, and virtual-instance attributes generally no longer inherit authentication
        expiration.

  - Updates supporting infrastructure:
      - Adds trusted-service errors and a dedicated logging target.
      - Updates zpr-common from v0.20.0 to v0.21.0.
      - Raises the minimum policy compiler version from 0.13.0 to 0.14.0.
      - Reduces the Valkey lock refresh interval from 60 to 30 seconds.
      - Updates zpt for the changed evaluator API.

  The service manager is created empty, and this branch does not yet wire file-store configuration or
  registration into normal startup. 

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>