### PR TITLE
(248ts-stack) sweep visas after attr flush

### DIFF
--- a/admin-http-api.txt
+++ b/admin-http-api.txt
@@ -215,6 +215,28 @@ GET /admin/services/{name}
     service_kind and service_endpoints are sourced from the current policy
     (both "" if the service is not present in it).
 
+DELETE /admin/services/{id}/cache
+---------------------------------
+  Summary
+    Refreshes a trusted service's attribute data and reconciles the system against
+    it. Use after the service's external data (e.g. its attribute file) changed.
+  Request
+    (none)
+  Response
+    202: accepted (reload succeeded, reconciliation queued)
+    403: permission denied (read-only key)
+    404: no such trusted service
+    500: reload failed (e.g. the attribute file is missing or unparseable)
+  Notes
+    The reload is synchronous, so a 202 means the new data is live. The
+    reconciliation that follows is asynchronous: the actors behind live visas are
+    refreshed from the service and their visas re-checked against current policy,
+    with visas no longer allowed queued for revocation. Its outcome is logged, not
+    returned.
+    Actors with no live visa are not touched here -- they refresh on their next
+    visa request.
+    Note that passed {id} must be url path encoded.
+
 GET /admin/visas
 ----------------
   Summary

--- a/vs-admin/src/executor.rs
+++ b/vs-admin/src/executor.rs
@@ -252,10 +252,11 @@ impl Executor {
         Ok(())
     }
 
-    /// Flush the cached attribute data held by a trusted service.
+    /// Refresh a trusted service's attribute data. The visa service then revalidates
+    /// active visas against the refreshed attributes asynchronously.
     fn flush_service_cache(&self, id: &str) -> Result<(), Box<dyn std::error::Error>> {
         self.vs_cli.flush_service_cache(id)?;
-        println!("flushed {id}");
+        println!("refreshed {id}; active visas are being revalidated");
         Ok(())
     }
 

--- a/vs-admin/src/main_args.rs
+++ b/vs-admin/src/main_args.rs
@@ -79,7 +79,8 @@ pub enum SubCmd {
         /// See more information on a specific service
         #[arg(long, short = 'i')]
         id: Option<String>,
-        /// Flush the cached attribute data for a trusted service. If flush is supplied, id must be as well
+        /// Refresh a trusted service's attribute data and revalidate active visas against
+        /// it. If flush is supplied, id must be as well
         #[arg(long, short = 'f', requires = "id")]
         flush: bool,
     },

--- a/vs-admin/src/vsclient.rs
+++ b/vs-admin/src/vsclient.rs
@@ -216,7 +216,8 @@ impl VsClient {
 
     /// `DELETE <api_url>/admin/services/<id>/cache`
     ///
-    /// Drops the trusted service's cached attribute data so the next lookup fetches fresh.
+    /// Reloads the trusted service's attribute data. The visa service then refreshes the
+    /// actors behind live visas and revalidates those visas asynchronously (202 Accepted).
     pub fn flush_service_cache(&self, id: &str) -> Result<(), VsaError> {
         let mut requrl = reqwest::Url::parse(&format!("{}/admin/services", self.api_url))?;
         requrl.path_segments_mut().unwrap().push(id).push("cache");

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -840,8 +840,13 @@ async fn get_service(
     }
 }
 
-/// DELETE /admin/services/{id}/cache — drop a trusted service's cached attribute
-/// data so the next lookup fetches fresh.
+/// DELETE /admin/services/{id}/cache — reload a trusted service's attribute data and
+/// reconcile against it: the actors behind live visas are refreshed and their visas
+/// re-checked, so no visa keeps relying on the old data.
+///
+/// The reload is synchronous (its failure is reported to the caller); the reconciliation
+/// runs on the event worker, so success returns `202 Accepted` and the outcome shows up
+/// in the log rather than the response.
 async fn flush_service_cache(
     Extension(perm): Extension<Permission>,
     State(state): State<SharedState>,
@@ -852,11 +857,23 @@ async fn flush_service_cache(
     }
     debug!(target: ADMIN, "DELETE /admin/services/{}/cache", svc_id);
 
-    // Clone the Arc and drop the read guard before awaiting the flush.
-    let ts_mgr = state.read().await.asm.ts_mgr.clone();
+    // Clone the Arcs and drop the read guard before awaiting the flush.
+    let (ts_mgr, event_mgr) = {
+        let rstate = state.read().await;
+        (rstate.asm.ts_mgr.clone(), rstate.asm.event_mgr.clone())
+    };
 
     match ts_mgr.flush_one(&svc_id).await {
-        Ok(()) => StatusCode::OK,
+        Ok(()) => {
+            // The flush itself is done. If the event cannot be queued we lose only the
+            // sweep of existing visas -- new visa decisions are still protected by the
+            // per-actor revision check.
+            let evt = VsEvent::TrustedServiceChange(svc_id.clone());
+            if let Err(e) = event_mgr.record_event(evt).await {
+                error!(target: ADMIN, "flushed trusted service {} but could not queue revalidation: {}", svc_id, e);
+            }
+            StatusCode::ACCEPTED
+        }
         Err(ServiceError::TrustedServiceNotFound(_)) => StatusCode::NOT_FOUND,
         Err(e) => {
             error!(target: ADMIN, "error flushing trusted service {}: {}", svc_id, e);
@@ -1028,7 +1045,7 @@ mod tests {
     use zpr::vsapi_types::PacketDesc;
 
     use crate::admin_apikeys::{ApiKeyRecord, KeyStatus};
-    use crate::assembly::tests::new_assembly_for_tests;
+    use crate::assembly::tests::{new_assembly_for_tests, new_assembly_with_event_rx};
     use crate::test_helpers::{make_adapter_actor_defexp, make_node_actor_defexp};
 
     /// Insert a readwrite test key into the assembly's key store and return the
@@ -2061,7 +2078,8 @@ mod tests {
     /// DELETE /admin/services/{id}/cache flushes the named trusted service.
     #[tokio::test]
     async fn test_flush_service_cache_ok() {
-        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let (asm, mut event_rx) = new_assembly_with_event_rx(None).await;
+        let asm = Arc::new(asm);
         let svc = register_flush_counting_service(&asm);
         let api_key = setup_test_api_rw_key(&asm);
         let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
@@ -2077,14 +2095,20 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
         assert_eq!(svc.flushes.load(std::sync::atomic::Ordering::SeqCst), 1);
+        // The revalidation of existing visas is queued for the event worker.
+        match event_rx.try_recv() {
+            Ok(VsEvent::TrustedServiceChange(id)) => assert_eq!(id, FLUSH_TS_ID),
+            other => panic!("expected TrustedServiceChange event, got {other:?}"),
+        }
     }
 
     /// DELETE /admin/services/{id}/cache for an unregistered service returns NOT_FOUND.
     #[tokio::test]
     async fn test_flush_service_cache_unknown_not_found() {
-        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let (asm, mut event_rx) = new_assembly_with_event_rx(None).await;
+        let asm = Arc::new(asm);
         register_flush_counting_service(&asm);
         let api_key = setup_test_api_rw_key(&asm);
         let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
@@ -2101,12 +2125,15 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        // Nothing was invalidated, so nothing needs revalidating.
+        assert!(event_rx.try_recv().is_err());
     }
 
     /// A read-only key may not flush a trusted service.
     #[tokio::test]
     async fn test_flush_service_cache_read_key_forbidden() {
-        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let (asm, mut event_rx) = new_assembly_with_event_rx(None).await;
+        let asm = Arc::new(asm);
         let svc = register_flush_counting_service(&asm);
         let api_key = setup_test_api_r_key(&asm);
         let shared_state = Arc::new(tokio::sync::RwLock::new(AdminState::new(asm.clone())));
@@ -2124,5 +2151,6 @@ mod tests {
             .unwrap();
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
         assert_eq!(svc.flushes.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert!(event_rx.try_recv().is_err());
     }
 }

--- a/vs/src/assembly.rs
+++ b/vs/src/assembly.rs
@@ -61,6 +61,7 @@ pub mod tests {
     use crate::connection_control::ConnectionControl;
     use crate::db::FakeDb;
     use crate::db::{ActorRepo, LinkRepo, NodeRepo, PolicyRepo, VisaRepo};
+    use crate::event_mgr::VsEvent;
     use crate::policy_mgr::PolicyMgr;
     use crate::test_helpers::FakeResolver;
     use crate::test_helpers::make_container_bytes;
@@ -93,9 +94,22 @@ pub mod tests {
         )
     }
 
+    /// Test assembly with no event manager worker running. The event receiver is kept
+    /// alive but never read, so `record_event` succeeds (a dropped receiver would make
+    /// every send fail). Use [new_assembly_with_event_rx] to inspect queued events.
     pub async fn new_assembly_for_tests(
         vreq_tx_chan: Option<mpsc::Sender<VisaRequestJob>>,
     ) -> Assembly {
+        let (asm, event_rx) = new_assembly_with_event_rx(vreq_tx_chan).await;
+        std::mem::forget(event_rx);
+        asm
+    }
+
+    /// As [new_assembly_for_tests], but hands back the event receiver so a test can
+    /// assert which events a handler queued.
+    pub async fn new_assembly_with_event_rx(
+        vreq_tx_chan: Option<mpsc::Sender<VisaRequestJob>>,
+    ) -> (Assembly, mpsc::Receiver<VsEvent>) {
         let vreq_tx = if let Some(tx) = vreq_tx_chan {
             tx
         } else {
@@ -114,13 +128,13 @@ pub mod tests {
 
         let counters: Arc<Counters> = Arc::new(Default::default());
 
-        let (event_tx, _event_rx) = mpsc::channel(100);
+        let (event_tx, event_rx) = mpsc::channel(100);
         // TODO: Start event manager worker?
 
         // Shared with the PolicyMgr below so it can publish policy-declared stores.
         let ts_mgr = Arc::new(TrustedServicesMgr::new());
 
-        Assembly {
+        let asm = Assembly {
             config: VSConfig::default(),
             counters: counters.clone(),
             system_start_time: std::time::Instant::now(),
@@ -144,6 +158,7 @@ pub mod tests {
             admin_api_keys: Arc::new(ReloadableApiKeys::default()),
             topo_mgr: TopologyMgr::new(LinkRepo::new(db_handle)),
             ts_mgr,
-        }
+        };
+        (asm, event_rx)
     }
 }

--- a/vs/src/db/actor.rs
+++ b/vs/src/db/actor.rs
@@ -169,7 +169,9 @@ impl ActorRepo {
         Ok(addrs)
     }
 
-    /// Update existing actor data.
+    /// Update existing actor data. The passed actor is authoritative: attributes it no
+    /// longer carries are dropped from the store (an attribute refresh can remove
+    /// attributes, and a stale copy left behind would resurface on the next load).
     pub async fn update_actor(&self, actor: &Actor) -> Result<(), StoreError> {
         let zpraddr = match actor.get_zpr_addr() {
             Some(addr) => addr.clone(),
@@ -214,14 +216,14 @@ impl ActorRepo {
         //
         // Write the attributes. We write out the attributes in JSON.
         // There may be a bunch of attributes so we take the time to set up a pipeline.
-        let ops = actor
-            .attrs_iter()
-            .map(|attr| DbOp::HSet {
-                hash_key: attrs_key.clone(),
-                field: attr.get_key().to_string(),
-                value: serde_json::to_string(attr).unwrap_or_default(),
-            })
-            .collect::<Vec<_>>();
+        // The hash is dropped first so removed attributes do not linger; the pipeline is
+        // atomic, so no reader sees the actor without its attributes.
+        let mut ops = vec![DbOp::Del(attrs_key.clone())];
+        ops.extend(actor.attrs_iter().map(|attr| DbOp::HSet {
+            hash_key: attrs_key.clone(),
+            field: attr.get_key().to_string(),
+            value: serde_json::to_string(attr).unwrap_or_default(),
+        }));
         self.db.atomic_pipeline(&ops).await?;
 
         //
@@ -873,6 +875,31 @@ mod test {
         let addr: IpAddr = "fd5a:5052::10".parse().unwrap();
         let err = repo.get_cn_by_zpr_addr(&addr).await.unwrap_err();
         assert!(matches!(err, StoreError::NotFound(_)));
+    }
+
+    /// update_actor is authoritative: an attribute dropped from the actor is dropped from
+    /// the store, so a later load does not resurrect it. (An attribute refresh can remove
+    /// attributes -- e.g. a trusted service no longer vends one.)
+    #[tokio::test]
+    async fn test_update_actor_drops_removed_attributes() {
+        let db = Arc::new(FakeDb::new());
+        let repo = ActorRepo::new(db);
+        let mut actor = make_actor_defexp(&[
+            (key::ROLE, ROLE_NODE),
+            (key::CN, "drop-node"),
+            (key::ZPR_ADDR, "fd5a:5052::10"),
+            ("user.dept", "sales"),
+        ]);
+        repo.add_actor(&actor).await.unwrap();
+
+        actor.remove_attribute("user.dept");
+        repo.update_actor(&actor).await.unwrap();
+
+        let addr: IpAddr = "fd5a:5052::10".parse().unwrap();
+        let loaded = repo.get_actor_by_zpr_addr(&addr).await.unwrap();
+        assert!(loaded.attrs_iter().all(|a| a.get_key() != "user.dept"));
+        // The rest of the actor survived the rewrite.
+        assert_eq!(loaded.get_cn(), Some("drop-node"));
     }
 
     #[tokio::test]

--- a/vs/src/event_mgr.rs
+++ b/vs/src/event_mgr.rs
@@ -5,6 +5,7 @@
 use futures::future::join_all;
 use futures::stream::{self, StreamExt};
 
+use std::collections::HashSet;
 use std::net::IpAddr;
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -20,7 +21,9 @@ use crate::error::ServiceError;
 use crate::logging::targets::EVENT;
 use crate::policy_mgr::PolicySnapshot;
 use crate::visa_mgr::VisaRecheck;
+use crate::visareq_worker::refresh_and_persist_actor;
 
+#[derive(Debug)]
 pub enum VsEvent {
     /// Use _after_ actor has been authenticated and the datastore updated.
     ActorJoins(IpAddr),
@@ -35,8 +38,26 @@ pub enum VsEvent {
 
     /// Indicates that policy has been successfully updated. Pass the new `vinst`.
     PolicyUpdated(u64),
+
+    /// The attribute data behind a trusted service changed (an admin refreshed it).
+    /// Pass the source id. Handler refreshes the actors behind live visas and
+    /// re-checks those visas against the refreshed attributes.
+    TrustedServiceChange(String),
 }
 
+/// Why a visa sweep is running. The two reasons need different handling because an
+/// attribute change does not move the policy generation, so the `checked_vinst`
+/// gates that make the policy sweep idempotent would make an attribute sweep a
+/// complete no-op.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum SweepReason {
+    /// A new policy was installed.
+    PolicyUpdate,
+    /// A trusted service's attribute data changed.
+    AttributeChange,
+}
+
+#[derive(Clone)]
 pub struct EventMgr {
     event_queue: mpsc::Sender<VsEvent>,
 }
@@ -79,6 +100,9 @@ pub async fn launch(asm: Arc<Assembly>, mut event_rx: mpsc::Receiver<VsEvent>) {
                 if let Err(e) = handle_policy_updated(&asm, vinst).await {
                     error!(target: EVENT, "failed to handle policy updated event: {}", e);
                 }
+            }
+            VsEvent::TrustedServiceChange(source_id) => {
+                handle_trusted_service_change(&asm, &source_id).await;
             }
         }
     }
@@ -260,9 +284,68 @@ async fn handle_policy_updated(asm: &Arc<Assembly>, vinst: u64) -> Result<(), Se
 
     // Re-check existing visas against the new policy. Runs last so route checks
     // and the nodes' own link state already reflect the updated topology.
-    revalidate_visas_against_policy(asm, &psnap).await;
+    revalidate_visas(asm, &psnap, SweepReason::PolicyUpdate).await;
 
     Ok(())
+}
+
+/// A trusted service's attribute data changed (an admin refreshed it). The new data may
+/// invalidate visas that were issued under the old data, so reconcile in two phases:
+/// refresh and persist the actors behind live visas, then re-check those visas.
+///
+/// Phase order matters: the sweep re-reads actors from the store, so their attributes
+/// have to be reconciled and written back first.
+///
+/// Note this only reconciles actors that hold a live visa. Everyone else is handled
+/// lazily on their next visa request by the revision check in `refresh_expired_attributes`.
+async fn handle_trusted_service_change(asm: &Arc<Assembly>, source_id: &str) {
+    // One snapshot for the whole pass, same as the policy handler.
+    let psnap = asm.policy_mgr.get_current_snapshot();
+
+    let (refreshed, unresolved, failed) = refresh_actors_for_live_visas(asm).await;
+    info!(
+        target: EVENT,
+        "trusted service '{source_id}' changed: actors refreshed={refreshed} unresolved={unresolved} failed={failed}"
+    );
+
+    revalidate_visas(asm, &psnap, SweepReason::AttributeChange).await;
+}
+
+/// Refresh (and persist) the attributes of every distinct actor referenced by a live
+/// visa. Only sources that are TTL-expired or revision-stale are actually fetched, so
+/// an actor already current costs nothing.
+///
+/// A failure is logged and skipped rather than aborting the pass: that actor's recorded
+/// revision stays mismatched, so its next visa request refreshes it again.
+///
+/// Returns `(refreshed, unresolved, failed)` counts for logging.
+async fn refresh_actors_for_live_visas(asm: &Arc<Assembly>) -> (u32, u32, u32) {
+    let mut zpr_addrs: HashSet<IpAddr> = HashSet::new();
+    for (_, md) in asm.visa_mgr.list_visa_metadata().await {
+        zpr_addrs.insert(md.five_tuple.source_addr);
+        zpr_addrs.insert(md.five_tuple.dest_addr);
+    }
+
+    let (mut refreshed, mut unresolved, mut failed) = (0u32, 0u32, 0u32);
+    // Sequential for now, join_all it if sweeps ever get slow.
+    for zpr_addr in zpr_addrs {
+        match asm.actor_mgr.get_actor_by_zpr_addr(&zpr_addr).await {
+            Ok(Some(mut actor)) => match refresh_and_persist_actor(asm, &mut actor).await {
+                Ok(true) => refreshed += 1,
+                Ok(false) => {}
+                Err(e) => {
+                    warn!(target: EVENT, "attribute reconcile: failed to refresh actor {zpr_addr}: {e}");
+                    failed += 1;
+                }
+            },
+            Ok(None) => unresolved += 1,
+            Err(e) => {
+                warn!(target: EVENT, "attribute reconcile: failed to load actor {zpr_addr}: {e}");
+                failed += 1;
+            }
+        }
+    }
+    (refreshed, unresolved, failed)
 }
 
 /// When we get a new policy, some nodes may no longer be valid. This checks each
@@ -325,16 +408,24 @@ async fn node_still_valid(asm: &Arc<Assembly>, ectx: &EvalContext, naddr: &IpAdd
     }
 }
 
-/// Sweep every live visa and re-evaluate it against the updated policy
-/// snapshot. Allowed visas get their `checked_vinst` bumped (and any queued
-/// revoke canceled); denied visas are marked `PendingRevoke` on all their nodes
-/// so VSS housekeeping revokes them.
+/// Sweep every live visa and re-evaluate it against the given policy snapshot.
+/// Denied visas (and visas whose route moved) are marked `PendingRevoke` on all
+/// their nodes so VSS housekeeping revokes them.
 ///
-/// A visa already checked at/after `target_vinst` is skipped. Visas whose
-/// actors can't be resolved are skipped (not revoked). A deny is only applied
-/// while `target_vinst` is still the live policy generation — otherwise a newer
-/// sweep is coming and will decide.
-async fn revalidate_visas_against_policy(asm: &Arc<Assembly>, psnap: &PolicySnapshot) {
+/// Visas whose actors can't be resolved are skipped (not revoked). A verdict is
+/// only applied while `target_vinst` is still the live policy generation —
+/// otherwise a newer policy sweep is coming and will decide.
+///
+/// [SweepReason::PolicyUpdate] skips any visa already checked at/after
+/// `target_vinst`, bumps `checked_vinst` on allow (canceling any older queued
+/// revoke), and denies through the vinst-gated verdict recorder.
+///
+/// [SweepReason::AttributeChange] cannot use those gates: the policy generation has
+/// not moved, so every visa looks "current". It checks every visa, revokes through
+/// the ungated [VisaMgr::mark_visa_revoked], and does nothing at all on allow —
+/// a revoke queued by an earlier attribute sweep stays queued, and the node simply
+/// re-requests to get a fresh decision.
+async fn revalidate_visas(asm: &Arc<Assembly>, psnap: &PolicySnapshot, reason: SweepReason) {
     let target_vinst = psnap.vinst();
     let snapshot = asm.visa_mgr.list_visa_metadata().await;
 
@@ -347,7 +438,9 @@ async fn revalidate_visas_against_policy(asm: &Arc<Assembly>, psnap: &PolicySnap
     let mut skipped_current = 0u32;
 
     for (visa_id, metadata) in snapshot {
-        if metadata.checked_vinst >= target_vinst {
+        // Only a policy sweep can skip on generation: an attribute change leaves the
+        // generation alone, so this would skip everything.
+        if reason == SweepReason::PolicyUpdate && metadata.checked_vinst >= target_vinst {
             skipped_current += 1;
             continue;
         }
@@ -361,6 +454,13 @@ async fn revalidate_visas_against_policy(asm: &Arc<Assembly>, psnap: &PolicySnap
                 debug!(target: EVENT, "visa sweep: visa {visa_id} actor unresolved, skipping");
             }
             Ok(VisaRecheck::AllowSameRoute) => {
+                // An attribute sweep records nothing on allow: it must not bump
+                // checked_vinst (that would make a later policy sweep skip the visa)
+                // and it deliberately leaves any queued revoke in place.
+                if reason == SweepReason::AttributeChange {
+                    allowed += 1;
+                    continue;
+                }
                 // Allowed. Only apply while target_vinst is still the live policy;
                 // otherwise an older sweep could cancel a newer revoke verdict.
                 if asm.policy_mgr.get_current_snapshot().vinst() != target_vinst {
@@ -386,11 +486,17 @@ async fn revalidate_visas_against_policy(asm: &Arc<Assembly>, psnap: &PolicySnap
                     skipped_stale += 1;
                     continue;
                 }
-                match asm
-                    .visa_mgr
-                    .record_deny_verdict(visa_id, target_vinst)
-                    .await
-                {
+                // The verdict recorder is vinst-gated, so an attribute sweep has to
+                // revoke through the ungated path.
+                let res = match reason {
+                    SweepReason::PolicyUpdate => {
+                        asm.visa_mgr
+                            .record_deny_verdict(visa_id, target_vinst)
+                            .await
+                    }
+                    SweepReason::AttributeChange => asm.visa_mgr.mark_visa_revoked(visa_id).await,
+                };
+                match res {
                     Ok(_) => revoked += 1,
                     Err(e) => {
                         warn!(target: EVENT, "visa sweep: failed to record deny for visa {visa_id}: {e}")
@@ -407,7 +513,7 @@ async fn revalidate_visas_against_policy(asm: &Arc<Assembly>, psnap: &PolicySnap
     // actual revocations happen asynchronously in VSS housekeeping.
     info!(
         target: EVENT,
-        "visa sweep vinst={target_vinst}: total={total} allowed={allowed} revoked={revoked} skipped_stale={skipped_stale} skipped_unresolved={skipped_unresolved} skipped_current={skipped_current}"
+        "visa sweep reason={reason:?} vinst={target_vinst}: total={total} allowed={allowed} revoked={revoked} skipped_stale={skipped_stale} skipped_unresolved={skipped_unresolved} skipped_current={skipped_current}"
     );
 }
 
@@ -420,7 +526,7 @@ mod tests {
     use crate::test_helpers::{
         make_adapter_actor_defexp, make_container_bytes, make_node_actor_defexp,
     };
-    use libeval::attribute::{Attribute, key};
+    use libeval::attribute::{Attribute, AttributeSource, key};
     use libeval::eval_result::{Direction, Hit};
     use libeval::route::{LinkId, Route};
     use std::time::Duration;
@@ -672,7 +778,7 @@ mod tests {
             psnap.vinst() > 0,
             "target must exceed the visa's checked_vinst"
         );
-        revalidate_visas_against_policy(&asm, &psnap).await;
+        revalidate_visas(&asm, &psnap, SweepReason::PolicyUpdate).await;
 
         let revoke_ids = asm
             .visa_mgr
@@ -692,7 +798,7 @@ mod tests {
         let id = create_sweep_visa(&asm, &node_a, target).await;
 
         let psnap = asm.policy_mgr.get_current_snapshot();
-        revalidate_visas_against_policy(&asm, &psnap).await;
+        revalidate_visas(&asm, &psnap, SweepReason::PolicyUpdate).await;
 
         assert!(
             asm.visa_mgr
@@ -719,7 +825,7 @@ mod tests {
         let id = create_sweep_visa(&asm, &node, 0).await;
 
         let psnap = asm.policy_mgr.get_current_snapshot();
-        revalidate_visas_against_policy(&asm, &psnap).await;
+        revalidate_visas(&asm, &psnap, SweepReason::PolicyUpdate).await;
 
         // Still held as PendingInstall (untouched); nothing marked for revoke.
         let pending = asm
@@ -753,7 +859,7 @@ mod tests {
             .unwrap();
         assert!(asm.policy_mgr.get_current_snapshot().vinst() > stale_psnap.vinst());
 
-        revalidate_visas_against_policy(&asm, &stale_psnap).await;
+        revalidate_visas(&asm, &stale_psnap, SweepReason::PolicyUpdate).await;
 
         // No revoke marked; the visa stays PendingInstall.
         assert!(
@@ -769,5 +875,264 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(pending, vec![id]);
+    }
+
+    // ---- attribute-change sweep ----
+
+    const TS_SOURCE: &str = "hr";
+    const TS_KEY: &str = "user.dept";
+
+    /// A trusted service whose vended attributes, revision, and failure mode are all
+    /// settable, so a test can simulate "the external data changed" and "the service is
+    /// down".
+    struct MutableTrustedService {
+        /// (key, value) pairs to vend; empty means the actor has no attributes here.
+        attrs: std::sync::Mutex<Vec<(String, String)>>,
+        fail: std::sync::atomic::AtomicBool,
+        revision: std::sync::atomic::AtomicU64,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::trusted_services_mgr::TrustedServiceInterface for MutableTrustedService {
+        async fn get_attributes_for_actor(
+            &self,
+            _actor_ident: &str,
+        ) -> Result<Vec<Attribute>, ServiceError> {
+            if self.fail.load(std::sync::atomic::Ordering::SeqCst) {
+                return Err(ServiceError::TrustedServiceInit("down".into()));
+            }
+            Ok(self
+                .attrs
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|(k, v)| {
+                    AttributeSource::new(TS_SOURCE)
+                        .builder(k)
+                        .expires_in(Duration::from_secs(600))
+                        .value(v)
+                })
+                .collect())
+        }
+
+        async fn flush(&self) -> Result<(), ServiceError> {
+            self.revision
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        }
+
+        fn current_revision(&self) -> u64 {
+            self.revision.load(std::sync::atomic::Ordering::SeqCst)
+        }
+
+        fn get_source_id(&self) -> &str {
+            TS_SOURCE
+        }
+    }
+
+    /// Register one [MutableTrustedService] vending `attrs` on the assembly, and return
+    /// it so the test can change its data or knock it over.
+    fn register_ts(asm: &Arc<Assembly>, attrs: &[(&str, &str)]) -> Arc<MutableTrustedService> {
+        let svc = Arc::new(MutableTrustedService {
+            attrs: std::sync::Mutex::new(
+                attrs
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect(),
+            ),
+            fail: std::sync::atomic::AtomicBool::new(false),
+            revision: std::sync::atomic::AtomicU64::new(1),
+        });
+        asm.ts_mgr.update_services(vec![svc.clone()]);
+        svc
+    }
+
+    /// Give the stored actor at `zpr_addr` an attribute from [TS_SOURCE], so the source
+    /// counts as relevant to that actor (a source the actor holds nothing from and has no
+    /// revision record for is not refreshed).
+    async fn seed_source_attr(asm: &Arc<Assembly>, zpr_addr: &str, ts_key: &str, value: &str) {
+        let addr: IpAddr = zpr_addr.parse().unwrap();
+        let mut actor = asm
+            .actor_mgr
+            .get_actor_by_zpr_addr(&addr)
+            .await
+            .unwrap()
+            .unwrap();
+        actor
+            .add_attribute(
+                AttributeSource::new(TS_SOURCE)
+                    .builder(ts_key)
+                    .expires_in(Duration::from_secs(600))
+                    .value(value),
+            )
+            .unwrap();
+        asm.actor_mgr.update_actor(&actor).await.unwrap();
+    }
+
+    /// The stored actor's attribute values for `key`, if any.
+    async fn stored_attr(asm: &Arc<Assembly>, zpr_addr: &str, attr_key: &str) -> Option<String> {
+        let addr: IpAddr = zpr_addr.parse().unwrap();
+        let actor = asm
+            .actor_mgr
+            .get_actor_by_zpr_addr(&addr)
+            .await
+            .unwrap()
+            .unwrap();
+        actor
+            .attrs_iter()
+            .find(|a| a.get_key() == attr_key)
+            .map(|a| a.get_value_as_string())
+    }
+
+    /// The core case: an attribute sweep re-checks (and revokes) a visa whose
+    /// `checked_vinst` already equals the live generation -- exactly what the policy
+    /// sweep skips, at both the sweep and the store layer.
+    #[tokio::test]
+    async fn test_attr_sweep_revokes_visa_at_current_vinst() {
+        let (asm, node_a) = build_sweep_asm(false).await;
+        let target = asm.policy_mgr.get_current_snapshot().vinst();
+        let id = create_sweep_visa(&asm, &node_a, target).await;
+
+        let psnap = asm.policy_mgr.get_current_snapshot();
+        revalidate_visas(&asm, &psnap, SweepReason::AttributeChange).await;
+
+        let revoke_ids = asm
+            .visa_mgr
+            .get_pending_revoke_visa_ids_for_node(&node_a)
+            .await
+            .unwrap();
+        assert_eq!(revoke_ids, vec![id]);
+
+        // The attribute sweep must not touch the policy generation it was checked at.
+        let md = asm.visa_mgr.list_visa_metadata().await;
+        assert_eq!(md.len(), 1);
+        assert_eq!(md[0].1.checked_vinst, target);
+    }
+
+    /// An attribute sweep holding a snapshot older than the live policy applies nothing:
+    /// a policy sweep is already coming and will decide.
+    #[tokio::test]
+    async fn test_attr_sweep_stale_target_skips() {
+        let (asm, node_a) = build_sweep_asm(false).await;
+        let id = create_sweep_visa(&asm, &node_a, 0).await;
+
+        let stale_psnap = asm.policy_mgr.get_current_snapshot();
+        asm.policy_mgr
+            .update_policy_from_container_bytes(make_policy("2024-01-02T00:00:00Z", 2, Some("m")))
+            .await
+            .unwrap();
+
+        revalidate_visas(&asm, &stale_psnap, SweepReason::AttributeChange).await;
+
+        assert!(
+            asm.visa_mgr
+                .get_pending_revoke_visa_ids_for_node(&node_a)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(
+            asm.visa_mgr
+                .get_pending_visa_ids_for_node(&node_a)
+                .await
+                .unwrap(),
+            vec![id]
+        );
+    }
+
+    /// An unresolvable actor is skipped by the attribute sweep too, never revoked.
+    #[tokio::test]
+    async fn test_attr_sweep_unresolved_actor_leaves_visa_untouched() {
+        let asm = Arc::new(new_assembly_for_tests(None).await);
+        let node: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
+        let id = create_sweep_visa(&asm, &node, 0).await;
+
+        let psnap = asm.policy_mgr.get_current_snapshot();
+        revalidate_visas(&asm, &psnap, SweepReason::AttributeChange).await;
+
+        assert_eq!(
+            asm.visa_mgr
+                .get_pending_visa_ids_for_node(&node)
+                .await
+                .unwrap(),
+            vec![id]
+        );
+        assert!(
+            asm.visa_mgr
+                .get_pending_revoke_visa_ids_for_node(&node)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    /// Phase A: handling the event refreshes the stored actors behind live visas from the
+    /// changed service -- replacing a changed value and dropping an attribute the service
+    /// no longer vends.
+    #[tokio::test]
+    async fn test_trusted_service_change_refreshes_stored_actors() {
+        let (asm, node_a) = build_sweep_asm(false).await;
+        create_sweep_visa(&asm, &node_a, 0).await;
+        let svc = register_ts(&asm, &[(TS_KEY, "engineering")]);
+        // What the actor holds from the old data: one value that changes, one that goes away.
+        seed_source_attr(&asm, "fd5a:5052:4000::a", TS_KEY, "sales").await;
+        seed_source_attr(&asm, "fd5a:5052:4000::a", "user.badge", "b-1").await;
+
+        // The external data changed and the service was reloaded.
+        *svc.attrs.lock().unwrap() = vec![(TS_KEY.to_string(), "engineering".to_string())];
+        {
+            use crate::trusted_services_mgr::TrustedServiceInterface;
+            svc.flush().await.unwrap();
+        }
+
+        handle_trusted_service_change(&asm, TS_SOURCE).await;
+
+        assert_eq!(
+            stored_attr(&asm, "fd5a:5052:4000::a", TS_KEY).await,
+            Some("engineering".to_string()),
+            "changed value must be refreshed in the store"
+        );
+        assert_eq!(
+            stored_attr(&asm, "fd5a:5052:4000::a", "user.badge").await,
+            None,
+            "attribute no longer vended must be pruned"
+        );
+    }
+
+    /// Phase A fails closed: if the changed service cannot be reached, its attributes are
+    /// stripped from the stored actor rather than left to satisfy a policy on their
+    /// unexpired TTL.
+    #[tokio::test]
+    async fn test_trusted_service_change_strips_attrs_when_service_fails() {
+        let (asm, node_a) = build_sweep_asm(false).await;
+        create_sweep_visa(&asm, &node_a, 0).await;
+        let svc = register_ts(&asm, &[(TS_KEY, "engineering")]);
+        seed_source_attr(&asm, "fd5a:5052:4000::a", TS_KEY, "sales").await;
+
+        svc.fail.store(true, std::sync::atomic::Ordering::SeqCst);
+        handle_trusted_service_change(&asm, TS_SOURCE).await;
+
+        assert_eq!(
+            stored_attr(&asm, "fd5a:5052:4000::a", TS_KEY).await,
+            None,
+            "unreachable service must not leave stale attributes in place"
+        );
+    }
+
+    /// An actor with no live visa is left alone: it reconciles lazily on its next visa
+    /// request instead.
+    #[tokio::test]
+    async fn test_trusted_service_change_ignores_actors_without_visas() {
+        let (asm, _node_a) = build_sweep_asm(false).await;
+        register_ts(&asm, &[(TS_KEY, "engineering")]);
+        seed_source_attr(&asm, "fd5a:5052:4000::a", TS_KEY, "sales").await;
+
+        // No visa created, so no actor is in scope for the refresh.
+        handle_trusted_service_change(&asm, TS_SOURCE).await;
+
+        assert_eq!(
+            stored_attr(&asm, "fd5a:5052:4000::a", TS_KEY).await,
+            Some("sales".to_string())
+        );
     }
 }

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -545,6 +545,13 @@ impl VisaMgr {
         Ok(self.repo.record_deny_verdict(visa_id, vinst).await?)
     }
 
+    /// Mark every node of a visa `PendingRevoke` with no policy-generation gate. Used by
+    /// the attribute-change sweep, where the policy `vinst` has not moved and so the
+    /// verdict recorders would no-op. See [db::VisaRepo::mark_visa_revoked].
+    pub async fn mark_visa_revoked(&self, visa_id: u64) -> Result<bool, ServiceError> {
+        Ok(self.repo.mark_visa_revoked(visa_id).await?)
+    }
+
     /// Remove a visa entirely (Redis + memory). See [db::VisaRepo::remove_visa].
     pub async fn remove_visa(&self, visa_id: u64) -> Result<(), ServiceError> {
         self.repo.remove_visa(visa_id).await?;

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -247,19 +247,13 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
 
     // If necessary, refresh any expired attributes
     // TODO: Can we parallize this?
-    if refresh_expired_attributes(&asm.ts_mgr, &mut source_actor).await {
-        // write to store
-        if let Err(e) = asm.actor_mgr.update_actor(&source_actor).await {
-            error!(target: VREQ, "failed to update source actor after refreshing attributes: {}", e);
-            return Ok(VisaDecision::Deny(DenyCode::NoReason));
-        }
+    if let Err(e) = refresh_and_persist_actor(&asm, &mut source_actor).await {
+        error!(target: VREQ, "failed to update source actor after refreshing attributes: {}", e);
+        return Ok(VisaDecision::Deny(DenyCode::NoReason));
     }
-    if refresh_expired_attributes(&asm.ts_mgr, &mut dest_actor).await {
-        // write to store
-        if let Err(e) = asm.actor_mgr.update_actor(&dest_actor).await {
-            error!(target: VREQ, "failed to update dest actor after refreshing attributes: {}", e);
-            return Ok(VisaDecision::Deny(DenyCode::NoReason));
-        }
+    if let Err(e) = refresh_and_persist_actor(&asm, &mut dest_actor).await {
+        error!(target: VREQ, "failed to update dest actor after refreshing attributes: {}", e);
+        return Ok(VisaDecision::Deny(DenyCode::NoReason));
     }
 
     // Docking-node resolution, routing, and policy eval all live in the shared
@@ -284,6 +278,22 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
         } => visa_from_allow(asm.clone(), job, &hits, &policy, default_route).await,
         PolicyOutcome::Deny(code) => Ok(VisaDecision::Deny(code)),
     }
+}
+
+/// Refresh the actor's attributes (see [refresh_expired_attributes]) and persist it to
+/// the store if anything changed. Used by the request path and by the attribute-change
+/// reconciliation in `event_mgr`.
+///
+/// Returns TRUE if the actor was changed and written back.
+pub(crate) async fn refresh_and_persist_actor(
+    asm: &Assembly,
+    actor: &mut Actor,
+) -> Result<bool, ServiceError> {
+    if !refresh_expired_attributes(&asm.ts_mgr, actor).await {
+        return Ok(false);
+    }
+    asm.actor_mgr.update_actor(actor).await?;
+    Ok(true)
 }
 
 /// Refresh the actor's attributes from the trusted service manager where needed: any


### PR DESCRIPTION
  - A successful trusted-service flush now queues a TrustedServiceChange event.

  - The event worker performs a two-phase reconciliation:
      1. Finds every distinct actor referenced by a live visa, refreshes stale trusted attributes, and persists any changes.
      2. Re-evaluates all live visas against the refreshed actors and current policy.

  - Visas that are no longer allowed—or whose required route changed—are marked for asynchronous revocation.

  - Actors without live visas are not swept:
      - They continue to refresh lazily on their next visa request through the revision mechanism added in 248-05.

  - Separates visa sweeps by cause:
      - Policy-update sweeps continue using policy-version gates.
      - Attribute-change sweeps recheck visas even when their policy version is already current, because trusted data can change
        without changing the policy version.

      - Attribute sweeps do not cancel an already queued revocation when a visa evaluates as allowed.

  - Preserves race safety:
      - Results from a sweep using an obsolete policy snapshot are not applied.
      - Unresolved actors are skipped rather than causing automatic revocation.

  - Changes the flush API response:
      - DELETE /admin/services/{id}/cache now returns 202 Accepted after the synchronous reload succeeds and reconciliation is
        queued.

      - The asynchronous sweep’s outcome is reported through logs.
      - If event queuing fails, the reload remains effective and subsequent visa requests are still protected by revision checks.

  - Makes actor persistence authoritative:
      - Updating an actor now atomically replaces its complete attribute hash.
      - Attributes removed during refresh can no longer remain in storage and reappear on a later load.

  - Extracts shared refresh-and-persist logic for use by both normal visa requests and the new sweep.

  - Updates CLI messaging and admin API documentation to explain that active visas are revalidated.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>