### PR TITLE
(248ts-stack) populate the trusted service manager

### DIFF
--- a/libeval/src/policy.rs
+++ b/libeval/src/policy.rs
@@ -11,7 +11,9 @@ use crate::attribute::{Attribute, key};
 use crate::joinpolicy::JPolicy;
 
 use zpr::policy::v1 as policy_capnp;
-use zpr::policy_types::{AttrExp, NetAddr, Peering, PolicyTypeError, Service, ServiceType};
+use zpr::policy_types::{
+    AttrExp, NetAddr, Peering, PolicyTypeError, Service, ServiceType, TrustedService,
+};
 
 /// The default and the minimum.
 pub const DEFAULT_LINK_COST: u32 = 1;
@@ -57,6 +59,9 @@ pub struct Policy {
     bootstrap_keys: HashMap<String, PKey<Public>>,
     join_policies: Vec<JPolicy>,
     services: HashMap<String, Service>,
+    /// Trusted service records, keyed by `service_id`. Pairs with the `services` entry
+    /// whose `kind` is [`ServiceType::Trusted`].
+    trusted_services: HashMap<String, TrustedService>,
     cpol_sources: Vec<String>,
     serialized: Bytes,
     peer_table: Option<HashMap<IpAddr, Vec<Peer>>>, // zpr_addr -> peers
@@ -109,6 +114,7 @@ impl Policy {
         let bootstrap_keys = load_bootstrap_keys(&policy)?;
         let join_policies = load_join_policies(&policy)?;
         let services = load_services(&policy)?;
+        let trusted_services = load_trusted_services(&policy)?;
         let cpol_sources = load_cpol_sources(&policy)?;
         let peerings = load_peerings(&policy)?;
         let peer_table = if let Some(ref peerings) = peerings {
@@ -131,6 +137,7 @@ impl Policy {
             bootstrap_keys,
             join_policies,
             services,
+            trusted_services,
             cpol_sources,
             serialized,
             peer_table,
@@ -234,6 +241,11 @@ impl Policy {
 
     pub fn service_by_id(&self, id: &str) -> Option<&Service> {
         self.services.get(id)
+    }
+
+    /// The trusted service record declared for `id`, if this policy has one.
+    pub fn trusted_service_by_id(&self, id: &str) -> Option<&TrustedService> {
+        self.trusted_services.get(id)
     }
 
     /// Get the ZPL source for the communication policy by policy index.
@@ -437,6 +449,26 @@ fn load_services(
     Ok(services)
 }
 
+// Load (cache) the trusted service records found in the binary policy object. Each pairs
+// with a service whose kind is ServiceType::Trusted; see [Policy::trusted_service_by_id].
+fn load_trusted_services(
+    policy: &policy_capnp::policy::Reader,
+) -> Result<HashMap<String, TrustedService>, PolicyError> {
+    let mut trusted_services = HashMap::new();
+    if policy.has_trusted_services() {
+        for ts_rdr in policy.get_trusted_services()?.iter() {
+            let ts = TrustedService::try_from(ts_rdr).map_err(PolicyTypeError::from)?;
+            if let Some(previous) = trusted_services.insert(ts.service_id.clone(), ts) {
+                return Err(PolicyError::InvalidFormat(format!(
+                    "duplicate trusted service id in policy: {}",
+                    previous.service_id
+                )));
+            }
+        }
+    }
+    Ok(trusted_services)
+}
+
 fn load_peerings(
     policy: &policy_capnp::policy::Reader,
 ) -> Result<Option<Vec<Peering>>, PolicyError> {
@@ -461,7 +493,7 @@ mod test {
 
     use bytes::Bytes;
     use zpr::policy::v1 as policy_capnp;
-    use zpr::policy_types::{AttrExp, AttrOp, NetAddr, Peering};
+    use zpr::policy_types::{AttrExp, AttrOp, NetAddr, Peering, parse_attribute_mapping};
     use zpr::write_to::WriteTo;
 
     const MIN_COMPILER_VERSION: Version = Version(0, 13, 0);
@@ -541,6 +573,59 @@ mod test {
         let policy = Policy::new_empty();
 
         assert!(policy.get_cpol_source(0).is_none());
+    }
+
+    /// Build policy bytes carrying the given trusted service records (ids may repeat, so
+    /// the duplicate-id path can be exercised).
+    fn policy_bytes_with_trusted_services(records: &[TrustedService]) -> Bytes {
+        let mut msg = capnp::message::Builder::new_default();
+        {
+            let mut policy = msg.init_root::<policy_capnp::policy::Builder>();
+            let mut list = policy
+                .reborrow()
+                .init_trusted_services(records.len() as u32);
+            for (i, ts) in records.iter().enumerate() {
+                ts.write_to(&mut list.reborrow().get(i as u32));
+            }
+        }
+        let mut bytes = Vec::new();
+        capnp::serialize::write_message(&mut bytes, &msg).unwrap();
+        Bytes::from(bytes)
+    }
+
+    /// A trusted service record and its attribute mappings survive the capnp round trip
+    /// and are reachable by id.
+    #[test]
+    fn test_trusted_service_by_id_round_trip() {
+        let ts = TrustedService {
+            service_id: "attrfile".to_string(),
+            expiration_seconds: 3600,
+            returns_attrs: vec![parse_attribute_mapping("color -> user.color").unwrap()],
+            identity_attrs: vec![],
+        };
+        let policy =
+            Policy::new_from_policy_bytes(policy_bytes_with_trusted_services(&[ts])).unwrap();
+
+        let found = policy.trusted_service_by_id("attrfile").unwrap();
+        assert_eq!(found.expiration_seconds, 3600);
+        assert_eq!(found.returns_attrs[0].service_attr_key, "color");
+        assert_eq!(found.returns_attrs[0].attr.zpl_key(), "user.color");
+        assert!(policy.trusted_service_by_id("nope").is_none());
+    }
+
+    /// Two trusted service records sharing an id are ambiguous, so the whole policy is
+    /// rejected rather than silently keeping one of them.
+    #[test]
+    fn test_duplicate_trusted_service_id_errors() {
+        let ts = TrustedService {
+            service_id: "attrfile".to_string(),
+            expiration_seconds: 3600,
+            returns_attrs: vec![],
+            identity_attrs: vec![],
+        };
+        let result =
+            Policy::new_from_policy_bytes(policy_bytes_with_trusted_services(&[ts.clone(), ts]));
+        assert!(matches!(result, Err(PolicyError::InvalidFormat(_))));
     }
 
     fn ip(s: &str) -> IpAddr {

--- a/vs/src/assembly.rs
+++ b/vs/src/assembly.rs
@@ -32,7 +32,7 @@ pub struct Assembly {
     pub event_mgr: EventMgr,
     pub admin_api_keys: Arc<ReloadableApiKeys>,
     pub topo_mgr: TopologyMgr,
-    pub ts_mgr: TrustedServicesMgr,
+    pub ts_mgr: Arc<TrustedServicesMgr>,
 }
 
 impl Assembly {
@@ -53,6 +53,8 @@ impl Assembly {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+
+    use std::path::PathBuf;
 
     use crate::actor_mgr::ActorMgr;
     use crate::config;
@@ -115,6 +117,9 @@ pub mod tests {
         let (event_tx, _event_rx) = mpsc::channel(100);
         // TODO: Start event manager worker?
 
+        // Shared with the PolicyMgr below so it can publish policy-declared stores.
+        let ts_mgr = Arc::new(TrustedServicesMgr::new());
+
         Assembly {
             config: VSConfig::default(),
             counters: counters.clone(),
@@ -124,6 +129,8 @@ pub mod tests {
                 policy_container_bytes,
                 policy_repo,
                 Arc::new(FakeResolver::ip_only()),
+                ts_mgr.clone(),
+                PathBuf::from("."),
             )
             .await
             .expect("failed to initialize PolicyMgr"),
@@ -136,7 +143,7 @@ pub mod tests {
             event_mgr: EventMgr::new(event_tx),
             admin_api_keys: Arc::new(ReloadableApiKeys::default()),
             topo_mgr: TopologyMgr::new(LinkRepo::new(db_handle)),
-            ts_mgr: TrustedServicesMgr::new(),
+            ts_mgr,
         }
     }
 }

--- a/vs/src/config.rs
+++ b/vs/src/config.rs
@@ -131,6 +131,9 @@ pub struct CoreSection {
 
     /// Path to the API keys file.
     pub api_keys: Option<PathBuf>,
+
+    /// Directory holding the `<service-id>.json` attribute files for `api=file` trusted services.
+    pub file_ts_dir: Option<PathBuf>,
 }
 
 impl Default for VSConfig {
@@ -151,6 +154,7 @@ impl Default for CoreSection {
             vk_uri: Some(VALKEY_URI.to_string()),
             identity: Some(String::new()),
             api_keys: Some(PathBuf::from(DEFAULT_API_KEYS_FILE)),
+            file_ts_dir: Some(PathBuf::from(".")),
         }
     }
 }

--- a/vs/src/main.rs
+++ b/vs/src/main.rs
@@ -233,6 +233,15 @@ async fn main() -> std::process::ExitCode {
         }
     };
 
+    // The policy manager builds the trusted service stores as part of every policy
+    // transaction, so it needs the manager and the attribute file directory up front.
+    let ts_mgr = Arc::new(TrustedServicesMgr::new());
+    let file_ts_dir = cfg
+        .core
+        .file_ts_dir
+        .clone()
+        .unwrap_or_else(|| PathBuf::from("."));
+
     // Initialize the policy manager either from provided policy-container or from database.
     let policy_mgr = {
         let policy_mgr_res = match initial_policy_bytes {
@@ -241,6 +250,8 @@ async fn main() -> std::process::ExitCode {
                     p,
                     db::PolicyRepo::new(db_handle.clone()),
                     Arc::new(SystemResolver),
+                    ts_mgr.clone(),
+                    file_ts_dir,
                 )
                 .await
             }
@@ -248,6 +259,8 @@ async fn main() -> std::process::ExitCode {
                 PolicyMgr::new_from_state(
                     db::PolicyRepo::new(db_handle.clone()),
                     Arc::new(SystemResolver),
+                    ts_mgr.clone(),
+                    file_ts_dir,
                 )
                 .await
             }
@@ -314,7 +327,7 @@ async fn main() -> std::process::ExitCode {
         event_mgr: EventMgr::new(event_tx),
         admin_api_keys: Arc::new(admin_api_keys),
         topo_mgr: TopologyMgr::new(db::LinkRepo::new(db_handle)),
-        ts_mgr: TrustedServicesMgr::new(),
+        ts_mgr,
     });
 
     // Rebuild the in-memory router topology from persisted state. This runs after

--- a/vs/src/policy_mgr.rs
+++ b/vs/src/policy_mgr.rs
@@ -15,6 +15,7 @@ use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{debug, info};
 
@@ -28,6 +29,9 @@ use crate::db;
 use crate::error::{ResolverError, ServiceError, StoreError, TopologyError};
 use crate::loaded_policy::LoadedPolicy;
 use crate::logging::targets::MAIN;
+use crate::trusted_services_mgr::{
+    TrustedServiceInterface, TrustedServicesMgr, build_services_from_policy,
+};
 
 /// Abstracts DNS hostname resolution so it can be swapped out in tests.
 #[async_trait]
@@ -47,6 +51,9 @@ struct PolicyState {
     policy: Arc<Policy>,
     container: PolicyContainerBytes,
     links_by_node: HashMap<IpAddr, Vec<Link>>,
+    /// Attribute stores for the trusted services this policy declares. Republished to
+    /// `ts_mgr` on every successful swap so the stores can never outlive their policy.
+    trusted_services: Vec<Arc<dyn TrustedServiceInterface>>,
 }
 
 pub struct PolicyMgr {
@@ -55,6 +62,9 @@ pub struct PolicyMgr {
     /// Serializes concurrent policy updates; reads remain lock-free via ArcSwap.
     update_lock: tokio::sync::Mutex<()>,
     resolver: PolicyResolver,
+    ts_mgr: Arc<TrustedServicesMgr>,
+    /// Directory holding the `<service-id>.json` files for `api=file` trusted services.
+    file_ts_dir: PathBuf,
 }
 
 /// A consistent, owned snapshot of policy, source container, and resolved topology,
@@ -134,6 +144,8 @@ impl PolicyMgr {
         container_bytes: Vec<u8>,
         repo: db::PolicyRepo,
         resolver: Arc<dyn DnsResolver>,
+        ts_mgr: Arc<TrustedServicesMgr>,
+        file_ts_dir: PathBuf,
     ) -> Result<Self, ServiceError> {
         debug!(target: MAIN, "initializing policy manager");
 
@@ -162,11 +174,11 @@ impl PolicyMgr {
         // Resolve topology before persisting so a policy that cannot initialize is never
         // stored as the current policy. build_state borrows `loaded`, leaving it
         // available for the post-resolution persist below.
-        let state = Self::build_state(&resolver, &loaded).await?;
+        let state = Self::build_state(&resolver, &loaded, &file_ts_dir).await?;
         repo.set_current_policy(&loaded, false).await?;
 
         debug!(target: MAIN, "policy manager initialized successfully");
-        Ok(Self::from_state(state, repo, resolver))
+        Ok(Self::from_state(state, repo, resolver, ts_mgr, file_ts_dir))
     }
 
     /// Create a new policy manager, initializing it with the current policy in
@@ -180,6 +192,8 @@ impl PolicyMgr {
     pub async fn new_from_state(
         repo: db::PolicyRepo,
         resolver: Arc<dyn DnsResolver>,
+        ts_mgr: Arc<TrustedServicesMgr>,
+        file_ts_dir: PathBuf,
     ) -> Result<Self, ServiceError> {
         debug!(target: MAIN, "initializing policy manager from state");
         let mut loaded = repo
@@ -194,10 +208,12 @@ impl PolicyMgr {
                 policy.get_created().unwrap_or("unknown").to_string());
         }
         let resolver = PolicyResolver::new(resolver);
-        let state = Self::build_state(&resolver, &loaded).await?;
+        // A trusted service the policy declares but that cannot be configured (e.g. its
+        // attribute file is missing) fails startup; the error names the service and file.
+        let state = Self::build_state(&resolver, &loaded, &file_ts_dir).await?;
 
         debug!(target: MAIN, "policy manager initialized successfully");
-        Ok(Self::from_state(state, repo, resolver))
+        Ok(Self::from_state(state, repo, resolver, ts_mgr, file_ts_dir))
     }
 
     /// This is the placeholder "update policy" function. It only replaces the current policy
@@ -224,24 +240,43 @@ impl PolicyMgr {
     async fn build_state(
         resolver: &PolicyResolver,
         loaded: &LoadedPolicy,
-    ) -> Result<PolicyState, ResolverError> {
+        file_ts_dir: &Path,
+    ) -> Result<PolicyState, ServiceError> {
         let policy = loaded.policy();
         let links_by_node = resolver.resolve_topology(&policy).await?;
+        let trusted_services = build_services_from_policy(&policy, file_ts_dir)?;
         Ok(PolicyState {
             policy,
             container: loaded.container().clone(),
             links_by_node,
+            trusted_services,
         })
     }
 
     /// Assemble a PolicyMgr from already-built state and constructor-owned parts.
-    fn from_state(state: PolicyState, repo: db::PolicyRepo, resolver: PolicyResolver) -> Self {
+    fn from_state(
+        state: PolicyState,
+        repo: db::PolicyRepo,
+        resolver: PolicyResolver,
+        ts_mgr: Arc<TrustedServicesMgr>,
+        file_ts_dir: PathBuf,
+    ) -> Self {
+        ts_mgr.update_services(state.trusted_services.clone());
         PolicyMgr {
             state: ArcSwap::from_pointee(state),
             repo,
             update_lock: tokio::sync::Mutex::new(()),
             resolver,
+            ts_mgr,
+            file_ts_dir,
         }
+    }
+
+    /// Swap in `state` and republish its trusted service stores, so the manager's stores
+    /// always come from the policy that is currently live.
+    fn publish(&self, state: PolicyState) {
+        self.ts_mgr.update_services(state.trusted_services.clone());
+        self.state.store(Arc::new(state));
     }
 
     /// Update the current policy in state database and memory.  The new policy
@@ -269,10 +304,10 @@ impl PolicyMgr {
         // Resolve topology before swapping in the new state so a failed update leaves
         // the current policy, container, and topology untouched. The new policy,
         // container, and links swap in together as one PolicyState.
-        let state = Self::build_state(&self.resolver, &loaded).await?;
+        let state = Self::build_state(&self.resolver, &loaded, &self.file_ts_dir).await?;
         self.repo.set_current_policy(&loaded, false).await?;
 
-        self.state.store(Arc::new(state));
+        self.publish(state);
         Ok(vinst)
     }
 
@@ -392,7 +427,7 @@ async fn resolve_netaddr(
 mod tests {
     use super::*;
 
-    use crate::test_helpers::make_container_bytes;
+    use crate::test_helpers::{make_container_bytes, make_trusted_service_policy};
     use std::sync::Arc;
     use zpr::policy::v1 as policy_capnp;
     use zpr::policy_types::{AttrExp, NetAddr, Peering};
@@ -437,9 +472,69 @@ mod tests {
     async fn make_policy_mgr(container_bytes: Vec<u8>) -> PolicyMgr {
         let db = Arc::new(FakeDb::new());
         let repo = PolicyRepo::new(db);
-        PolicyMgr::new_with_initial_policy(container_bytes, repo, Arc::new(FakeResolver::ip_only()))
-            .await
-            .unwrap()
+        PolicyMgr::new_with_initial_policy(
+            container_bytes,
+            repo,
+            Arc::new(FakeResolver::ip_only()),
+            Arc::new(TrustedServicesMgr::new()),
+            PathBuf::from("."),
+        )
+        .await
+        .unwrap()
+    }
+
+    /// A PolicyMgr over a FakeDb that publishes its trusted service stores into `ts_mgr`
+    /// and looks for attribute files in `dir`.
+    async fn make_policy_mgr_with_ts(
+        container_bytes: Vec<u8>,
+        ts_mgr: Arc<TrustedServicesMgr>,
+        dir: &Path,
+    ) -> PolicyMgr {
+        PolicyMgr::new_with_initial_policy(
+            container_bytes,
+            PolicyRepo::new(Arc::new(FakeDb::new())),
+            Arc::new(FakeResolver::ip_only()),
+            ts_mgr,
+            dir.to_path_buf(),
+        )
+        .await
+        .unwrap()
+    }
+
+    /// A successful update publishes the policy's trusted service stores, and a later
+    /// update whose attribute file is missing fails without disturbing the live state.
+    #[tokio::test]
+    async fn test_update_publishes_stores_and_preserves_state_on_failure() {
+        let dir = std::env::temp_dir().join("vs-pm-ts");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("attrfile.json"),
+            r#"{"alice": {"color": ["red"]}}"#,
+        )
+        .unwrap();
+
+        let ts_mgr = Arc::new(TrustedServicesMgr::new());
+        let good = make_trusted_service_policy("attrfile", "file", Some(3600), &[]);
+        let mgr = make_policy_mgr_with_ts(good, ts_mgr.clone(), &dir).await;
+
+        // The declared store is live: looking it up by source id no longer reports it missing.
+        let results = ts_mgr
+            .get_attributes_from_source_for_actor("attrfile", "alice")
+            .await;
+        assert!(results[0].is_ok());
+
+        // An update declaring a service with no attribute file fails...
+        let bad = make_trusted_service_policy("nosuchfile", "file", Some(3600), &[]);
+        assert!(mgr.update_policy_from_container_bytes(bad).await.is_err());
+
+        // ...leaving the current policy and its published stores untouched.
+        assert_eq!(mgr.get_current().vinst(), 1);
+        let results = ts_mgr
+            .get_attributes_from_source_for_actor("attrfile", "alice")
+            .await;
+        assert!(results[0].is_ok());
+
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 
     /// Build a Peering between two ZPR addresses. describe_link(node_a, node_b) will find it.
@@ -477,6 +572,8 @@ mod tests {
             policy_with_peerings(&[peering]),
             PolicyRepo::new(db.clone()),
             Arc::new(FakeResolver::ip_only()),
+            Arc::new(TrustedServicesMgr::new()),
+            PathBuf::from("."),
         )
         .await;
 
@@ -692,6 +789,8 @@ mod tests {
             policy_no_topology(),
             PolicyRepo::new(db.clone()),
             Arc::new(FakeResolver::ip_only()),
+            Arc::new(TrustedServicesMgr::new()),
+            PathBuf::from("."),
         )
         .await
         .unwrap();
@@ -701,10 +800,14 @@ mod tests {
             .await
             .unwrap();
 
-        let restored =
-            PolicyMgr::new_from_state(PolicyRepo::new(db), Arc::new(FakeResolver::ip_only()))
-                .await
-                .unwrap();
+        let restored = PolicyMgr::new_from_state(
+            PolicyRepo::new(db),
+            Arc::new(FakeResolver::ip_only()),
+            Arc::new(TrustedServicesMgr::new()),
+            PathBuf::from("."),
+        )
+        .await
+        .unwrap();
         assert_eq!(restored.get_current().vinst(), 2);
     }
 
@@ -719,6 +822,8 @@ mod tests {
             container.clone(),
             PolicyRepo::new(db.clone()),
             Arc::new(FakeResolver::ip_only()),
+            Arc::new(TrustedServicesMgr::new()),
+            PathBuf::from("."),
         )
         .await
         .unwrap();
@@ -729,6 +834,8 @@ mod tests {
             container,
             PolicyRepo::new(db.clone()),
             Arc::new(FakeResolver::ip_only()),
+            Arc::new(TrustedServicesMgr::new()),
+            PathBuf::from("."),
         )
         .await
         .unwrap();
@@ -740,6 +847,8 @@ mod tests {
             policy_with_peerings(&[peering]),
             PolicyRepo::new(db),
             Arc::new(FakeResolver::ip_only()),
+            Arc::new(TrustedServicesMgr::new()),
+            PathBuf::from("."),
         )
         .await
         .unwrap();
@@ -757,6 +866,8 @@ mod tests {
             policy_no_topology(),
             PolicyRepo::new(db.clone()),
             Arc::new(FakeResolver::ip_only()),
+            Arc::new(TrustedServicesMgr::new()),
+            PathBuf::from("."),
         )
         .await
         .unwrap();
@@ -764,8 +875,13 @@ mod tests {
         db.del("policy:current").await.unwrap();
         db.hset("policy:current", "phash", &phash).await.unwrap();
 
-        let res =
-            PolicyMgr::new_from_state(PolicyRepo::new(db), Arc::new(FakeResolver::ip_only())).await;
+        let res = PolicyMgr::new_from_state(
+            PolicyRepo::new(db),
+            Arc::new(FakeResolver::ip_only()),
+            Arc::new(TrustedServicesMgr::new()),
+            PathBuf::from("."),
+        )
+        .await;
         assert!(res.is_err());
     }
 

--- a/vs/src/test_helpers.rs
+++ b/vs/src/test_helpers.rs
@@ -10,7 +10,11 @@ use std::net::SocketAddr;
 use std::time::Duration;
 use std::time::SystemTime;
 use zpr::policy::v1 as capnp_policy;
+use zpr::policy_types::{
+    JoinPolicy, PFlags, Service, ServiceType, TrustedService, parse_attribute_mapping,
+};
 use zpr::vsapi_types::{DockPepType, EndpointT, KeySet, PacketDesc, TcpUdpPep, Visa};
+use zpr::write_to::WriteTo;
 
 use crate::error::ResolverError;
 use crate::policy_mgr::DnsResolver;
@@ -160,6 +164,60 @@ pub fn make_visa(visa_id: u64, expires_in: Duration) -> Visa {
 /// care about its contents.
 pub fn make_pdesc() -> PacketDesc {
     PacketDesc::new_tcp("fd5a:5052::10", "fd5a:5052::20", 1234, 443).unwrap()
+}
+
+/// Build a policy container declaring one trusted service: a join policy providing a
+/// `ServiceType::Trusted(api)` service named `id`, plus (when `expiration_seconds` is
+/// `Some`) the matching `TrustedService` record carrying `mappings`.
+///
+/// Pass `None` for `expiration_seconds` to get the "service declared but no record"
+/// case. Each entry of `mappings` is a `"<service key> -> <attr spec>"` string.
+pub fn make_trusted_service_policy(
+    id: &str,
+    api: &str,
+    expiration_seconds: Option<u32>,
+    mappings: &[&str],
+) -> Vec<u8> {
+    let service = Service {
+        id: id.to_string(),
+        endpoints: Vec::new(),
+        kind: ServiceType::Trusted(api.to_string()),
+    };
+    let jp = JoinPolicy {
+        conditions: Vec::new(),
+        flags: PFlags::default(),
+        provides: Some(vec![service]),
+    };
+
+    let mut msg = capnp::message::Builder::new_default();
+    {
+        let mut policy_bldr = msg.init_root::<capnp_policy::policy::Builder>();
+        policy_bldr.set_created("2024-01-01T00:00:00Z");
+        policy_bldr.set_version(1);
+        policy_bldr.set_metadata("");
+        jp.write_to(&mut policy_bldr.reborrow().init_join_policies(1).get(0));
+
+        if let Some(secs) = expiration_seconds {
+            let ts = TrustedService {
+                service_id: id.to_string(),
+                expiration_seconds: secs,
+                returns_attrs: mappings
+                    .iter()
+                    .map(|m| parse_attribute_mapping(m).unwrap())
+                    .collect(),
+                identity_attrs: Vec::new(),
+            };
+            ts.write_to(&mut policy_bldr.reborrow().init_trusted_services(1).get(0));
+        }
+    }
+    let mut bytes = Vec::new();
+    capnp::serialize::write_message(&mut bytes, &msg).unwrap();
+    make_container_bytes(
+        crate::config::POLICY_MIN_COMPILER_MAJOR,
+        crate::config::POLICY_MIN_COMPILER_MINOR,
+        crate::config::POLICY_MIN_COMPILER_PATCH,
+        &bytes,
+    )
 }
 
 /// Build the Cap'n Proto encoded bytes of a `PolicyContainer` with the given

--- a/vs/src/topology_mgr.rs
+++ b/vs/src/topology_mgr.rs
@@ -577,7 +577,10 @@ impl TopologyQueryApi for TopologyMgr {
 mod tests {
     use super::*;
 
+    use std::path::PathBuf;
     use std::sync::Arc;
+
+    use crate::trusted_services_mgr::TrustedServicesMgr;
 
     use zpr::policy::v1 as policy_capnp;
     use zpr::policy_types::{AttrExp, AttrOp, NetAddr, Peering};
@@ -649,6 +652,8 @@ mod tests {
             ),
             repo,
             Arc::new(FakeResolver::ip_only()),
+            Arc::new(TrustedServicesMgr::new()),
+            PathBuf::from("."),
         )
         .await
         .unwrap()

--- a/vs/src/trusted_services_mgr.rs
+++ b/vs/src/trusted_services_mgr.rs
@@ -17,11 +17,15 @@ use std::fs;
 use tracing::debug;
 
 use libeval::attribute::{Attribute, AttributeSource};
+use libeval::policy::Policy;
 
-use zpr::policy_types::AttrMapping;
+use zpr::policy_types::{AttrMapping, ServiceType};
 
 use crate::error::ServiceError;
 use crate::logging::targets::TS;
+
+/// The api name in `ServiceType::Trusted(<api>)` served by [`FileAttributeStore`].
+const TS_API_FILE: &str = "file";
 
 /// Shortest TTL we are willing to stamp on an emitted attribute. When a store's cached
 /// data has less than this left, it refreshes early rather than hand a consumer something
@@ -115,6 +119,8 @@ impl TrustedServicesMgr {
 
     /// Ask every trusted service to drop its cached attribute data, so the next lookup
     /// fetches fresh. Returns one result per service.
+    ///
+    /// For api=file trusted services, this re-reads the file.
     pub async fn flush_all(&self) -> Vec<Result<(), ServiceError>> {
         let snapshot = self.services.load_full();
 
@@ -127,6 +133,59 @@ impl TrustedServicesMgr {
 
         join_all(futures).await
     }
+}
+
+/// Build the trusted service stores (only works for local file at the moment)
+/// declared by `policy`.
+///
+/// One store per `ServiceType::Trusted` service; for the `file` api the
+/// attribute data is `<file_ts_dir>/<service-id>.json`. Any service that cannot
+/// be built is an error, so a caller can run this before committing a policy
+/// and reject the whole policy on failure.
+///
+pub fn build_services_from_policy(
+    policy: &Policy,
+    file_ts_dir: &Path,
+) -> Result<Vec<Arc<dyn TrustedServiceInterface>>, ServiceError> {
+    let mut stores: Vec<Arc<dyn TrustedServiceInterface>> = Vec::new();
+
+    for svc in policy.list_services() {
+        let ServiceType::Trusted(api) = &svc.kind else {
+            continue;
+        };
+        if api != TS_API_FILE {
+            return Err(ServiceError::Param(format!(
+                "trusted service '{}': unsupported api '{api}'",
+                svc.id
+            )));
+        }
+        // The id becomes a filename, so it must not be able to escape `file_ts_dir`.
+        if svc.id.contains('/') || svc.id.contains("..") {
+            return Err(ServiceError::Param(format!(
+                "trusted service '{}': id is not a plain filename",
+                svc.id
+            )));
+        }
+        let Some(ts) = policy.trusted_service_by_id(&svc.id) else {
+            return Err(ServiceError::Param(format!(
+                "trusted service '{}': no trusted service record in policy",
+                svc.id
+            )));
+        };
+
+        // Covers the missing/unparseable file and the below-floor ttl (including an unset
+        // expiration_seconds of 0).
+        stores.push(Arc::new(FileAttributeStore::new(
+            svc.id.clone(),
+            AttributeMapper {
+                mappings: ts.returns_attrs.clone(),
+            },
+            Duration::from_secs(ts.expiration_seconds as u64),
+            &file_ts_dir.join(format!("{}.json", svc.id)),
+        )?));
+    }
+
+    Ok(stores)
 }
 
 /// File based attributes encoded in JSON.
@@ -346,7 +405,10 @@ impl AttributeMapper {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use zpr::policy_types::parse_attribute_mapping;
+    use zpr::policy_types::{PolicyContainerBytes, parse_attribute_mapping};
+
+    use crate::loaded_policy::LoadedPolicy;
+    use crate::test_helpers::make_trusted_service_policy;
 
     /// A mapper covering all three RHS spec forms: single, multi, and tag.
     fn test_mapper() -> AttributeMapper {
@@ -446,6 +508,73 @@ mod tests {
         assert!(snapshot.remaining() >= MIN_ATTRIBUTE_TTL);
 
         fs::remove_file(&fp).unwrap();
+    }
+
+    /// Decode a container built by `make_trusted_service_policy` into a `Policy`.
+    fn policy_from_container(container_bytes: Vec<u8>) -> Arc<Policy> {
+        let loaded = LoadedPolicy::from_container(
+            PolicyContainerBytes::from(container_bytes),
+            &crate::config::POLICY_MIN_VERSION,
+        )
+        .unwrap();
+        loaded.policy()
+    }
+
+    /// A well-formed `api=file` trusted service yields a working store: it is named after
+    /// the service and serves the mapped attributes out of `<id>.json`.
+    #[tokio::test]
+    async fn test_build_services_from_policy_happy_path() {
+        let dir = std::env::temp_dir().join("vs-bsfp-ok");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("attrfile.json"),
+            r#"{"alice": {"color": ["red"]}}"#,
+        )
+        .unwrap();
+
+        let policy = policy_from_container(make_trusted_service_policy(
+            "attrfile",
+            "file",
+            Some(3600),
+            &["color -> user.color"],
+        ));
+        let stores = build_services_from_policy(&policy, &dir).unwrap();
+
+        assert_eq!(stores.len(), 1);
+        assert_eq!(stores[0].get_source_id(), "attrfile");
+        let attrs = stores[0].get_attributes_for_actor("alice").await.unwrap();
+        assert_eq!(attrs.len(), 1);
+        assert_eq!(attrs[0].get_key(), "user.color");
+        assert!(attrs[0].value_has("red"));
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// Every way a declared trusted service can fail to configure must be an error, so the
+    /// policy carrying it is rejected rather than silently losing the service.
+    #[test]
+    fn test_build_services_from_policy_rejects_bad_declarations() {
+        // Empty dir: no `<id>.json` exists for any of these.
+        let dir = std::env::temp_dir().join("vs-bsfp-bad");
+        fs::create_dir_all(&dir).unwrap();
+
+        let cases = [
+            // (id, api, expiration_seconds) — the failure each one exercises.
+            ("attrfile", "file", Some(3600)), // attribute file is missing
+            ("attrfile", "ldap", Some(3600)), // unsupported api
+            ("attrfile", "file", None),       // no TrustedService record in policy
+            ("attrfile", "file", Some(1)),    // ttl below MIN_ATTRIBUTE_TTL
+            ("../escape", "file", Some(3600)), // path traversal in the id
+        ];
+        for (id, api, secs) in cases {
+            let policy = policy_from_container(make_trusted_service_policy(id, api, secs, &[]));
+            assert!(
+                build_services_from_policy(&policy, &dir).is_err(),
+                "expected failure for id={id} api={api} secs={secs:?}"
+            );
+        }
+
+        fs::remove_dir_all(&dir).unwrap();
     }
 
     /// `flush_all` must reach every registered service.


### PR DESCRIPTION
  - Loads trusted-service definitions from compiled policy:
      - Caches records by service ID.
      - Exposes lookup by ID.
      - Rejects duplicate trusted-service IDs.

  - Automatically builds trusted-service providers from the active policy:
      - Recognizes services declared with ServiceType::Trusted("file").
      - Creates a FileAttributeStore for each service.
      - Uses <file_ts_dir>/<service-id>.json as its attribute source.
      - Applies the TTL and attribute mappings declared by policy.

  - Adds core.file_ts_dir configuration:
      - Specifies where file-backed trusted-service JSON files live.
      - Defaults to the current directory.

  - Connects trusted services to the policy lifecycle:
      - Providers are created during startup and policy updates.
      - A successful policy change republishes the complete provider set.
      - Providers from an old policy are replaced when the new policy becomes active.

  - Makes trusted-service configuration transactional:
      - Missing or malformed JSON files, unsupported APIs, missing policy records, invalid TTLs, and unsafe service IDs cause policy
        loading to fail.

      - A failed policy update leaves the current policy and trusted-service providers intact.

  - Adds validation against path traversal:
      - Trusted-service IDs containing / or .. cannot be used as filenames.

  - Shares the TrustedServicesMgr through Arc so the policy manager and request-processing assembly use the same live instance.

  - Adds tests for policy serialization, duplicate IDs, valid provider construction, invalid declarations, and preservation of live
    state after failed updates.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>