### PR TITLE
(248ts-stack) revision the trusted source

### DIFF
--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -2038,6 +2038,11 @@ mod tests {
             Ok(())
         }
 
+        // Holds no snapshot; its flush count doubles as the revision.
+        fn current_revision(&self) -> u64 {
+            self.flushes.load(std::sync::atomic::Ordering::SeqCst) as u64
+        }
+
         fn get_source_id(&self) -> &str {
             FLUSH_TS_ID
         }

--- a/vs/src/trusted_services_mgr.rs
+++ b/vs/src/trusted_services_mgr.rs
@@ -5,13 +5,15 @@
 use async_trait::async_trait;
 
 use arc_swap::ArcSwap;
+use dashmap::DashMap;
 use futures::future::join_all;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use serde::Deserialize;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 
 use tracing::{debug, info};
@@ -32,6 +34,23 @@ const TS_API_FILE: &str = "file";
 /// that expires almost immediately.
 const MIN_ATTRIBUTE_TTL: Duration = Duration::from_secs(60);
 
+/// Process-wide source of snapshot revisions: every snapshot ever built in this
+/// process gets a distinct value, across all services. Not durable.
+/// The per-actor revision records are in-memory too, so both reset together on
+/// restart and "missing record = stale" forces a safe refresh.
+static REVISION_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+/// A revision no snapshot will ever carry (the counter starts at 1). Recording it for
+/// an actor keeps a source relevant-and-stale, forcing a retry on the next request —
+/// used when a revision-triggered refresh fails and the source's attributes were
+/// stripped fail-closed.
+pub const REVISION_NEVER: u64 = 0;
+
+/// Hand out the next snapshot revision.
+fn next_revision() -> u64 {
+    REVISION_COUNTER.fetch_add(1, Ordering::Relaxed)
+}
+
 /// Interface for trusted services that can provide attributes for actors.
 #[async_trait]
 pub trait TrustedServiceInterface: Send + Sync {
@@ -48,6 +67,11 @@ pub trait TrustedServiceInterface: Send + Sync {
     /// flushes. Implementors holding no cache should return `Ok(())`.
     async fn flush(&self) -> Result<(), ServiceError>;
 
+    /// Revision of the data the service currently serves; bumps whenever the data may
+    /// have changed (flush or reload). Implementors without snapshots (e.g. test fakes)
+    /// return a counter of their own flushes.
+    fn current_revision(&self) -> u64;
+
     fn get_source_id(&self) -> &str;
 }
 
@@ -59,6 +83,17 @@ pub trait TrustedServiceInterface: Send + Sync {
 /// the underlying set of services.
 pub struct TrustedServicesMgr {
     services: ArcSwap<Vec<Arc<dyn TrustedServiceInterface>>>,
+
+    /// Per actor (keyed by CN): the revision of each source the actor's
+    /// attributes were last refreshed from. Memory-only; a missing entry reads
+    /// as "stale", which seems safe (forces a refresh on the actor's next visa
+    /// request).
+    ///
+    // TODO: for now entries are never evicted — bounded by distinct CNs seen since process
+    // start. I think we are going to rework attributes soon. I'm not sure it makes sense to
+    // keep then "on" the actors. I think we want to manage attribute data as its own thing
+    // especially as we want to support multiple credentials for attribute sources.
+    actor_revisions: DashMap<String, HashMap<String, u64>>,
 }
 
 impl TrustedServicesMgr {
@@ -66,7 +101,49 @@ impl TrustedServicesMgr {
     pub fn new() -> Self {
         TrustedServicesMgr {
             services: ArcSwap::new(Arc::new(Vec::new())),
+            actor_revisions: DashMap::new(),
         }
+    }
+
+    /// Get the sources needing a revision-triggered refresh for `actor_ident`: every
+    /// registered service that appears in `attr_sources` (the sources of the actor's
+    /// attributes) or in the actor's revision record, whose current revision differs
+    /// from the recorded one. A missing record counts as stale.
+    ///
+    /// Returns `(source id, current revision at check time)` pairs; pass the revision
+    /// back to [`Self::record_revision`] after a successful refresh so a flush racing
+    /// the fetch re-triggers rather than being missed.
+    pub fn stale_sources_for_actor(
+        &self,
+        actor_ident: &str,
+        attr_sources: &HashSet<String>,
+    ) -> Vec<(String, u64)> {
+        let services = self.services.load_full();
+        let recorded = self.actor_revisions.get(actor_ident);
+        services
+            .iter()
+            .filter_map(|svc| {
+                let sid = svc.get_source_id();
+                let rec = recorded.as_ref().and_then(|r| r.value().get(sid).copied());
+                // A service the actor holds no attributes from and has no record for is
+                // not relevant to this actor.
+                if rec.is_none() && !attr_sources.contains(sid) {
+                    return None;
+                }
+                let cur = svc.current_revision();
+                (rec != Some(cur)).then(|| (sid.to_string(), cur))
+            })
+            .collect()
+    }
+
+    /// Record that `actor_ident`'s attributes from `source` are current as of
+    /// `revision`. Call after a successful refresh (including one that returned zero
+    /// attributes), or with [`REVISION_NEVER`] to pin the source stale for a retry.
+    pub fn record_revision(&self, actor_ident: &str, source: &str, revision: u64) {
+        self.actor_revisions
+            .entry(actor_ident.to_string())
+            .or_default()
+            .insert(source.to_string(), revision);
     }
 
     /// Atomically replaces the whole service list.
@@ -223,12 +300,13 @@ pub struct FileAttributeStore {
     refresh_lock: tokio::sync::Mutex<()>,
 }
 
-/// Attribute data and the instant it goes stale, swapped as a unit so the two can
-/// never drift apart.
+/// Attribute data, the instant it goes stale, and its revision, swapped as a unit so
+/// they can never drift apart.
 #[derive(Debug)]
 struct Snapshot {
     attributes: ActorAttributes,
     expires_at: Instant,
+    revision: u64,
 }
 
 impl Snapshot {
@@ -292,6 +370,7 @@ impl FileAttributeStore {
         let snapshot = Snapshot {
             attributes,
             expires_at: Instant::now() + ttl,
+            revision: next_revision(),
         };
         let store = FileAttributeStore {
             id,
@@ -327,6 +406,7 @@ impl FileAttributeStore {
         let fresh = Arc::new(Snapshot {
             attributes: load_actor_attributes_from_file(&self.fp)?,
             expires_at: Instant::now() + self.ttl,
+            revision: next_revision(),
         });
         self.snapshot.store(fresh.clone());
         Ok(fresh)
@@ -375,15 +455,23 @@ impl TrustedServiceInterface for FileAttributeStore {
         Ok(result)
     }
 
-    /// Expire the cached data in place so the next lookup re-reads the file. Reuses the
-    /// normal staleness path rather than carrying a separate "force reload" flag.
+    /// Re-read the attribute file and swap in a fresh snapshot (with a fresh
+    /// revision). On failure the current snapshot and revision are left untouched and
+    /// the error is returned — a bad file must not advance the revision.
     async fn flush(&self) -> Result<(), ServiceError> {
         info!(target: TS, "TS {} flushing cached actor attributes", self.id);
-        self.snapshot.rcu(|cur| Snapshot {
-            attributes: cur.attributes.clone(),
-            expires_at: Instant::now(),
-        });
+        let _guard = self.refresh_lock.lock().await;
+        let attributes = load_actor_attributes_from_file(&self.fp)?;
+        self.snapshot.store(Arc::new(Snapshot {
+            attributes,
+            expires_at: Instant::now() + self.ttl,
+            revision: next_revision(),
+        }));
         Ok(())
+    }
+
+    fn current_revision(&self) -> u64 {
+        self.snapshot.load().revision
     }
 }
 
@@ -627,14 +715,88 @@ mod tests {
         );
         mgr.update_services(vec![store.clone()]);
 
-        assert!(store.snapshot.load().remaining() >= MIN_ATTRIBUTE_TTL);
+        let rev_before = store.current_revision();
 
         let results = mgr.flush_all().await;
         assert_eq!(results.len(), 1);
         assert!(results[0].is_ok());
 
-        // Flushed means expired: the cached data is now below the floor.
-        assert!(store.snapshot.load().remaining() < MIN_ATTRIBUTE_TTL);
+        // Eager flush: a fresh, fully-valid snapshot with a new revision was swapped in.
+        assert!(store.current_revision() > rev_before);
+        assert!(store.snapshot.load().remaining() >= MIN_ATTRIBUTE_TTL);
+
+        fs::remove_file(&fp).unwrap();
+    }
+
+    /// A failed flush (unparseable file) must leave the current snapshot and revision
+    /// untouched; a subsequent successful flush moves both forward.
+    #[tokio::test]
+    async fn test_flush_failure_keeps_snapshot_and_revision() {
+        let fp = write_fixture("vs-fas-flush-fail.json", r#"{"alice": {"color": ["red"]}}"#);
+        let store = FileAttributeStore::new(
+            "test".to_string(),
+            test_mapper(),
+            Duration::from_secs(3600),
+            &fp,
+        )
+        .unwrap();
+        let rev = store.current_revision();
+
+        // Corrupt the file: flush must fail and change nothing.
+        fs::write(&fp, "not json").unwrap();
+        assert!(store.flush().await.is_err());
+        assert_eq!(store.current_revision(), rev);
+        assert!(store.snapshot.load().attributes.0.contains_key("alice"));
+
+        // Fix the file: flush succeeds, data and revision move forward.
+        fs::write(&fp, r#"{"bob": {"color": ["blue"]}}"#).unwrap();
+        store.flush().await.unwrap();
+        assert!(store.current_revision() > rev);
+        assert!(store.snapshot.load().attributes.0.contains_key("bob"));
+
+        fs::remove_file(&fp).unwrap();
+    }
+
+    /// Revision staleness bookkeeping: an irrelevant source is skipped, a missing
+    /// record reads as stale, recording the revision clears it, and a flush makes the
+    /// actor stale again even when only the record marks the source relevant.
+    #[tokio::test]
+    async fn test_stale_sources_for_actor_tracks_revisions() {
+        let fp = write_fixture("vs-fas-stale.json", r#"{"alice": {"color": ["red"]}}"#);
+        let mgr = TrustedServicesMgr::new();
+        let store = Arc::new(
+            FileAttributeStore::new(
+                "test".to_string(),
+                test_mapper(),
+                Duration::from_secs(3600),
+                &fp,
+            )
+            .unwrap(),
+        );
+        mgr.update_services(vec![store.clone()]);
+
+        // No attributes from the source and no record: not relevant, not stale.
+        assert!(
+            mgr.stale_sources_for_actor("alice", &HashSet::new())
+                .is_empty()
+        );
+
+        // Attributes from the source but no record: stale.
+        let sources = HashSet::from(["test".to_string()]);
+        let stale = mgr.stale_sources_for_actor("alice", &sources);
+        assert_eq!(stale, vec![("test".to_string(), store.current_revision())]);
+
+        // Recording the fetched revision clears the staleness.
+        mgr.record_revision("alice", "test", stale[0].1);
+        assert!(mgr.stale_sources_for_actor("alice", &sources).is_empty());
+
+        // A flush bumps the revision: stale again, and the record alone is enough to
+        // keep the source relevant (no attr_sources needed).
+        store.flush().await.unwrap();
+        assert_eq!(
+            mgr.stale_sources_for_actor("alice", &HashSet::new()),
+            vec![("test".to_string(), store.current_revision())]
+        );
 
         fs::remove_file(&fp).unwrap();
     }

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -19,7 +19,7 @@
 //! Once we have a path, the visa is queued up for install on all the impacted nodes and
 //! returned to the caller.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
@@ -43,7 +43,7 @@ use crate::assembly::Assembly;
 use crate::counters::CounterType;
 use crate::error::ServiceError;
 use crate::logging::targets::VREQ;
-use crate::trusted_services_mgr::TrustedServicesMgr;
+use crate::trusted_services_mgr::{REVISION_NEVER, TrustedServicesMgr};
 use crate::visa_mgr::VisaWithMetadata;
 use crate::{config, net_mgr};
 
@@ -286,11 +286,19 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
     }
 }
 
-/// Look for expired attributes and refresh them from the trusted service manager if possible.
+/// Refresh the actor's attributes from the trusted service manager where needed: any
+/// source with an expired attribute (TTL path), plus any source whose snapshot revision
+/// differs from the actor's recorded one (revision path, e.g. after an admin flush).
 ///
-/// A successful lookup is authoritative for that source: anything the service did not vend
-/// stays expired and is dropped from the actor. A failed lookup changes nothing, so a service
-/// outage cannot strip attributes.
+/// A successful lookup is authoritative for that source: anything the service did not
+/// vend is dropped — still-expired leftovers on the TTL path, *everything* not just
+/// returned on the revision path (the old snapshot's data is invalid by definition).
+///
+/// A failed TTL lookup changes nothing, so a service outage cannot strip attributes.
+/// A failed lookup for a revision-stale source fails closed: all of that source's
+/// attributes are removed before policy evaluation, and the sentinel REVISION_NEVER is
+/// recorded so the source stays stale — the next request retries and restores the
+/// attributes once the service is reachable again.
 ///
 /// Returns TRUE if any attribute was added, replaced, or removed.
 ///
@@ -300,21 +308,34 @@ async fn refresh_expired_attributes(ts_mgr: &TrustedServicesMgr, actor: &mut Act
         None => return false,
     };
 
-    let mut ts_sources = HashSet::new();
+    let mut attr_sources = HashSet::new();
+    let mut sources = HashSet::new();
     for attr in actor.attrs_iter() {
+        attr_sources.insert(attr.get_source().to_string());
         if attr.is_expired() {
-            ts_sources.insert(attr.get_source().to_string());
+            sources.insert(attr.get_source().to_string());
         }
     }
 
+    // Sources whose snapshot revision the actor has not caught up with, and the
+    // revision to record once a refresh from them succeeds.
+    let stale: HashMap<String, u64> = ts_mgr
+        .stale_sources_for_actor(&actor_ident, &attr_sources)
+        .into_iter()
+        .collect();
+    sources.extend(stale.keys().cloned());
+
     let mut changed = false;
-    for source in &ts_sources {
+    for source in &sources {
+        let stale_rev = stale.get(source);
         for ts_result in ts_mgr
             .get_attributes_from_source_for_actor(source, &actor_ident)
             .await
         {
             match ts_result {
                 Ok(ts_attrs) => {
+                    let returned: HashSet<String> =
+                        ts_attrs.iter().map(|a| a.get_key().to_string()).collect();
                     for attr in ts_attrs {
                         if let Err(e) = actor.add_attribute(attr) {
                             warn!(target: VREQ, "failed to add attribute for actor {}: {}", actor_ident, e);
@@ -322,12 +343,31 @@ async fn refresh_expired_attributes(ts_mgr: &TrustedServicesMgr, actor: &mut Act
                             changed = true;
                         }
                     }
-                    // Whatever the service did not just set for this source is gone: drop
-                    // the leftovers rather than carry a permanently expired copy.
-                    changed |= prune_expired_from_source(actor, source);
+                    if let Some(&rev) = stale_rev {
+                        // Revision refresh: the old snapshot's data is invalid, so drop
+                        // everything the service did not just return. Record the
+                        // revision even when zero attributes came back — that is what
+                        // detects both removed and newly added attributes.
+                        changed |=
+                            prune_from_source(actor, source, |a| !returned.contains(a.get_key()));
+                        ts_mgr.record_revision(&actor_ident, source, rev);
+                    } else {
+                        // TTL refresh: whatever the service did not just set for this
+                        // source is gone; drop the leftovers rather than carry a
+                        // permanently expired copy.
+                        changed |= prune_from_source(actor, source, |a| a.is_expired());
+                    }
                 }
                 Err(e) => {
                     warn!(target: VREQ, "ts service attr lookup failed for actor {}: {}", actor_ident, e);
+                    if stale_rev.is_some() {
+                        // Stale-revision attributes must never satisfy an
+                        // allow policy just because their TTL has not run out. The
+                        // sentinel keeps the source stale so the next request retries
+                        // (the strip would otherwise leave nothing marking it relevant).
+                        changed |= prune_from_source(actor, source, |_| true);
+                        ts_mgr.record_revision(&actor_ident, source, REVISION_NEVER);
+                    }
                 }
             }
         }
@@ -335,17 +375,17 @@ async fn refresh_expired_attributes(ts_mgr: &TrustedServicesMgr, actor: &mut Act
     changed
 }
 
-/// Removes every still-expired attribute on `actor` that came from `source`.
+/// Removes every attribute on `actor` from `source` that matches `pred`.
 /// Returns TRUE if anything was removed.
-fn prune_expired_from_source(actor: &mut Actor, source: &str) -> bool {
+fn prune_from_source(actor: &mut Actor, source: &str, pred: impl Fn(&Attribute) -> bool) -> bool {
     let stale: Vec<String> = actor
         .attrs_iter()
-        .filter(|a| a.is_expired() && a.get_source() == source)
+        .filter(|a| a.get_source() == source && pred(a))
         .map(|a| a.get_key().to_string())
         .collect();
 
     for key in &stale {
-        debug!(target: VREQ, "dropping expired attribute '{key}' no longer vended by source '{source}'");
+        debug!(target: VREQ, "dropping attribute '{key}' no longer vended by source '{source}'");
         actor.remove_attribute(key);
     }
     !stale.is_empty()
@@ -1222,9 +1262,11 @@ mod tests {
     }
 
     /// A trusted service that records the actor idents it was asked about and returns
-    /// one canned, freshly-expiring attribute.
+    /// one canned, freshly-expiring attribute. Its revision starts at 1 and bumps on
+    /// every flush, like the real store.
     struct FakeTrustedService {
         calls: std::sync::Mutex<Vec<String>>,
+        revision: std::sync::atomic::AtomicU64,
     }
 
     const FAKE_SOURCE: &str = "fake";
@@ -1246,7 +1288,13 @@ mod tests {
         }
 
         async fn flush(&self) -> Result<(), ServiceError> {
+            self.revision
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Ok(())
+        }
+
+        fn current_revision(&self) -> u64 {
+            self.revision.load(std::sync::atomic::Ordering::SeqCst)
         }
 
         fn get_source_id(&self) -> &str {
@@ -1258,14 +1306,15 @@ mod tests {
     fn ts_mgr_with_fake() -> (TrustedServicesMgr, Arc<FakeTrustedService>) {
         let fake = Arc::new(FakeTrustedService {
             calls: std::sync::Mutex::new(Vec::new()),
+            revision: std::sync::atomic::AtomicU64::new(1),
         });
         let mgr = TrustedServicesMgr::new();
         mgr.update_services(vec![fake.clone()]);
         (mgr, fake)
     }
 
-    /// An actor with a CN and one already-expired attribute from the given source.
-    fn actor_with_expired_attr(cn: &str, source: &str) -> Actor {
+    /// An actor with a CN and one attribute (expired or still fresh) from the given source.
+    fn actor_with_attr(cn: &str, source: &str, expired: bool) -> Actor {
         let mut actor = Actor::new();
         actor
             .add_attribute(
@@ -1274,11 +1323,16 @@ mod tests {
                     .value(cn),
             )
             .unwrap();
+        let expires = if expired {
+            SystemTime::now() - Duration::from_secs(1)
+        } else {
+            SystemTime::now() + Duration::from_secs(600)
+        };
         actor
             .add_attribute(
                 AttributeSource::new(source)
                     .builder(FAKE_ATTR_KEY)
-                    .expires(SystemTime::now() - Duration::from_secs(1))
+                    .expires(expires)
                     .value("engineering"),
             )
             .unwrap();
@@ -1290,7 +1344,7 @@ mod tests {
     #[tokio::test]
     async fn test_refresh_expired_attributes_refreshes_from_source() {
         let (mgr, fake) = ts_mgr_with_fake();
-        let mut actor = actor_with_expired_attr("someone.zpr.org", FAKE_SOURCE);
+        let mut actor = actor_with_attr("someone.zpr.org", FAKE_SOURCE, true);
         assert!(actor.get_attribute(FAKE_ATTR_KEY).unwrap().is_expired());
 
         assert!(refresh_expired_attributes(&mgr, &mut actor).await);
@@ -1332,6 +1386,11 @@ mod tests {
             Ok(())
         }
 
+        // Holds no cache, so its data never changes: a constant revision is honest.
+        fn current_revision(&self) -> u64 {
+            1
+        }
+
         fn get_source_id(&self) -> &str {
             FAKE_SOURCE
         }
@@ -1343,7 +1402,7 @@ mod tests {
     async fn test_refresh_expired_attributes_prunes_unvended() {
         let mgr = TrustedServicesMgr::new();
         mgr.update_services(vec![Arc::new(EmptyTrustedService)]);
-        let mut actor = actor_with_expired_attr("someone.zpr.org", FAKE_SOURCE);
+        let mut actor = actor_with_attr("someone.zpr.org", FAKE_SOURCE, true);
 
         assert!(refresh_expired_attributes(&mgr, &mut actor).await);
         assert!(actor.get_attribute(FAKE_ATTR_KEY).is_none());
@@ -1358,7 +1417,7 @@ mod tests {
         let (mgr, fake) = ts_mgr_with_fake();
 
         // SOURCE_ZPR is internal -- no trusted service vends it.
-        let mut internal = actor_with_expired_attr("someone.zpr.org", SOURCE_ZPR);
+        let mut internal = actor_with_attr("someone.zpr.org", SOURCE_ZPR, true);
         assert!(!refresh_expired_attributes(&mgr, &mut internal).await);
         assert!(fake.calls.lock().unwrap().is_empty());
 
@@ -1374,5 +1433,116 @@ mod tests {
             .unwrap();
         assert!(!refresh_expired_attributes(&mgr, &mut no_cn).await);
         assert!(fake.calls.lock().unwrap().is_empty());
+    }
+
+    /// A revision-stale source (no record yet, or bumped by a flush) is refreshed even
+    /// when none of its attributes have expired, and the recorded revision stops
+    /// further refreshes until the next bump.
+    #[tokio::test]
+    async fn test_refresh_revision_stale_refreshes_and_records() {
+        let (mgr, fake) = ts_mgr_with_fake();
+        let mut actor = actor_with_attr("someone.zpr.org", FAKE_SOURCE, false);
+
+        // No record yet: stale, so the source is queried despite nothing being expired.
+        assert!(refresh_expired_attributes(&mgr, &mut actor).await);
+        assert_eq!(fake.calls.lock().unwrap().len(), 1);
+
+        // Revision recorded: a second pass is a no-op.
+        assert!(!refresh_expired_attributes(&mgr, &mut actor).await);
+        assert_eq!(fake.calls.lock().unwrap().len(), 1);
+
+        // A flush bumps the revision: stale again.
+        use crate::trusted_services_mgr::TrustedServiceInterface;
+        fake.flush().await.unwrap();
+        assert!(refresh_expired_attributes(&mgr, &mut actor).await);
+        assert_eq!(fake.calls.lock().unwrap().len(), 2);
+    }
+
+    /// A revision-triggered refresh that returns zero attributes prunes everything the
+    /// source previously vended — even attributes that had not expired — and records
+    /// the revision so there is no further churn.
+    #[tokio::test]
+    async fn test_refresh_revision_stale_zero_attrs_prunes_all() {
+        let mgr = TrustedServicesMgr::new();
+        mgr.update_services(vec![Arc::new(EmptyTrustedService)]);
+        let mut actor = actor_with_attr("someone.zpr.org", FAKE_SOURCE, false);
+        assert!(!actor.get_attribute(FAKE_ATTR_KEY).unwrap().is_expired());
+
+        assert!(refresh_expired_attributes(&mgr, &mut actor).await);
+        assert!(actor.get_attribute(FAKE_ATTR_KEY).is_none());
+        assert!(actor.get_attribute(key::CN).is_some());
+
+        // The zero-attribute response was recorded: no further refresh churn.
+        assert!(!refresh_expired_attributes(&mgr, &mut actor).await);
+    }
+
+    /// A trusted service whose lookups always fail, standing in for an outage.
+    struct FailingTrustedService {
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::trusted_services_mgr::TrustedServiceInterface for FailingTrustedService {
+        async fn get_attributes_for_actor(
+            &self,
+            _actor_ident: &str,
+        ) -> Result<Vec<Attribute>, ServiceError> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Err(ServiceError::Internal("service is down".to_string()))
+        }
+
+        async fn flush(&self) -> Result<(), ServiceError> {
+            Ok(())
+        }
+
+        // Never flushed in these tests; a constant revision is enough.
+        fn current_revision(&self) -> u64 {
+            1
+        }
+
+        fn get_source_id(&self) -> &str {
+            FAKE_SOURCE
+        }
+    }
+
+    /// A failed lookup for a revision-stale source fails closed: the source's
+    /// attributes are stripped even though unexpired, and the source stays stale so
+    /// the next request retries.
+    #[tokio::test]
+    async fn test_refresh_revision_stale_failure_strips_source() {
+        let mgr = TrustedServicesMgr::new();
+        let failing = Arc::new(FailingTrustedService {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        });
+        mgr.update_services(vec![failing.clone()]);
+        let mut actor = actor_with_attr("someone.zpr.org", FAKE_SOURCE, false);
+
+        assert!(refresh_expired_attributes(&mgr, &mut actor).await);
+        assert!(actor.get_attribute(FAKE_ATTR_KEY).is_none());
+        assert!(actor.get_attribute(key::CN).is_some());
+
+        // No revision was recorded on failure, so the next request retries the source
+        // (nothing left to strip, so no change is reported).
+        assert!(!refresh_expired_attributes(&mgr, &mut actor).await);
+        assert_eq!(failing.calls.load(std::sync::atomic::Ordering::SeqCst), 2);
+    }
+
+    /// A plain TTL-refresh failure keeps today's behavior: the expired attributes are
+    /// left in place (an outage cannot strip attributes on the TTL path).
+    #[tokio::test]
+    async fn test_refresh_ttl_failure_retains_attributes() {
+        let mgr = TrustedServicesMgr::new();
+        let failing = Arc::new(FailingTrustedService {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        });
+        mgr.update_services(vec![failing.clone()]);
+        let mut actor = actor_with_attr("someone.zpr.org", FAKE_SOURCE, true);
+
+        // Mark the actor current for this source so only the TTL path triggers.
+        mgr.record_revision("someone.zpr.org", FAKE_SOURCE, 1);
+
+        assert!(!refresh_expired_attributes(&mgr, &mut actor).await);
+        assert!(actor.get_attribute(FAKE_ATTR_KEY).unwrap().is_expired());
+        assert_eq!(failing.calls.load(std::sync::atomic::Ordering::SeqCst), 1);
     }
 }


### PR DESCRIPTION
  - Adds revision numbers to trusted-service snapshots:
      - Each initial load, TTL reload, or successful flush gets a new process-wide revision.
      - Providers expose their current revision through the trusted-service interface.

  - Tracks trusted-service revisions per actor:
      - The manager records which revision of each source was last applied to an actor.
      - Revision data is held in memory and resets safely on restart.

  - Expands visa-request refresh behavior:
      - Refreshes attributes when their TTL expires, as before.
      - Also refreshes still-unexpired attributes when their source’s revision changes.
      - This means an administrative flush takes effect on an actor’s next visa request instead of waiting for that actor’s
        attribute TTL.

  - Treats revision refreshes as authoritative:
      - Attributes no longer returned by the provider are removed, even if their old copies have not expired.
      - An empty successful response removes all attributes previously supplied by that source and records the new revision.

  - Uses fail-closed behavior for revision refresh failures:
      - If data is known to have changed but cannot be fetched, existing attributes from that source are removed before policy
        evaluation.

      - The source remains marked stale so later requests retry.
      - Ordinary TTL-refresh failures retain the previous behavior: expired attributes remain attached, although libeval cannot use
        them to grant access.

  - Changes file-provider flushing from lazy to eager:
      - The flush operation now immediately reads and validates the JSON file.
      - A successful read atomically installs the new snapshot and revision.
      - A failed read leaves both the prior snapshot and revision unchanged and returns an error.

  - Adds tests for revision changes, refresh suppression when current, removal of deleted attributes, failed refresh behavior, and
    failed flush preservation.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>