### PR TITLE
(248ts-stack) make sure libeval is sensitive to expired attributes

### DIFF
--- a/libeval/src/actor.rs
+++ b/libeval/src/actor.rs
@@ -135,6 +135,22 @@ impl Actor {
         Ok(())
     }
 
+    /// Removes the attribute named `key`, clearing any derived field it fed and
+    /// dropping it from the identity keys. Returns the removed attribute, or None
+    /// if the actor did not have one.
+    pub fn remove_attribute(&mut self, key: &str) -> Option<Attribute> {
+        let attr = self.attrs.remove(key)?;
+        match key {
+            key::ZPR_ADDR => self.zpr_addr = None,
+            key::SERVICES => self.provider = false,
+            key::CN => self.cn = None,
+            key::ROLE => self.role = Role::default(),
+            _ => (),
+        }
+        self.identity_keys.retain(|k| k != key);
+        Some(attr)
+    }
+
     pub fn get_attribute(&self, key: &str) -> Option<&Attribute> {
         self.attrs.get(key)
     }

--- a/libeval/src/eval.rs
+++ b/libeval/src/eval.rs
@@ -417,7 +417,7 @@ impl EvalContext {
                     }
                     debug!(target: EVAL, "policy #{i} matches FWD scope");
                     // This policy matches only if all conditions match.
-                    if self.match_policy_conditions(src_actor, dst_actor, &com_policy) {
+                    if self.match_policy_conditions(src_actor, dst_actor, &com_policy, allows) {
                         Some(Direction::Forward)
                     } else {
                         None
@@ -442,7 +442,7 @@ impl EvalContext {
                     }
                     debug!(target: EVAL, "policy #{i} matches REV scope");
                     // This policy matches only if all conditions match.
-                    if self.match_policy_conditions(dst_actor, src_actor, &com_policy) {
+                    if self.match_policy_conditions(dst_actor, src_actor, &com_policy, allows) {
                         Some(Direction::Reverse)
                     } else {
                         None
@@ -474,11 +474,14 @@ impl EvalContext {
         client_actor: &Actor,
         server_actor: &Actor,
         com_policy: &policy_capnp::c_policy::Reader,
+        for_allow: bool,
     ) -> bool {
-        // All conditions must match for the policy to match.
+        // All conditions must match for the policy to match. Expired attributes must
+        // not help satisfy an allow policy; denies are matched against all attributes,
+        // expired or not, so they stay fail-closed.
         if com_policy.has_client_conds() {
             for cond in com_policy.get_client_conds().unwrap() {
-                if !self.match_condition_to_actor(&cond, client_actor) {
+                if !self.match_condition_to_actor(&cond, client_actor, for_allow) {
                     debug!(target: EVAL, "-- client condition not met: {:?}", cond);
                     return false;
                 }
@@ -486,7 +489,7 @@ impl EvalContext {
         }
         if com_policy.has_service_conds() {
             for cond in com_policy.get_service_conds().unwrap() {
-                if !self.match_condition_to_actor(&cond, server_actor) {
+                if !self.match_condition_to_actor(&cond, server_actor, for_allow) {
                     debug!(target: EVAL, "-- service condition not met: {:?}", cond);
                     return false;
                 }
@@ -495,11 +498,13 @@ impl EvalContext {
         true
     }
 
-    /// Returns TRUE if the policy condition is satisfied by the actor.
+    /// Returns TRUE if the policy condition is satisfied by the actor. `for_allow`
+    /// marks this as part of the allow pass, where expired attributes cannot match.
     fn match_condition_to_actor(
         &self,
         cond: &policy_capnp::attr_expr::Reader,
         actor: &Actor,
+        for_allow: bool,
     ) -> bool {
         let value = if !cond.has_value() {
             None
@@ -521,6 +526,15 @@ impl EvalContext {
             }
         };
         let key = cond.get_key().unwrap().to_str().unwrap();
+
+        // An expired attribute is indeterminate: we can neither confirm nor rule out
+        // its value, so it can never satisfy an allow condition. Note this is not the
+        // same as treating it as absent -- absent would make NE and EXCLUDES *pass*,
+        // which would let expiry grant access. A key that was never set is unaffected.
+        if for_allow && actor.get_attribute(key).is_some_and(|a| a.is_expired()) {
+            debug!(target: EVAL, "-- condition key '{}' is expired, cannot match allow", key);
+            return false;
+        }
 
         match cond.get_op().unwrap() {
             policy_capnp::AttrOp::Eq => {
@@ -677,7 +691,7 @@ mod test {
     use crate::attribute::key;
     use bytes::{Buf, Bytes};
     use std::net::IpAddr;
-    use std::time::Duration;
+    use std::time::{Duration, SystemTime};
     use std::{path::Path, sync::Once};
     use tracing::Level;
     use tracing_subscriber::{filter::LevelFilter, fmt, prelude::*};
@@ -1148,6 +1162,121 @@ mod test {
 
         // "not-allowed" is not among join policy 4's permitted services.
         let actor = node_actor_with_services(&["zpr/n0/vss", "not-allowed"]);
+        assert!(!ctx.approve_connected(&actor).unwrap());
+    }
+
+    /// Build an attribute that is already expired.
+    fn expired(key: &str, value: &str) -> Attribute {
+        Attribute::builder(key)
+            .expires(SystemTime::now() - Duration::from_secs(1))
+            .value(value)
+    }
+
+    /// A user whose tag has expired cannot satisfy the allow policy that keys on it.
+    #[test]
+    fn test_expired_attr_cannot_match_allow() {
+        setup();
+        let pol = load_policy("basic.bin2");
+        let ctx = EvalContext::new(Arc::new(pol));
+
+        let mut user = Actor::new();
+        user.add_attribute(expired("user.zpr.tag", "user.red"))
+            .unwrap();
+
+        let mut service = Actor::new();
+        service
+            .add_attr_from_parts(key::SERVICES, "database", Duration::from_secs(60))
+            .unwrap();
+        service
+            .add_attr_from_parts("service.content", "red", Duration::from_secs(60))
+            .unwrap();
+        let packet =
+            PacketDesc::new_tcp("fd5a:5052:3000::1", "fd5a:5052:3000::2", 12345, 80).unwrap();
+
+        let decision = ctx.eval_request(&user, &service, &packet).unwrap();
+        match decision {
+            PartialEvalResult::Deny(FinalDeny::NoMatch(_)) => {}
+            _ => panic!("expected NoMatch deny, not {:?}", decision),
+        }
+    }
+
+    /// Expiry must never *grant* access: the deny pass ignores expiry, so an expired
+    /// green tag still hits the deny policy rather than falling through to NoMatch.
+    #[test]
+    fn test_expired_attr_does_not_flip_deny() {
+        setup();
+        let pol = load_policy("basic.bin2");
+        let ctx = EvalContext::new(Arc::new(pol));
+
+        let mut green_user = Actor::new();
+        green_user
+            .add_attribute(expired("user.zpr.tag", "user.green"))
+            .unwrap();
+
+        let mut service = Actor::new();
+        service
+            .add_attr_from_parts(key::SERVICES, "database", Duration::from_secs(60))
+            .unwrap();
+        service
+            .add_attr_from_parts("service.content", "red", Duration::from_secs(60))
+            .unwrap();
+        let packet =
+            PacketDesc::new_tcp("fd5a:5052:3000::1", "fd5a:5052:3000::2", 12345, 80).unwrap();
+
+        let decision = ctx.eval_request(&green_user, &service, &packet).unwrap();
+        match decision {
+            PartialEvalResult::Deny(FinalDeny::Deny(hits)) => {
+                assert_eq!(hits.len(), 1);
+                assert_eq!(hits[0].match_idx, 0);
+            }
+            _ => panic!("expected deny decision, not {:?}", decision),
+        }
+    }
+
+    /// A key the actor never sets at all behaves exactly as before: the new guard is
+    /// keyed on present-but-expired, not on absence.
+    #[test]
+    fn test_absent_attr_unaffected_by_expiry_guard() {
+        setup();
+        let pol = load_policy("basic.bin2");
+        let ctx = EvalContext::new(Arc::new(pol));
+
+        // No user.zpr.tag at all -- neither the deny nor the allow policy can match.
+        let user = Actor::new();
+
+        let mut service = Actor::new();
+        service
+            .add_attr_from_parts(key::SERVICES, "database", Duration::from_secs(60))
+            .unwrap();
+        service
+            .add_attr_from_parts("service.content", "red", Duration::from_secs(60))
+            .unwrap();
+        let packet =
+            PacketDesc::new_tcp("fd5a:5052:3000::1", "fd5a:5052:3000::2", 12345, 80).unwrap();
+
+        let decision = ctx.eval_request(&user, &service, &packet).unwrap();
+        match decision {
+            PartialEvalResult::Deny(FinalDeny::NoMatch(_)) => {}
+            _ => panic!("expected NoMatch deny, not {:?}", decision),
+        }
+    }
+
+    /// A connected node whose join-policy key (CN) has expired matches no join policy
+    /// and must be disconnected rather than silently re-approved. Role is a cached
+    /// snapshot and NEVER_EXPIRES, so `is_node()` still reports true.
+    #[test]
+    fn test_approve_connected_expired_join_key_rejects_node() {
+        setup();
+        let pol = load_policy("basic.bin2");
+        let ctx = EvalContext::new(Arc::new(pol));
+
+        let mut actor = node_actor_with_services(&["zpr/n0/vss"]);
+        // Overwrite the CN join policy 4 keys on with an expired copy.
+        actor
+            .add_attribute(expired(key::CN, "node.zpr.org"))
+            .unwrap();
+        assert!(actor.is_node());
+
         assert!(!ctx.approve_connected(&actor).unwrap());
     }
 }

--- a/libeval/src/joinpolicy.rs
+++ b/libeval/src/joinpolicy.rs
@@ -128,6 +128,14 @@ impl JPolicy {
 
             for attr in attrs {
                 if attr.get_key() == jp_exp.key {
+                    // An expired attribute is indeterminate -- it cannot satisfy any
+                    // expression, so this policy cannot grant the join. Returning false
+                    // rather than leaving `found` unset matters: the !found branch below
+                    // lets an empty-value EXCLUDES succeed, which would make expiry grant
+                    // access.
+                    if attr.is_expired() {
+                        return false;
+                    }
                     // We assume the key appears only once in the incoming list.
                     found = true;
 
@@ -181,6 +189,7 @@ impl JPolicy {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{Duration, SystemTime};
 
     fn attr(key: &str, values: Vec<&str>) -> Attribute {
         Attribute::builder(key).values(values)
@@ -514,5 +523,52 @@ mod tests {
         let attrs = vec![attr("k1", vec!["a"])];
 
         assert!(policy.matches(&attrs));
+    }
+
+    /// Build an already-expired attribute.
+    fn expired_attr(key: &str, values: Vec<&str>) -> Attribute {
+        Attribute::builder(key)
+            .expires(SystemTime::now() - Duration::from_secs(1))
+            .values(values)
+    }
+
+    /// Build a single-expression join policy.
+    fn jpolicy(op: AttrOp, value: Vec<&str>) -> JPolicy {
+        JPolicy {
+            matches: vec![AttrExp {
+                key: "k1".to_string(),
+                op,
+                value: value.into_iter().map(str::to_string).collect(),
+            }],
+            flags: EnumSet::new(),
+            services: None,
+        }
+    }
+
+    // An expired claim cannot satisfy an EQ expression it would otherwise match.
+    #[test]
+    fn test_jpolicy_expired_attr_fails_eq() {
+        let policy = jpolicy(AttrOp::Eq, vec!["a", "b"]);
+        assert!(policy.matches(&[attr("k1", vec!["a", "b"])]));
+        assert!(!policy.matches(&[expired_attr("k1", vec!["a", "b"])]));
+    }
+
+    // The no-flip case: an expired claim that would *pass* EXCLUDES must not, or
+    // expiry would grant the join.
+    #[test]
+    fn test_jpolicy_expired_attr_fails_excludes() {
+        let policy = jpolicy(AttrOp::Excludes, vec!["b"]);
+        assert!(policy.matches(&[attr("k1", vec!["a"])]));
+        assert!(!policy.matches(&[expired_attr("k1", vec!["a"])]));
+    }
+
+    // EXCLUDES with an empty value means "must not have this key". An expired
+    // attribute is present-but-indeterminate, so it must fail rather than count
+    // as absent.
+    #[test]
+    fn test_jpolicy_expired_attr_fails_excludes_empty_value() {
+        let policy = jpolicy(AttrOp::Excludes, vec![""]);
+        assert!(policy.matches(&[attr("k2", vec!["a"])]));
+        assert!(!policy.matches(&[expired_attr("k1", vec!["a"])]));
     }
 }

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -43,6 +43,7 @@ use crate::assembly::Assembly;
 use crate::counters::CounterType;
 use crate::error::ServiceError;
 use crate::logging::targets::VREQ;
+use crate::trusted_services_mgr::TrustedServicesMgr;
 use crate::visa_mgr::VisaWithMetadata;
 use crate::{config, net_mgr};
 
@@ -244,18 +245,16 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
         }
     };
 
-    // TODO: make sure libeval ignores expired attributes
-
     // If necessary, refresh any expired attributes
     // TODO: Can we parallize this?
-    if refresh_expired_attributes(&asm, &mut source_actor).await {
+    if refresh_expired_attributes(&asm.ts_mgr, &mut source_actor).await {
         // write to store
         if let Err(e) = asm.actor_mgr.update_actor(&source_actor).await {
             error!(target: VREQ, "failed to update source actor after refreshing attributes: {}", e);
             return Ok(VisaDecision::Deny(DenyCode::NoReason));
         }
     }
-    if refresh_expired_attributes(&asm, &mut dest_actor).await {
+    if refresh_expired_attributes(&asm.ts_mgr, &mut dest_actor).await {
         // write to store
         if let Err(e) = asm.actor_mgr.update_actor(&dest_actor).await {
             error!(target: VREQ, "failed to update dest actor after refreshing attributes: {}", e);
@@ -288,7 +287,14 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
 }
 
 /// Look for expired attributes and refresh them from the trusted service manager if possible.
-async fn refresh_expired_attributes(asm: &Assembly, actor: &mut Actor) -> bool {
+///
+/// A successful lookup is authoritative for that source: anything the service did not vend
+/// stays expired and is dropped from the actor. A failed lookup changes nothing, so a service
+/// outage cannot strip attributes.
+///
+/// Returns TRUE if any attribute was added, replaced, or removed.
+///
+async fn refresh_expired_attributes(ts_mgr: &TrustedServicesMgr, actor: &mut Actor) -> bool {
     let actor_ident = match actor.get_cn() {
         Some(cn) => cn.to_string(),
         None => return false,
@@ -300,32 +306,49 @@ async fn refresh_expired_attributes(asm: &Assembly, actor: &mut Actor) -> bool {
             ts_sources.insert(attr.get_source().to_string());
         }
     }
-    let mut updates = 0;
-    if !ts_sources.is_empty() {
-        for source in &ts_sources {
-            for ts_result in asm
-                .ts_mgr
-                .get_attributes_from_source_for_actor(source, &actor_ident)
-                .await
-            {
-                match ts_result {
-                    Ok(ts_attrs) => {
-                        for attr in ts_attrs {
-                            if let Err(e) = actor.add_attribute(attr) {
-                                warn!(target: VREQ, "failed to add attribute for actor {}: {}", actor_ident, e);
-                            } else {
-                                updates += 1;
-                            }
+
+    let mut changed = false;
+    for source in &ts_sources {
+        for ts_result in ts_mgr
+            .get_attributes_from_source_for_actor(source, &actor_ident)
+            .await
+        {
+            match ts_result {
+                Ok(ts_attrs) => {
+                    for attr in ts_attrs {
+                        if let Err(e) = actor.add_attribute(attr) {
+                            warn!(target: VREQ, "failed to add attribute for actor {}: {}", actor_ident, e);
+                        } else {
+                            changed = true;
                         }
                     }
-                    Err(e) => {
-                        warn!(target: VREQ, "ts service attr lookup failed for actor {}: {}", actor_ident, e);
-                    }
+                    // Whatever the service did not just set for this source is gone: drop
+                    // the leftovers rather than carry a permanently expired copy.
+                    changed |= prune_expired_from_source(actor, source);
+                }
+                Err(e) => {
+                    warn!(target: VREQ, "ts service attr lookup failed for actor {}: {}", actor_ident, e);
                 }
             }
         }
     }
-    updates > 0 // TRUE if we have changed an attribute
+    changed
+}
+
+/// Removes every still-expired attribute on `actor` that came from `source`.
+/// Returns TRUE if anything was removed.
+fn prune_expired_from_source(actor: &mut Actor, source: &str) -> bool {
+    let stale: Vec<String> = actor
+        .attrs_iter()
+        .filter(|a| a.is_expired() && a.get_source() == source)
+        .map(|a| a.get_key().to_string())
+        .collect();
+
+    for key in &stale {
+        debug!(target: VREQ, "dropping expired attribute '{key}' no longer vended by source '{source}'");
+        actor.remove_attribute(key);
+    }
+    !stale.is_empty()
 }
 
 /// Resolve an actor's docking node: the connection-table entry, falling back to
@@ -734,7 +757,7 @@ mod tests {
     use crate::test_helpers::{
         make_actor_with_services_defexp, make_container_bytes, make_node_actor_defexp,
     };
-    use libeval::attribute::ROLE_ADAPTER;
+    use libeval::attribute::{AttributeSource, ROLE_ADAPTER, SOURCE_ZPR};
     use libeval::eval_result::Direction;
     use libeval::policy::Policy;
     use libeval::route::LinkId;
@@ -1196,5 +1219,160 @@ mod tests {
             matches!(result, VisaDecision::Deny(DenyCode::NoMatch)),
             "expected NoMatch (policy eval reached)"
         );
+    }
+
+    /// A trusted service that records the actor idents it was asked about and returns
+    /// one canned, freshly-expiring attribute.
+    struct FakeTrustedService {
+        calls: std::sync::Mutex<Vec<String>>,
+    }
+
+    const FAKE_SOURCE: &str = "fake";
+    const FAKE_ATTR_KEY: &str = "user.dept";
+
+    #[async_trait::async_trait]
+    impl crate::trusted_services_mgr::TrustedServiceInterface for FakeTrustedService {
+        async fn get_attributes_for_actor(
+            &self,
+            actor_ident: &str,
+        ) -> Result<Vec<Attribute>, ServiceError> {
+            self.calls.lock().unwrap().push(actor_ident.to_string());
+            Ok(vec![
+                AttributeSource::new(FAKE_SOURCE)
+                    .builder(FAKE_ATTR_KEY)
+                    .expires_in(Duration::from_secs(600))
+                    .value("engineering"),
+            ])
+        }
+
+        async fn flush(&self) -> Result<(), ServiceError> {
+            Ok(())
+        }
+
+        fn get_source_id(&self) -> &str {
+            FAKE_SOURCE
+        }
+    }
+
+    /// A manager holding one FakeTrustedService, plus a handle on the fake for assertions.
+    fn ts_mgr_with_fake() -> (TrustedServicesMgr, Arc<FakeTrustedService>) {
+        let fake = Arc::new(FakeTrustedService {
+            calls: std::sync::Mutex::new(Vec::new()),
+        });
+        let mgr = TrustedServicesMgr::new();
+        mgr.update_services(vec![fake.clone()]);
+        (mgr, fake)
+    }
+
+    /// An actor with a CN and one already-expired attribute from the given source.
+    fn actor_with_expired_attr(cn: &str, source: &str) -> Actor {
+        let mut actor = Actor::new();
+        actor
+            .add_attribute(
+                Attribute::builder(key::CN)
+                    .expires_in(Duration::from_secs(600))
+                    .value(cn),
+            )
+            .unwrap();
+        actor
+            .add_attribute(
+                AttributeSource::new(source)
+                    .builder(FAKE_ATTR_KEY)
+                    .expires(SystemTime::now() - Duration::from_secs(1))
+                    .value("engineering"),
+            )
+            .unwrap();
+        actor
+    }
+
+    /// An expired attribute whose source is a registered trusted service is refreshed
+    /// from that service, and only that service is queried.
+    #[tokio::test]
+    async fn test_refresh_expired_attributes_refreshes_from_source() {
+        let (mgr, fake) = ts_mgr_with_fake();
+        let mut actor = actor_with_expired_attr("someone.zpr.org", FAKE_SOURCE);
+        assert!(actor.get_attribute(FAKE_ATTR_KEY).unwrap().is_expired());
+
+        assert!(refresh_expired_attributes(&mgr, &mut actor).await);
+        assert!(!actor.get_attribute(FAKE_ATTR_KEY).unwrap().is_expired());
+        assert_eq!(*fake.calls.lock().unwrap(), vec!["someone.zpr.org"]);
+    }
+
+    /// The hot path: no expired attributes means no trusted-service round trip at all.
+    #[tokio::test]
+    async fn test_refresh_expired_attributes_skips_when_nothing_expired() {
+        let (mgr, fake) = ts_mgr_with_fake();
+        let mut actor = Actor::new();
+        actor
+            .add_attribute(
+                Attribute::builder(key::CN)
+                    .expires_in(Duration::from_secs(600))
+                    .value("someone.zpr.org"),
+            )
+            .unwrap();
+
+        assert!(!refresh_expired_attributes(&mgr, &mut actor).await);
+        assert!(fake.calls.lock().unwrap().is_empty());
+    }
+
+    /// A trusted service that knows nothing about any actor: every lookup succeeds and
+    /// returns no attributes.
+    struct EmptyTrustedService;
+
+    #[async_trait::async_trait]
+    impl crate::trusted_services_mgr::TrustedServiceInterface for EmptyTrustedService {
+        async fn get_attributes_for_actor(
+            &self,
+            _actor_ident: &str,
+        ) -> Result<Vec<Attribute>, ServiceError> {
+            Ok(Vec::new())
+        }
+
+        async fn flush(&self) -> Result<(), ServiceError> {
+            Ok(())
+        }
+
+        fn get_source_id(&self) -> &str {
+            FAKE_SOURCE
+        }
+    }
+
+    /// A successful lookup is authoritative: an expired attribute the service no longer
+    /// vends is dropped from the actor rather than kept in its expired state.
+    #[tokio::test]
+    async fn test_refresh_expired_attributes_prunes_unvended() {
+        let mgr = TrustedServicesMgr::new();
+        mgr.update_services(vec![Arc::new(EmptyTrustedService)]);
+        let mut actor = actor_with_expired_attr("someone.zpr.org", FAKE_SOURCE);
+
+        assert!(refresh_expired_attributes(&mgr, &mut actor).await);
+        assert!(actor.get_attribute(FAKE_ATTR_KEY).is_none());
+        // The unexpired CN from another source is untouched.
+        assert!(actor.get_attribute(key::CN).is_some());
+    }
+
+    /// An unroutable source (no registered service) and an actor with no CN must both
+    /// fall through quietly rather than panic.
+    #[tokio::test]
+    async fn test_refresh_expired_attributes_handles_unrefreshable() {
+        let (mgr, fake) = ts_mgr_with_fake();
+
+        // SOURCE_ZPR is internal -- no trusted service vends it.
+        let mut internal = actor_with_expired_attr("someone.zpr.org", SOURCE_ZPR);
+        assert!(!refresh_expired_attributes(&mgr, &mut internal).await);
+        assert!(fake.calls.lock().unwrap().is_empty());
+
+        // No CN means no ident to look up.
+        let mut no_cn = Actor::new();
+        no_cn
+            .add_attribute(
+                AttributeSource::new(FAKE_SOURCE)
+                    .builder(FAKE_ATTR_KEY)
+                    .expires(SystemTime::now() - Duration::from_secs(1))
+                    .value("engineering"),
+            )
+            .unwrap();
+        assert!(!refresh_expired_attributes(&mgr, &mut no_cn).await);
+        assert!(fake.calls.lock().unwrap().is_empty());
     }
 }


### PR DESCRIPTION
 - Makes libeval expiration-aware:
      - Expired attributes cannot satisfy allow-policy conditions.
      - This includes negative conditions such as “not equal” or “excludes,” preventing expiration from accidentally granting
        access.

      - Deny policies still consider expired attributes, preserving fail-closed behavior.

  - Applies the same rule to join policies:
      - An expired attribute cannot satisfy any join-policy expression.
      - Connected nodes with expired join attributes will no longer be silently re-approved.

  - Makes trusted-service refresh authoritative:
      - Expired attributes are refreshed only from the service that originally supplied them.
      - If the service responds successfully but no longer returns an attribute, that stale attribute is removed.
      - If the service lookup fails, existing attributes are retained; an outage therefore does not mutate the actor.
      - Actors without expired attributes avoid trusted-service calls.

  - Adds Actor::remove_attribute():
      - Removes the stored attribute.
      - Also clears derived actor state such as CN, role, ZPR address, provider status, and identity-key membership when applicable.

  - Adds focused tests covering:
      - Expired attributes in allow and deny policies.
      - Join-policy expiration.
      - Successful trusted-service refresh.
      - Removal of attributes no longer supplied.
      - Missing services, missing CNs, and the no-refresh fast path.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>