### PR TITLE
(248ts-stack) mk/248 04 flush api

### DIFF
--- a/vs-admin/src/executor.rs
+++ b/vs-admin/src/executor.rs
@@ -86,9 +86,16 @@ impl Executor {
         Ok(())
     }
 
-    pub fn do_cmd_services(&self, id: Option<String>) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn do_cmd_services(
+        &self,
+        id: Option<String>,
+        flush: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         match id {
-            Some(id) => self.get_service(&id)?,
+            Some(id) => match flush {
+                true => self.flush_service_cache(&id)?,
+                false => self.get_service(&id)?,
+            },
             None => self.get_services()?,
         }
         Ok(())
@@ -242,6 +249,13 @@ impl Executor {
     fn get_service(&self, id: &str) -> Result<(), Box<dyn std::error::Error>> {
         let svc = self.vs_cli.get_service(id)?;
         println!("{svc}");
+        Ok(())
+    }
+
+    /// Flush the cached attribute data held by a trusted service.
+    fn flush_service_cache(&self, id: &str) -> Result<(), Box<dyn std::error::Error>> {
+        self.vs_cli.flush_service_cache(id)?;
+        println!("flushed {id}");
         Ok(())
     }
 

--- a/vs-admin/src/main.rs
+++ b/vs-admin/src/main.rs
@@ -78,7 +78,7 @@ fn main() {
             visas,
         }) => exec.do_cmd_actors(cn, revoke, nodes, visas),
 
-        Some(SubCmd::Services { id }) => exec.do_cmd_services(id),
+        Some(SubCmd::Services { id, flush }) => exec.do_cmd_services(id, flush),
         // Some(SubCmd::Install {
         //     compiler_version,
         //     policy,

--- a/vs-admin/src/main_args.rs
+++ b/vs-admin/src/main_args.rs
@@ -79,6 +79,9 @@ pub enum SubCmd {
         /// See more information on a specific service
         #[arg(long, short = 'i')]
         id: Option<String>,
+        /// Flush the cached attribute data for a trusted service. If flush is supplied, id must be as well
+        #[arg(long, short = 'f', requires = "id")]
+        flush: bool,
     },
 
     /// Commands related to auth revokes, provide no additional arguments to see list of IDs of all auth revokes

--- a/vs-admin/src/vsclient.rs
+++ b/vs-admin/src/vsclient.rs
@@ -214,6 +214,16 @@ impl VsClient {
         Ok(entry)
     }
 
+    /// `DELETE <api_url>/admin/services/<id>/cache`
+    ///
+    /// Drops the trusted service's cached attribute data so the next lookup fetches fresh.
+    pub fn flush_service_cache(&self, id: &str) -> Result<(), VsaError> {
+        let mut requrl = reqwest::Url::parse(&format!("{}/admin/services", self.api_url))?;
+        requrl.path_segments_mut().unwrap().push(id).push("cache");
+        self.ht_delete(requrl.as_str())?;
+        Ok(())
+    }
+
     /// `GET <api_url>/admin/visas`
     pub fn get_visas(&self) -> Result<Vec<u64>, VsaError> {
         let entry_vec =

--- a/vs/src/admin_apikeys.rs
+++ b/vs/src/admin_apikeys.rs
@@ -53,7 +53,6 @@ impl Permission {
         matches!(self, Permission::Read | Permission::ReadWrite)
     }
 
-    #[allow(dead_code)]
     pub fn can_write(&self) -> bool {
         matches!(self, Permission::ReadWrite)
     }

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -39,6 +39,7 @@ use crate::apikey::ApiKey;
 use crate::assembly::Assembly;
 use crate::counters::CounterType;
 use crate::db::Role;
+use crate::error::ServiceError;
 use crate::event_mgr::VsEvent;
 use crate::logging::targets::ADMIN;
 use crate::policy_mgr::DEFAULT_POLICY_ID;
@@ -173,6 +174,10 @@ fn admin_app(state: SharedState) -> Router {
         .route("/admin/nodes/{capture}/visas", get(get_visas_on_node))
         .route("/admin/services", get(get_services))
         .route("/admin/services/{capture}", get(get_service))
+        .route(
+            "/admin/services/{capture}/cache",
+            delete(flush_service_cache),
+        )
         .route("/admin/authrevoke", get(get_revokes))
         .route("/admin/authrevoke/{capture}", get(get_revoke))
         .route("/admin/authrevoke/{capture}", post(add_revoke))
@@ -831,6 +836,31 @@ async fn get_service(
             } else {
                 Err(StatusCode::NOT_FOUND)
             }
+        }
+    }
+}
+
+/// DELETE /admin/services/{id}/cache — drop a trusted service's cached attribute
+/// data so the next lookup fetches fresh.
+async fn flush_service_cache(
+    Extension(perm): Extension<Permission>,
+    State(state): State<SharedState>,
+    EPath(svc_id): EPath<String>,
+) -> StatusCode {
+    if !perm.can_write() {
+        return StatusCode::FORBIDDEN;
+    }
+    debug!(target: ADMIN, "DELETE /admin/services/{}/cache", svc_id);
+
+    // Clone the Arc and drop the read guard before awaiting the flush.
+    let ts_mgr = state.read().await.asm.ts_mgr.clone();
+
+    match ts_mgr.flush_one(&svc_id).await {
+        Ok(()) => StatusCode::OK,
+        Err(ServiceError::TrustedServiceNotFound(_)) => StatusCode::NOT_FOUND,
+        Err(e) => {
+            error!(target: ADMIN, "error flushing trusted service {}: {}", svc_id, e);
+            StatusCode::INTERNAL_SERVER_ERROR
         }
     }
 }
@@ -1984,5 +2014,110 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    const FLUSH_TS_ID: &str = "ts-file";
+
+    /// Minimal trusted service that only records whether it was flushed.
+    struct FlushCountingService {
+        flushes: std::sync::atomic::AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::trusted_services_mgr::TrustedServiceInterface for FlushCountingService {
+        async fn get_attributes_for_actor(
+            &self,
+            _actor_ident: &str,
+        ) -> Result<Vec<Attribute>, ServiceError> {
+            Ok(Vec::new())
+        }
+
+        async fn flush(&self) -> Result<(), ServiceError> {
+            self.flushes
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        }
+
+        fn get_source_id(&self) -> &str {
+            FLUSH_TS_ID
+        }
+    }
+
+    /// Register one flush-counting trusted service on the assembly and return it for
+    /// assertions.
+    fn register_flush_counting_service(asm: &Arc<Assembly>) -> Arc<FlushCountingService> {
+        let svc = Arc::new(FlushCountingService {
+            flushes: std::sync::atomic::AtomicUsize::new(0),
+        });
+        asm.ts_mgr.update_services(vec![svc.clone()]);
+        svc
+    }
+
+    /// DELETE /admin/services/{id}/cache flushes the named trusted service.
+    #[tokio::test]
+    async fn test_flush_service_cache_ok() {
+        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let svc = register_flush_counting_service(&asm);
+        let api_key = setup_test_api_rw_key(&asm);
+        let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
+        let app = admin_app(shared_state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/admin/services/{FLUSH_TS_ID}/cache"))
+                    .header("X-API-Key", &api_key)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(svc.flushes.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    /// DELETE /admin/services/{id}/cache for an unregistered service returns NOT_FOUND.
+    #[tokio::test]
+    async fn test_flush_service_cache_unknown_not_found() {
+        let asm = Arc::new(new_assembly_for_tests(None).await);
+        register_flush_counting_service(&asm);
+        let api_key = setup_test_api_rw_key(&asm);
+        let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
+        let app = admin_app(shared_state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/admin/services/does-not-exist/cache")
+                    .header("X-API-Key", &api_key)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// A read-only key may not flush a trusted service.
+    #[tokio::test]
+    async fn test_flush_service_cache_read_key_forbidden() {
+        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let svc = register_flush_counting_service(&asm);
+        let api_key = setup_test_api_r_key(&asm);
+        let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
+        let app = admin_app(shared_state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/admin/services/{FLUSH_TS_ID}/cache"))
+                    .header("X-API-Key", &api_key)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(svc.flushes.load(std::sync::atomic::Ordering::SeqCst), 0);
     }
 }

--- a/vs/src/connection_control.rs
+++ b/vs/src/connection_control.rs
@@ -387,8 +387,6 @@ impl ConnectionControl {
             }
         }
 
-        info!(target: CC, "XXX authorize_connection - consulting trusted services");
-
         let ectx = EvalContext::new(current_policy.clone());
 
         // TODO: Need to go in to eval and fix the approve_connection logic w/respect to the ROLE claim.

--- a/vs/src/error.rs
+++ b/vs/src/error.rs
@@ -72,6 +72,9 @@ pub enum ServiceError {
 
     #[error("trusted service not found: ID={0}")]
     TrustedServiceNotFound(String),
+
+    #[error("trusted service initialization error: {0}")]
+    TrustedServiceInit(String),
 }
 
 #[derive(Debug, Error)]

--- a/vs/src/trusted_services_mgr.rs
+++ b/vs/src/trusted_services_mgr.rs
@@ -14,7 +14,7 @@ use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::fs;
 
-use tracing::debug;
+use tracing::{debug, info};
 
 use libeval::attribute::{Attribute, AttributeSource};
 use libeval::policy::Policy;
@@ -121,6 +121,7 @@ impl TrustedServicesMgr {
     /// fetches fresh. Returns one result per service.
     ///
     /// For api=file trusted services, this re-reads the file.
+    #[allow(dead_code)]
     pub async fn flush_all(&self) -> Vec<Result<(), ServiceError>> {
         let snapshot = self.services.load_full();
 
@@ -132,6 +133,27 @@ impl TrustedServicesMgr {
         });
 
         join_all(futures).await
+    }
+
+    /// Flush one service. Error returned if the operation fails or service is not found.
+    ///
+    /// ### Errors
+    /// - `ServiceError::TrustedServiceNotFound` if the service with the given `source_ident` does not exist.
+    /// - Any error returned by the service's `flush` method.
+    pub async fn flush_one(&self, source_ident: &str) -> Result<(), ServiceError> {
+        let snapshot = self.services.load_full();
+
+        if let Some(svc) = snapshot
+            .iter()
+            .find(|svc| svc.get_source_id() == source_ident)
+        {
+            let svc = svc.clone();
+            return svc.flush().await;
+        }
+
+        Err(ServiceError::TrustedServiceNotFound(
+            source_ident.to_string(),
+        ))
     }
 }
 
@@ -257,8 +279,18 @@ impl FileAttributeStore {
                 "trusted service '{id}' ttl {ttl:?} is below the minimum of {MIN_ATTRIBUTE_TTL:?}"
             )));
         }
+
+        let attributes = match load_actor_attributes_from_file(fp) {
+            Ok(attrs) => attrs,
+            Err(e) => {
+                return Err(ServiceError::TrustedServiceInit(format!(
+                    "TS '{id}' failed to read attribute data file {fp:?}: {e}"
+                )));
+            }
+        };
+
         let snapshot = Snapshot {
-            attributes: load_actor_attributes_from_file(fp)?,
+            attributes,
             expires_at: Instant::now() + ttl,
         };
         let store = FileAttributeStore {
@@ -291,6 +323,7 @@ impl FileAttributeStore {
             return Ok(snapshot);
         }
 
+        info!(target: TS, "TS {} re-loading actor attributes", self.id);
         let fresh = Arc::new(Snapshot {
             attributes: load_actor_attributes_from_file(&self.fp)?,
             expires_at: Instant::now() + self.ttl,
@@ -345,6 +378,7 @@ impl TrustedServiceInterface for FileAttributeStore {
     /// Expire the cached data in place so the next lookup re-reads the file. Reuses the
     /// normal staleness path rather than carrying a separate "force reload" flag.
     async fn flush(&self) -> Result<(), ServiceError> {
+        info!(target: TS, "TS {} flushing cached actor attributes", self.id);
         self.snapshot.rcu(|cur| Snapshot {
             attributes: cur.attributes.clone(),
             expires_at: Instant::now(),

--- a/vs/src/trusted_services_mgr.rs
+++ b/vs/src/trusted_services_mgr.rs
@@ -246,7 +246,7 @@ type AttributeValue = String;
 #[derive(Debug, Deserialize, Clone)]
 struct ActorAttributes(BTreeMap<ActorId, BTreeMap<AttributeName, Vec<AttributeValue>>>);
 
-// ponytail: blocking read of a small local JSON file, at most once per `ttl` and always
+// Blocking read of a small local JSON file, at most once per `ttl` and always
 // under the refresh lock. Move to tokio::fs (or spawn_blocking, as actor_mgr.rs does) if
 // the file ever gets big enough to stall the runtime.
 fn load_actor_attributes_from_file(fp: &Path) -> Result<ActorAttributes, ServiceError> {


### PR DESCRIPTION
  - Adds an authenticated admin endpoint:
      - DELETE /admin/services/{id}/cache
      - Flushes the named trusted service’s cached attribute data.
      - Requires a read/write API key; read-only keys receive 403 Forbidden.
      - Returns 404 Not Found for an unknown service.
      - Returns 500 Internal Server Error if the provider’s flush fails.

  - Adds corresponding vs-admin CLI support:
      - services --id <service-id> --flush
      - The --flush option requires --id.

  - Adds TrustedServicesMgr::flush_one():
      - Locates a provider by source/service ID.
      - Invokes that provider’s flush operation.
      - Reports unknown provider IDs explicitly.

  - For file-backed providers, flushing invalidates the current snapshot:
      - The file is not reread during the DELETE request.
      - The next attribute lookup reloads the JSON file.

  - Improves trusted-service diagnostics:
      - Adds a distinct initialization error containing the service ID, file path, and underlying read/parse error.
      - Logs cache flushes and subsequent file reloads.

  - Adds endpoint tests covering:
      - Successful cache flushing.
      - Unknown service IDs.
      - Rejection of read-only API keys.

  - Removes a leftover debug message and performs minor comment/dead-code cleanup.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>