### PR TITLE
(248ts-stack) mk/248 08 fixes round 1

### DIFF
--- a/libeval/src/eval.rs
+++ b/libeval/src/eval.rs
@@ -540,14 +540,15 @@ impl EvalContext {
             policy_capnp::AttrOp::Eq => {
                 match value {
                     None => {
-                        // Hmm... KEY, EQ, NONE ?? Is this valid?
-                        if actor.has_attribute_named(key) {
-                            return false;
-                        }
+                        // TODO: This is not valid and should be rejected at policy install.
+                        warn!(target: EVAL, "INVALID ZPL: condition key '{}' has EQ op but no value", key);
+                        return !for_allow;
                     }
                     Some(PAttrValue::Set(_)) => {
-                        // EQ with a set is not supported for now.
-                        return false;
+                        // EQ with a set is not supported for now, so this condition is
+                        // indeterminate: it cannot satisfy an allow, and a deny keyed on
+                        // it must still fire rather than silently disappear.
+                        return !for_allow;
                     }
                     Some(PAttrValue::Atom(s)) => {
                         if !actor.has_attribute_value(key, s.as_str()) {
@@ -559,14 +560,15 @@ impl EvalContext {
             policy_capnp::AttrOp::Ne => {
                 match value {
                     None => {
-                        // Hmm... KEY, NE, NONE ?? Is this valid?
-                        if !actor.has_attribute_named(key) {
-                            return false;
-                        }
+                        // TODO: This is not valid and should be rejected at policy install.
+                        warn!(target: EVAL, "INVALID ZPL: condition key '{}' has NE op but no value", key);
+                        return !for_allow;
                     }
                     Some(PAttrValue::Set(_)) => {
-                        // NE with a set is not supported for now.
-                        return false;
+                        // NE with a set is not supported for now, so this condition is
+                        // indeterminate: it cannot satisfy an allow, and a deny keyed on
+                        // it must still fire rather than silently disappear.
+                        return !for_allow;
                     }
                     Some(PAttrValue::Atom(s)) => {
                         if actor.has_attribute_value(key, s.as_str()) {
@@ -594,7 +596,14 @@ impl EvalContext {
             }
             policy_capnp::AttrOp::Excludes => {
                 // Any values in here must not be present in the actor.
-                if actor.has_any_attribute_values(key, value.as_ref().unwrap().as_slice()) {
+                // TODO: The compiler does not produce EXCLUDES or NE, so maybe we should remove them.
+                let Some(ref values) = value else {
+                    // Valueless EXCLUDES is indeterminate rather than a panic: it cannot
+                    // satisfy an allow, and a deny keyed on it must still fire.
+                    warn!(target: EVAL, "INVALID ZPL: condition key '{}' has EXCLUDES op but no value", key);
+                    return !for_allow;
+                };
+                if actor.has_any_attribute_values(key, values.as_slice()) {
                     return false;
                 }
             }
@@ -1278,5 +1287,57 @@ mod test {
         assert!(actor.is_node());
 
         assert!(!ctx.approve_connected(&actor).unwrap());
+    }
+
+    /// Build a standalone `AttrExpr` message so a single condition can be evaluated
+    /// without compiling a whole policy.
+    fn cond_message(
+        key: &str,
+        op: policy_capnp::AttrOp,
+        values: &[&str],
+    ) -> capnp::message::Builder<capnp::message::HeapAllocator> {
+        let mut msg = capnp::message::Builder::new_default();
+        {
+            let mut expr = msg.init_root::<policy_capnp::attr_expr::Builder>();
+            expr.set_key(key);
+            expr.set_op(op);
+            let mut vlist = expr.init_value(values.len() as u32);
+            for (i, v) in values.iter().enumerate() {
+                vlist.set(i as u32, *v);
+            }
+        }
+        msg
+    }
+
+    /// Conditions libeval cannot evaluate -- valueless EQ/NE/EXCLUDES, and set-valued
+    /// EQ/NE -- are indeterminate: they must never satisfy an allow, and must never let
+    /// a deny silently stop matching. Valueless EXCLUDES also used to panic here.
+    #[test]
+    fn test_indeterminate_conditions_fail_safe() {
+        setup();
+        let ctx = EvalContext::new(Arc::new(load_policy("basic.bin2")));
+        let actor = Actor::new();
+
+        let cases: [(policy_capnp::AttrOp, &[&str]); 5] = [
+            (policy_capnp::AttrOp::Eq, &[]),
+            (policy_capnp::AttrOp::Ne, &[]),
+            (policy_capnp::AttrOp::Excludes, &[]),
+            (policy_capnp::AttrOp::Eq, &["a", "b"]),
+            (policy_capnp::AttrOp::Ne, &["a", "b"]),
+        ];
+        for (op, values) in cases {
+            let msg = cond_message("user.zpr.tag", op, values);
+            let cond = msg
+                .get_root_as_reader::<policy_capnp::attr_expr::Reader>()
+                .unwrap();
+            assert!(
+                !ctx.match_condition_to_actor(&cond, &actor, true),
+                "{op:?} with {values:?} must not satisfy an allow"
+            );
+            assert!(
+                ctx.match_condition_to_actor(&cond, &actor, false),
+                "{op:?} with {values:?} must keep a deny matching"
+            );
+        }
     }
 }

--- a/vs/src/connection_control.rs
+++ b/vs/src/connection_control.rs
@@ -374,6 +374,11 @@ impl ConnectionControl {
         // TODO: But why don't we set CN as the identity attribute on the actor? Why mess with the JWT?
         // TODO: We will need some formal way to pass an IDENTITY value to this function.
 
+        // A lookup failure is indeterminate, not "the actor has no such attribute", and
+        // the two are indistinguishable once evaluation starts: a join policy can be
+        // satisfied by a missing key. Refuse the connection rather than authorize
+        // against a partial claim set. Note this means a trusted-service outage blocks
+        // new connections.
         for ts_results in asm.ts_mgr.get_attributes_for_actor(endpoint_cn).await {
             match ts_results {
                 Ok(ts_attrs) => {
@@ -383,6 +388,9 @@ impl ConnectionControl {
                 }
                 Err(e) => {
                     error!(target: CC, "ts service attr lookup failed for actor {}: {}", endpoint_cn, e);
+                    return Err(ServiceError::AttributesIndeterminate(format!(
+                        "trusted service lookup failed for {endpoint_cn}: {e}"
+                    )));
                 }
             }
         }
@@ -779,6 +787,55 @@ mod tests {
 
         pio::load_policy_from_container(&container_bytes, &config::POLICY_MIN_VERSION)
             .expect("should load policy from container bytes");
+    }
+
+    /// A trusted service whose lookups always fail, standing in for an unreadable
+    /// attribute file or an unreachable service.
+    struct FailingTrustedService;
+
+    #[async_trait::async_trait]
+    impl crate::trusted_services::TrustedServiceInterface for FailingTrustedService {
+        async fn get_attributes_for_actor(
+            &self,
+            _actor_ident: &str,
+        ) -> Result<Vec<Attribute>, ServiceError> {
+            Err(ServiceError::Internal("service is down".to_string()))
+        }
+
+        async fn flush(&self) -> Result<(), ServiceError> {
+            Ok(())
+        }
+
+        fn current_revision(&self) -> u64 {
+            1
+        }
+
+        fn get_source_id(&self) -> &str {
+            "failing"
+        }
+    }
+
+    /// A trusted-service lookup failure must reject the connection rather than
+    /// authorize against a partial claim set -- a join policy can be satisfied by a
+    /// missing key, so falling through would let an outage approve an actor.
+    #[tokio::test]
+    async fn authorize_connection_rejects_on_trusted_service_failure() {
+        let asm = Arc::new(crate::assembly::tests::new_assembly_for_tests(None).await);
+        let cc = make_cc("test-vs");
+
+        // Baseline: with no trusted services configured this same call succeeds, so the
+        // rejection below is caused by the failure and not by the surrounding setup.
+        cc.authenticate_visa_service(asm.clone(), Vec::new())
+            .await
+            .expect("should authorize with no trusted services");
+
+        asm.ts_mgr
+            .update_services(vec![Arc::new(FailingTrustedService)]);
+        let result = cc.authenticate_visa_service(asm, Vec::new()).await;
+        assert!(matches!(
+            result,
+            Err(ServiceError::AttributesIndeterminate(_))
+        ));
     }
 
     #[tokio::test]

--- a/vs/src/error.rs
+++ b/vs/src/error.rs
@@ -75,6 +75,9 @@ pub enum ServiceError {
 
     #[error("trusted service initialization error: {0}")]
     TrustedServiceInit(String),
+
+    #[error("trusted service attributes indeterminate: {0}")]
+    AttributesIndeterminate(String),
 }
 
 #[derive(Debug, Error)]

--- a/vs/src/event_mgr.rs
+++ b/vs/src/event_mgr.rs
@@ -222,9 +222,32 @@ async fn handle_policy_updated(asm: &Arc<Assembly>, vinst: u64) -> Result<(), Se
         );
     }
 
-    // The new policy may invalidate some existing nodes. An error here will bail on the
-    // update handling.
-    let (connected_node_addrs, invalid_node_addrs) = revalidate_nodes(asm, &psnap).await?;
+    // Reconcile attributes before anything reads them. Both consumers below --
+    // node revalidation and the visa sweep -- evaluate actors exactly as stored, so
+    // a stale actor is judged on the previous store's data. Nothing between here and
+    // the sweep mutates attributes, so this one pass covers both.
+    //
+    // Only actors that are actually stale cost a fetch: `PolicyMgr::build_state`
+    // carries unchanged trusted-service stores (and their revisions) across a policy
+    // install, so this is a no-op unless the policy changed a trusted-service
+    // declaration.
+    //
+    // TODO: when a declaration does change, this refetches every source for every
+    // actor in the set, sequentially -- an N x M synchronous fan-out on the event
+    // handler's critical path once services are network-backed and actor/visa counts
+    // are large.
+    let connected_node_addrs = asm.actor_mgr.list_node_addrs().await?;
+    let mut refresh_set = live_visa_actor_addrs(asm).await;
+    refresh_set.extend(connected_node_addrs.iter().copied());
+    let (refreshed, unresolved, failed) = refresh_actors(asm, refresh_set).await;
+    info!(
+        target: EVENT,
+        "policy updated vinst={vinst}: actors refreshed={refreshed} unresolved={unresolved} failed={failed}"
+    );
+
+    // The new policy may invalidate some existing nodes.
+    let (valid_node_addrs, invalid_node_addrs) =
+        revalidate_nodes(asm, &psnap, connected_node_addrs).await;
 
     // Disconnect the nodes that are no longer approved by the new policy.
     for naddr in &invalid_node_addrs {
@@ -248,11 +271,11 @@ async fn handle_policy_updated(asm: &Arc<Assembly>, vinst: u64) -> Result<(), Se
     // have been (or will soon be) updated via other code paths.  The purpose of
     // updating the topology when presented with a new policy is to verify that
     // existing links are still allowed, and send out peer messages.
-    if !connected_node_addrs.is_empty() {
-        info!(target: EVENT, "policy updated vinst={vinst}: revalidating topology ({} nodes)", connected_node_addrs.len());
+    if !valid_node_addrs.is_empty() {
+        info!(target: EVENT, "policy updated vinst={vinst}: revalidating topology ({} nodes)", valid_node_addrs.len());
         let report = asm
             .topo_mgr
-            .revalidate_against_policy(&psnap, &connected_node_addrs)
+            .revalidate_against_policy(&psnap, &valid_node_addrs)
             .await?;
         info!(
             target: EVENT,
@@ -264,7 +287,7 @@ async fn handle_policy_updated(asm: &Arc<Assembly>, vinst: u64) -> Result<(), Se
         );
 
         // Queue up setTopology messages in parallel.
-        let futs = connected_node_addrs.iter().filter_map(|naddr| {
+        let futs = valid_node_addrs.iter().filter_map(|naddr| {
             let links = psnap.links_for_node(naddr);
             asm.vss_mgr.get_handle(naddr).map(|vss_handle| async move {
                 if let Err(e) = vss_handle.set_topology(links).await {
@@ -282,23 +305,6 @@ async fn handle_policy_updated(asm: &Arc<Assembly>, vinst: u64) -> Result<(), Se
         }
     }
 
-    // Reconcile before sweeping, same two-phase order as the trusted-service
-    // handler: the sweep re-reads actors from the store, so their attributes
-    // have to be current first. Only actors that are actually stale cost a
-    // fetch: `PolicyMgr::build_state` carries unchanged trusted-service stores
-    // (and their revisions) across a policy install, so this is a no-op unless
-    // the policy changed a trusted-service declaration.
-    //
-    // TODO: when a declaration does change, this refetches every source for
-    // every actor holding a live visa, sequentially -- an N x M synchronous
-    // fan-out on the event handler's critical path once services are
-    // network-backed and actor/visa counts are large.
-    let (refreshed, unresolved, failed) = refresh_actors_for_live_visas(asm).await;
-    info!(
-        target: EVENT,
-        "policy updated vinst={vinst}: actors refreshed={refreshed} unresolved={unresolved} failed={failed}"
-    );
-
     // Re-check existing visas against the new policy. Runs last so route checks
     // and the nodes' own link state already reflect the updated topology.
     revalidate_visas(asm, &psnap, SweepReason::PolicyUpdate).await;
@@ -313,13 +319,15 @@ async fn handle_policy_updated(asm: &Arc<Assembly>, vinst: u64) -> Result<(), Se
 /// Phase order matters: the sweep re-reads actors from the store, so their attributes
 /// have to be reconciled and written back first.
 ///
-/// Note this only reconciles actors that hold a live visa. Everyone else is handled
-/// lazily on their next visa request by the revision check in `refresh_expired_attributes`.
+/// Note this only reconciles actors that hold a live visa -- the visa sweep is the only
+/// consumer here. Everyone else is handled lazily on their next visa request by the
+/// revision check in `refresh_expired_attributes`.
 async fn handle_trusted_service_change(asm: &Arc<Assembly>, source_id: &str) {
     // One snapshot for the whole pass, same as the policy handler.
     let psnap = asm.policy_mgr.get_current_snapshot();
 
-    let (refreshed, unresolved, failed) = refresh_actors_for_live_visas(asm).await;
+    let (refreshed, unresolved, failed) =
+        refresh_actors(asm, live_visa_actor_addrs(asm).await).await;
     info!(
         target: EVENT,
         "trusted service '{source_id}' changed: actors refreshed={refreshed} unresolved={unresolved} failed={failed}"
@@ -328,25 +336,30 @@ async fn handle_trusted_service_change(asm: &Arc<Assembly>, source_id: &str) {
     revalidate_visas(asm, &psnap, SweepReason::AttributeChange).await;
 }
 
-/// Refresh (and persist) the attributes of every distinct actor referenced by a live
-/// visa. Only sources that are TTL-expired or revision-stale are actually fetched, so
-/// an actor already current costs nothing.
+/// The distinct actor addresses referenced by a live visa (both ends of every visa's
+/// five-tuple). The reconcile set for a sweep that only re-checks visas.
+async fn live_visa_actor_addrs(asm: &Arc<Assembly>) -> HashSet<IpAddr> {
+    let mut zpr_addrs: HashSet<IpAddr> = HashSet::new();
+    for (_, md) in asm.visa_mgr.list_visa_metadata().await {
+        zpr_addrs.insert(md.five_tuple.source_addr);
+        zpr_addrs.insert(md.five_tuple.dest_addr);
+    }
+    zpr_addrs
+}
+
+/// Refresh (and persist) the attributes of each actor in `zpr_addrs`. Only sources that
+/// are TTL-expired or revision-stale are actually fetched, so an actor already current
+/// costs nothing.
 ///
 /// A failure is logged and skipped rather than aborting the pass: that actor's recorded
 /// revision stays mismatched, so its next visa request refreshes it again.
 ///
 /// Returns `(refreshed, unresolved, failed)` counts for logging.
 ///
-/// TODO: sequential, and unbounded in the number of live visas. Fine while the only
-/// trusted service is the in-memory file store; revisit once services are network calls
-/// and actor/visa counts are large.
-async fn refresh_actors_for_live_visas(asm: &Arc<Assembly>) -> (u32, u32, u32) {
-    let mut zpr_addrs: HashSet<IpAddr> = HashSet::new();
-    for (_, md) in asm.visa_mgr.list_visa_metadata().await {
-        zpr_addrs.insert(md.five_tuple.source_addr);
-        zpr_addrs.insert(md.five_tuple.dest_addr);
-    }
-
+/// TODO: sequential, and unbounded in the size of the set. Fine while the only trusted
+/// service is the in-memory file store; revisit once services are network calls and
+/// actor/visa counts are large.
+async fn refresh_actors(asm: &Arc<Assembly>, zpr_addrs: HashSet<IpAddr>) -> (u32, u32, u32) {
     let (mut refreshed, mut unresolved, mut failed) = (0u32, 0u32, 0u32);
     // Sequential for now, join_all it if sweeps ever get slow.
     for zpr_addr in zpr_addrs {
@@ -369,22 +382,21 @@ async fn refresh_actors_for_live_visas(asm: &Arc<Assembly>) -> (u32, u32, u32) {
     (refreshed, unresolved, failed)
 }
 
-/// When we get a new policy, some nodes may no longer be valid. This checks each
-/// connected node against the policy and partitions them into `(valid, invalid)`
+/// When we get a new policy, some nodes may no longer be valid. This checks each of
+/// `connected_node_addrs` against the policy and partitions them into `(valid, invalid)`
 /// addresses. It has no side effects -- disconnecting the invalid nodes is left to
 /// the caller.
 ///
+/// The caller supplies the address list because it also needs it to reconcile those
+/// nodes' attributes first; the evaluation below reads the actors as stored.
+///
 /// Note that the best way to revalidate a node is to prompt it to
 /// re-authenticate. (TODO).
-///
-/// ### Errors
-/// - The only error you get from this will be an error from `list_node_addrs`.
 async fn revalidate_nodes(
     asm: &Arc<Assembly>,
     psnap: &PolicySnapshot,
-) -> Result<(Vec<IpAddr>, Vec<IpAddr>), ServiceError> {
-    let connected_node_addrs = asm.actor_mgr.list_node_addrs().await?;
-
+    connected_node_addrs: Vec<IpAddr>,
+) -> (Vec<IpAddr>, Vec<IpAddr>) {
     // Check existing nodes against policy.
     let ectx = EvalContext::new(psnap.policy_arc());
 
@@ -404,7 +416,7 @@ async fn revalidate_nodes(
     let valid = valid.into_iter().map(|(naddr, _)| naddr).collect();
     let invalid = invalid.into_iter().map(|(naddr, _)| naddr).collect();
 
-    Ok((valid, invalid))
+    (valid, invalid)
 }
 
 /// Pure predicate helper for [revalidate_nodes].
@@ -636,7 +648,8 @@ mod tests {
             .unwrap();
 
         let psnap = asm.policy_mgr.get_current_snapshot();
-        let (valid, invalid) = revalidate_nodes(&asm, &psnap).await.unwrap();
+        let node_addrs = asm.actor_mgr.list_node_addrs().await.unwrap();
+        let (valid, invalid) = revalidate_nodes(&asm, &psnap, node_addrs).await;
 
         assert_eq!(sorted(valid), sorted(vec![a, b]));
         assert!(invalid.is_empty());
@@ -667,7 +680,8 @@ mod tests {
             .unwrap();
 
         let psnap = asm.policy_mgr.get_current_snapshot();
-        let (valid, invalid) = revalidate_nodes(&asm, &psnap).await.unwrap();
+        let node_addrs = asm.actor_mgr.list_node_addrs().await.unwrap();
+        let (valid, invalid) = revalidate_nodes(&asm, &psnap, node_addrs).await;
 
         assert!(valid.is_empty());
         assert_eq!(sorted(invalid), sorted(vec![a, b]));
@@ -710,7 +724,8 @@ mod tests {
         asm.actor_mgr.add_node(&bad_actor, false).await.unwrap();
 
         let psnap = asm.policy_mgr.get_current_snapshot();
-        let (valid, invalid) = revalidate_nodes(&asm, &psnap).await.unwrap();
+        let node_addrs = asm.actor_mgr.list_node_addrs().await.unwrap();
+        let (valid, invalid) = revalidate_nodes(&asm, &psnap, node_addrs).await;
 
         assert_eq!(valid, vec![good]);
         assert_eq!(invalid, vec![bad]);
@@ -721,7 +736,8 @@ mod tests {
     async fn test_revalidate_nodes_empty() {
         let asm = Arc::new(new_assembly_for_tests(None).await);
         let psnap = asm.policy_mgr.get_current_snapshot();
-        let (valid, invalid) = revalidate_nodes(&asm, &psnap).await.unwrap();
+        let node_addrs = asm.actor_mgr.list_node_addrs().await.unwrap();
+        let (valid, invalid) = revalidate_nodes(&asm, &psnap, node_addrs).await;
         assert!(valid.is_empty());
         assert!(invalid.is_empty());
     }
@@ -1164,6 +1180,30 @@ mod tests {
             stored_attr(&asm, "fd5a:5052:4000::a", TS_KEY).await,
             Some("engineering".to_string()),
             "policy update must reconcile attributes before the visa sweep reads actors"
+        );
+    }
+
+    /// A connected node is reconciled even though it holds no visa: `revalidate_nodes`
+    /// judges it on its stored attributes, so those have to be current first. The
+    /// live-visa refresh alone did not cover this (item 1 in ts-followups.md).
+    #[tokio::test]
+    async fn test_policy_update_refreshes_connected_nodes_without_visas() {
+        let (asm, _node_a) = build_sweep_asm(false).await;
+        asm.policy_mgr
+            .update_policy_from_container_bytes(make_node_join_policy(None))
+            .await
+            .unwrap();
+        register_ts(&asm, &[(TS_KEY, "engineering")]);
+        // No visa anywhere, so the node is in scope only via the node-address list.
+        seed_source_attr(&asm, "fd5a:5052:3000::1", TS_KEY, "sales").await;
+
+        let vinst = asm.policy_mgr.get_current_snapshot().vinst();
+        handle_policy_updated(&asm, vinst).await.unwrap();
+
+        assert_eq!(
+            stored_attr(&asm, "fd5a:5052:3000::1", TS_KEY).await,
+            Some("engineering".to_string()),
+            "policy update must reconcile connected nodes before revalidating them"
         );
     }
 

--- a/vs/src/event_mgr.rs
+++ b/vs/src/event_mgr.rs
@@ -282,6 +282,25 @@ async fn handle_policy_updated(asm: &Arc<Assembly>, vinst: u64) -> Result<(), Se
         }
     }
 
+    // Reconcile before sweeping, same two-phase order as the trusted-service
+    // handler: the sweep re-reads actors from the store, so their attributes
+    // have to be current first. Installing a policy rebuilds every
+    // trusted-service store with a fresh revision, so every actor is
+    // revision-stale at this point.
+    //
+    // TODO: this refetches every source for every actor holding a live visa, on
+    // every policy update, sequentially. Cheap today -- the only trusted
+    // service is the in-memory file store -- but with network-backed services
+    // and many actors/visas this is an N x M synchronous fan-out on the event
+    // handler's critical path. The root fix is to stop rebuilding unchanged
+    // stores (which is what churns the revisions), not just to parallelize this
+    // loop.
+    let (refreshed, unresolved, failed) = refresh_actors_for_live_visas(asm).await;
+    info!(
+        target: EVENT,
+        "policy updated vinst={vinst}: actors refreshed={refreshed} unresolved={unresolved} failed={failed}"
+    );
+
     // Re-check existing visas against the new policy. Runs last so route checks
     // and the nodes' own link state already reflect the updated topology.
     revalidate_visas(asm, &psnap, SweepReason::PolicyUpdate).await;
@@ -319,6 +338,10 @@ async fn handle_trusted_service_change(asm: &Arc<Assembly>, source_id: &str) {
 /// revision stays mismatched, so its next visa request refreshes it again.
 ///
 /// Returns `(refreshed, unresolved, failed)` counts for logging.
+///
+/// TODO: sequential, and unbounded in the number of live visas. Fine while the only
+/// trusted service is the in-memory file store; revisit once services are network calls
+/// and actor/visa counts are large.
 async fn refresh_actors_for_live_visas(asm: &Arc<Assembly>) -> (u32, u32, u32) {
     let mut zpr_addrs: HashSet<IpAddr> = HashSet::new();
     for (_, md) in asm.visa_mgr.list_visa_metadata().await {
@@ -947,9 +970,8 @@ mod tests {
         svc
     }
 
-    /// Give the stored actor at `zpr_addr` an attribute from [TS_SOURCE], so the source
-    /// counts as relevant to that actor (a source the actor holds nothing from and has no
-    /// revision record for is not refreshed).
+    /// Give the stored actor at `zpr_addr` an attribute from [TS_SOURCE], standing in for
+    /// data the actor picked up from that source under the previous snapshot.
     async fn seed_source_attr(asm: &Arc<Assembly>, zpr_addr: &str, ts_key: &str, value: &str) {
         let addr: IpAddr = zpr_addr.parse().unwrap();
         let mut actor = asm
@@ -1116,6 +1138,34 @@ mod tests {
             stored_attr(&asm, "fd5a:5052:4000::a", TS_KEY).await,
             None,
             "unreachable service must not leave stale attributes in place"
+        );
+    }
+
+    /// A policy update reconciles the actors behind live visas before it sweeps them.
+    /// Installing a policy rebuilds every trusted-service store, so every actor is
+    /// revision-stale; the sweep re-reads actors from the store, and would otherwise
+    /// judge them on the previous store's data.
+    #[tokio::test]
+    async fn test_policy_update_refreshes_stored_actors_before_sweep() {
+        let (asm, node_a) = build_sweep_asm(false).await;
+        // A policy the connected nodes still satisfy, so revalidation keeps them (and
+        // their docked adapters) rather than disconnecting everything out from under us.
+        asm.policy_mgr
+            .update_policy_from_container_bytes(make_node_join_policy(None))
+            .await
+            .unwrap();
+        create_sweep_visa(&asm, &node_a, 0).await;
+        register_ts(&asm, &[(TS_KEY, "engineering")]);
+        // What the actor holds from the previous store's data.
+        seed_source_attr(&asm, "fd5a:5052:4000::a", TS_KEY, "sales").await;
+
+        let vinst = asm.policy_mgr.get_current_snapshot().vinst();
+        handle_policy_updated(&asm, vinst).await.unwrap();
+
+        assert_eq!(
+            stored_attr(&asm, "fd5a:5052:4000::a", TS_KEY).await,
+            Some("engineering".to_string()),
+            "policy update must reconcile attributes before the visa sweep reads actors"
         );
     }
 

--- a/vs/src/event_mgr.rs
+++ b/vs/src/event_mgr.rs
@@ -352,7 +352,10 @@ async fn live_visa_actor_addrs(asm: &Arc<Assembly>) -> HashSet<IpAddr> {
 /// costs nothing.
 ///
 /// A failure is logged and skipped rather than aborting the pass: that actor's recorded
-/// revision stays mismatched, so its next visa request refreshes it again.
+/// revision stays mismatched, so its next visa request refreshes it again. This includes
+/// an unreachable trusted service (`AttributesIndeterminate`) -- the actor has already
+/// been stripped and persisted, and the deny that comes with it belongs to the request
+/// path, not to a background reconcile.
 ///
 /// Returns `(refreshed, unresolved, failed)` counts for logging.
 ///

--- a/vs/src/event_mgr.rs
+++ b/vs/src/event_mgr.rs
@@ -284,17 +284,15 @@ async fn handle_policy_updated(asm: &Arc<Assembly>, vinst: u64) -> Result<(), Se
 
     // Reconcile before sweeping, same two-phase order as the trusted-service
     // handler: the sweep re-reads actors from the store, so their attributes
-    // have to be current first. Installing a policy rebuilds every
-    // trusted-service store with a fresh revision, so every actor is
-    // revision-stale at this point.
+    // have to be current first. Only actors that are actually stale cost a
+    // fetch: `PolicyMgr::build_state` carries unchanged trusted-service stores
+    // (and their revisions) across a policy install, so this is a no-op unless
+    // the policy changed a trusted-service declaration.
     //
-    // TODO: this refetches every source for every actor holding a live visa, on
-    // every policy update, sequentially. Cheap today -- the only trusted
-    // service is the in-memory file store -- but with network-backed services
-    // and many actors/visas this is an N x M synchronous fan-out on the event
-    // handler's critical path. The root fix is to stop rebuilding unchanged
-    // stores (which is what churns the revisions), not just to parallelize this
-    // loop.
+    // TODO: when a declaration does change, this refetches every source for
+    // every actor holding a live visa, sequentially -- an N x M synchronous
+    // fan-out on the event handler's critical path once services are
+    // network-backed and actor/visa counts are large.
     let (refreshed, unresolved, failed) = refresh_actors_for_live_visas(asm).await;
     info!(
         target: EVENT,
@@ -1142,9 +1140,9 @@ mod tests {
     }
 
     /// A policy update reconciles the actors behind live visas before it sweeps them.
-    /// Installing a policy rebuilds every trusted-service store, so every actor is
-    /// revision-stale; the sweep re-reads actors from the store, and would otherwise
-    /// judge them on the previous store's data.
+    /// The actor here is revision-stale against the registered store (it has no recorded
+    /// revision for it); the sweep re-reads actors from the store, and would otherwise
+    /// judge them on the attributes seeded below.
     #[tokio::test]
     async fn test_policy_update_refreshes_stored_actors_before_sweep() {
         let (asm, node_a) = build_sweep_asm(false).await;

--- a/vs/src/policy_mgr.rs
+++ b/vs/src/policy_mgr.rs
@@ -30,7 +30,8 @@ use crate::error::{ResolverError, ServiceError, StoreError, TopologyError};
 use crate::loaded_policy::LoadedPolicy;
 use crate::logging::targets::MAIN;
 use crate::trusted_services::{
-    TrustedServiceInterface, TrustedServicesMgr, build_services_from_policy,
+    TrustedServiceDefinition, TrustedServiceInterface, TrustedServicesMgr, build_services,
+    trusted_service_definitions,
 };
 
 /// Abstracts DNS hostname resolution so it can be swapped out in tests.
@@ -54,6 +55,9 @@ struct PolicyState {
     /// Attribute stores for the trusted services this policy declares. Republished to
     /// `ts_mgr` on every successful swap so the stores can never outlive their policy.
     trusted_services: Vec<Arc<dyn TrustedServiceInterface>>,
+    /// The declarations `trusted_services` was built from. Carried alongside the stores so
+    /// the next policy can be compared against them and reuse the stores when unchanged.
+    ts_definitions: Vec<TrustedServiceDefinition>,
 }
 
 pub struct PolicyMgr {
@@ -174,7 +178,7 @@ impl PolicyMgr {
         // Resolve topology before persisting so a policy that cannot initialize is never
         // stored as the current policy. build_state borrows `loaded`, leaving it
         // available for the post-resolution persist below.
-        let state = Self::build_state(&resolver, &loaded, &file_ts_dir).await?;
+        let state = Self::build_state(&resolver, &loaded, &file_ts_dir, None).await?;
         repo.set_current_policy(&loaded, false).await?;
 
         debug!(target: MAIN, "policy manager initialized successfully");
@@ -210,7 +214,7 @@ impl PolicyMgr {
         let resolver = PolicyResolver::new(resolver);
         // A trusted service the policy declares but that cannot be configured (e.g. its
         // attribute file is missing) fails startup; the error names the service and file.
-        let state = Self::build_state(&resolver, &loaded, &file_ts_dir).await?;
+        let state = Self::build_state(&resolver, &loaded, &file_ts_dir, None).await?;
 
         debug!(target: MAIN, "policy manager initialized successfully");
         Ok(Self::from_state(state, repo, resolver, ts_mgr, file_ts_dir))
@@ -237,19 +241,32 @@ impl PolicyMgr {
     /// leaking partial policy state. Borrows `loaded` (cloning only the `Arc<Policy>`
     /// and the `Bytes`-backed container — both refcount bumps) so the caller can still
     /// persist it after resolution succeeds.
+    ///
+    /// `previous` is the currently live state, when there is one, and is used only to
+    /// carry unchanged trusted-service stores forward.
     async fn build_state(
         resolver: &PolicyResolver,
         loaded: &LoadedPolicy,
         file_ts_dir: &Path,
+        previous: Option<&PolicyState>,
     ) -> Result<PolicyState, ServiceError> {
         let policy = loaded.policy();
         let links_by_node = resolver.resolve_topology(&policy).await?;
-        let trusted_services = build_services_from_policy(&policy, file_ts_dir)?;
+        let ts_definitions = trusted_service_definitions(&policy)?;
+        let trusted_services = match previous {
+            // Identical declarations mean the live stores are still correct.
+            // Reusing them keeps their revisions, otherwise a policy install
+            // makes every actor revision-stale against every source. Cached
+            // attribute data now only moves on a TTL reload or an admin flush.
+            Some(prev) if prev.ts_definitions == ts_definitions => prev.trusted_services.clone(),
+            _ => build_services(&ts_definitions, file_ts_dir)?,
+        };
         Ok(PolicyState {
             policy,
             container: loaded.container().clone(),
             links_by_node,
             trusted_services,
+            ts_definitions,
         })
     }
 
@@ -303,8 +320,12 @@ impl PolicyMgr {
 
         // Resolve topology before swapping in the new state so a failed update leaves
         // the current policy, container, and topology untouched. The new policy,
-        // container, and links swap in together as one PolicyState.
-        let state = Self::build_state(&self.resolver, &loaded, &self.file_ts_dir).await?;
+        // container, and links swap in together as one PolicyState. The live state is
+        // passed in so trusted-service stores whose declaration did not change are
+        // carried over rather than rebuilt with a fresh revision.
+        let previous = self.state.load_full();
+        let state =
+            Self::build_state(&self.resolver, &loaded, &self.file_ts_dir, Some(&previous)).await?;
         self.repo.set_current_policy(&loaded, false).await?;
 
         self.publish(state);
@@ -533,6 +554,45 @@ mod tests {
             .get_attributes_from_source_for_actor("attrfile", "alice")
             .await;
         assert!(results[0].is_ok());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// Installing a policy whose trusted-service declarations are unchanged keeps the live
+    /// stores, so actors stay caught up. A changed declaration rebuilds the store and makes
+    /// them stale again.
+    #[tokio::test]
+    async fn test_policy_update_preserves_revisions_when_ts_config_unchanged() {
+        let dir = std::env::temp_dir().join("vs-pm-ts-rev");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("attrfile.json"),
+            r#"{"alice": {"color": ["red"]}}"#,
+        )
+        .unwrap();
+
+        let ts_mgr = Arc::new(TrustedServicesMgr::new());
+        let policy = make_trusted_service_policy("attrfile", "file", Some(3600), &[]);
+        let mgr = make_policy_mgr_with_ts(policy.clone(), ts_mgr.clone(), &dir).await;
+
+        // Catch "alice" up with the store's current revision.
+        let stale = ts_mgr.stale_sources_for_actor("alice");
+        assert_eq!(stale.len(), 1);
+        ts_mgr.record_revision("alice", &stale[0].0, stale[0].1);
+        assert!(ts_mgr.stale_sources_for_actor("alice").is_empty());
+
+        // Same trusted-service declarations: the store (and its revision) is carried over.
+        mgr.update_policy_from_container_bytes(policy)
+            .await
+            .unwrap();
+        assert!(ts_mgr.stale_sources_for_actor("alice").is_empty());
+
+        // A changed declaration rebuilds the store, so the actor is stale again.
+        let changed = make_trusted_service_policy("attrfile", "file", Some(7200), &[]);
+        mgr.update_policy_from_container_bytes(changed)
+            .await
+            .unwrap();
+        assert_eq!(ts_mgr.stale_sources_for_actor("alice").len(), 1);
 
         std::fs::remove_dir_all(&dir).unwrap();
     }

--- a/vs/src/trusted_services/factory.rs
+++ b/vs/src/trusted_services/factory.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use libeval::policy::Policy;
-use zpr::policy_types::ServiceType;
+use zpr::policy_types::{ServiceType, TrustedService};
 
 use crate::error::ServiceError;
 
@@ -16,12 +16,21 @@ use super::file_attribute_store::FileAttributeStore;
 /// API name used by file-backed trusted services.
 const TS_API_FILE: &str = "file";
 
-/// Build all trusted services declared by a policy.
-pub fn build_services_from_policy(
+/// One policy-declared trusted service, reduced to the inputs that determine its store
+/// instance. Comparing these across policies tells us whether the live stores are still
+/// correct, so an unchanged declaration can keep its store (and its revision).
+#[derive(Debug, Clone, PartialEq)]
+pub struct TrustedServiceDefinition {
+    id: String,
+    api: String,
+    record: TrustedService,
+}
+
+/// Validate and extract the trusted services a policy declares.
+pub fn trusted_service_definitions(
     policy: &Policy,
-    file_ts_dir: &Path,
-) -> Result<Vec<Arc<dyn TrustedServiceInterface>>, ServiceError> {
-    let mut stores: Vec<Arc<dyn TrustedServiceInterface>> = Vec::new();
+) -> Result<Vec<TrustedServiceDefinition>, ServiceError> {
+    let mut definitions = Vec::new();
 
     for service in policy.list_services() {
         let ServiceType::Trusted(api) = &service.kind else {
@@ -46,17 +55,35 @@ pub fn build_services_from_policy(
             )));
         };
 
-        stores.push(Arc::new(FileAttributeStore::new(
-            service.id.clone(),
-            AttributeMapper {
-                mappings: trusted_service.returns_attrs.clone(),
-            },
-            Duration::from_secs(trusted_service.expiration_seconds as u64),
-            &file_ts_dir.join(format!("{}.json", service.id)),
-        )?));
+        definitions.push(TrustedServiceDefinition {
+            id: service.id.clone(),
+            api: api.clone(),
+            record: trusted_service.clone(),
+        });
     }
 
-    Ok(stores)
+    Ok(definitions)
+}
+
+/// Build one store per declaration, loading each initial attribute snapshot.
+pub fn build_services(
+    definitions: &[TrustedServiceDefinition],
+    file_ts_dir: &Path,
+) -> Result<Vec<Arc<dyn TrustedServiceInterface>>, ServiceError> {
+    definitions
+        .iter()
+        .map(|definition| {
+            let store = FileAttributeStore::new(
+                definition.id.clone(),
+                AttributeMapper {
+                    mappings: definition.record.returns_attrs.clone(),
+                },
+                Duration::from_secs(definition.record.expiration_seconds as u64),
+                &file_ts_dir.join(format!("{}.json", definition.id)),
+            )?;
+            Ok(Arc::new(store) as Arc<dyn TrustedServiceInterface>)
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -77,6 +104,14 @@ mod tests {
         loaded.policy()
     }
 
+    /// Validate and build in one step, as `PolicyMgr` does for a brand-new policy.
+    fn build_from_policy(
+        policy: &Policy,
+        dir: &std::path::Path,
+    ) -> Result<Vec<Arc<dyn TrustedServiceInterface>>, ServiceError> {
+        build_services(&trusted_service_definitions(policy)?, dir)
+    }
+
     /// A valid file declaration constructs a working mapped attribute store.
     #[tokio::test]
     async fn test_build_services_from_policy_happy_path() {
@@ -94,7 +129,7 @@ mod tests {
             Some(3600),
             &["color -> user.color"],
         ));
-        let stores = build_services_from_policy(&policy, &dir).unwrap();
+        let stores = build_from_policy(&policy, &dir).unwrap();
 
         assert_eq!(stores.len(), 1);
         assert_eq!(stores[0].get_source_id(), "attrfile");
@@ -122,7 +157,7 @@ mod tests {
         for (id, api, seconds) in cases {
             let policy = policy_from_container(make_trusted_service_policy(id, api, seconds, &[]));
             assert!(
-                build_services_from_policy(&policy, &dir).is_err(),
+                build_from_policy(&policy, &dir).is_err(),
                 "expected failure for id={id} api={api} seconds={seconds:?}"
             );
         }

--- a/vs/src/trusted_services/file_attribute_store.rs
+++ b/vs/src/trusted_services/file_attribute_store.rs
@@ -71,9 +71,9 @@ impl FileAttributeStore {
         ttl: Duration,
         fp: &Path,
     ) -> Result<Self, ServiceError> {
-        if ttl < MIN_ATTRIBUTE_TTL {
+        if ttl <= MIN_ATTRIBUTE_TTL {
             return Err(ServiceError::Param(format!(
-                "trusted service '{id}' ttl {ttl:?} is below the minimum of {MIN_ATTRIBUTE_TTL:?}"
+                "trusted service '{id}' ttl {ttl:?} must exceed minimum of {MIN_ATTRIBUTE_TTL:?}"
             )));
         }
 
@@ -198,9 +198,19 @@ mod tests {
             &fp,
         );
         assert!(matches!(result, Err(ServiceError::Param(_))));
+
+        let result =
+            FileAttributeStore::new("test".to_string(), test_mapper(), MIN_ATTRIBUTE_TTL, &fp);
+        assert!(matches!(result, Err(ServiceError::Param(_))));
+
         assert!(
-            FileAttributeStore::new("test".to_string(), test_mapper(), MIN_ATTRIBUTE_TTL, &fp)
-                .is_ok()
+            FileAttributeStore::new(
+                "test".to_string(),
+                test_mapper(),
+                MIN_ATTRIBUTE_TTL + Duration::from_secs(1),
+                &fp
+            )
+            .is_ok()
         );
         fs::remove_file(&fp).unwrap();
     }

--- a/vs/src/trusted_services/manager.rs
+++ b/vs/src/trusted_services/manager.rs
@@ -3,7 +3,7 @@
 use arc_swap::ArcSwap;
 use dashmap::DashMap;
 use futures::future::join_all;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use libeval::attribute::Attribute;
@@ -28,12 +28,12 @@ impl TrustedServicesMgr {
         }
     }
 
-    /// Return relevant sources whose current revision differs from the actor's record.
-    pub fn stale_sources_for_actor(
-        &self,
-        actor_ident: &str,
-        attr_sources: &HashSet<String>,
-    ) -> Vec<(String, u64)> {
+    /// Return sources whose current revision differs from the actor's record. A source
+    /// with no record at all is stale: the actor has never been refreshed from it (or
+    /// the last attempt failed), so it must be consulted even when the actor holds no
+    /// attribute from it -- otherwise a source that vended nothing on the first lookup
+    /// would be skipped forever, including after a flush adds attributes for the actor.
+    pub fn stale_sources_for_actor(&self, actor_ident: &str) -> Vec<(String, u64)> {
         let services = self.services.load_full();
         let recorded = self.actor_revisions.get(actor_ident);
         services
@@ -43,9 +43,6 @@ impl TrustedServicesMgr {
                 let recorded_revision = recorded
                     .as_ref()
                     .and_then(|revisions| revisions.value().get(source_id).copied());
-                if recorded_revision.is_none() && !attr_sources.contains(source_id) {
-                    return None;
-                }
                 let current_revision = service.current_revision();
                 (recorded_revision != Some(current_revision))
                     .then(|| (source_id.to_string(), current_revision))
@@ -176,26 +173,18 @@ mod tests {
         );
         manager.update_services(vec![store.clone()]);
 
-        assert!(
-            manager
-                .stale_sources_for_actor("alice", &HashSet::new())
-                .is_empty()
-        );
-
-        let sources = HashSet::from(["test".to_string()]);
-        let stale = manager.stale_sources_for_actor("alice", &sources);
+        // A configured source the actor has no record for is stale, even though the
+        // actor holds no attribute from it -- otherwise a source that vended nothing on
+        // the first lookup would never be consulted again.
+        let stale = manager.stale_sources_for_actor("alice");
         assert_eq!(stale, vec![("test".to_string(), store.current_revision())]);
 
         manager.record_revision("alice", "test", stale[0].1);
-        assert!(
-            manager
-                .stale_sources_for_actor("alice", &sources)
-                .is_empty()
-        );
+        assert!(manager.stale_sources_for_actor("alice").is_empty());
 
         store.flush().await.unwrap();
         assert_eq!(
-            manager.stale_sources_for_actor("alice", &HashSet::new()),
+            manager.stale_sources_for_actor("alice"),
             vec![("test".to_string(), store.current_revision())]
         );
 

--- a/vs/src/trusted_services/mod.rs
+++ b/vs/src/trusted_services/mod.rs
@@ -15,7 +15,7 @@ mod manager;
 #[cfg(test)]
 mod test_support;
 
-pub use factory::build_services_from_policy;
+pub use factory::{TrustedServiceDefinition, build_services, trusted_service_definitions};
 pub use manager::TrustedServicesMgr;
 
 /// A revision no snapshot will ever carry (the counter starts at 1). Recording it for

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -280,20 +280,68 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
     }
 }
 
-/// Refresh the actor's attributes (see [refresh_expired_attributes]) and persist it to
-/// the store if anything changed. Used by the request path and by the attribute-change
-/// reconciliation in `event_mgr`.
+/// What a refresh pass found. Kept separate from the act of applying it so the caller
+/// can persist the actor before any of it is committed -- see [refresh_and_persist_actor].
+#[derive(Default)]
+struct RefreshOutcome {
+    /// The actor was modified and needs writing back.
+    changed: bool,
+    /// Source revisions to record once that write succeeds.
+    revisions: Vec<(String, u64)>,
+    /// Revision-stale sources that could not be reached. Their attributes have been
+    /// stripped, so the actor's claim set is incomplete and must not be evaluated.
+    indeterminate: Vec<String>,
+}
+
+impl RefreshOutcome {
+    /// Record the pending source revisions against `actor_ident`. Deliberately not done
+    /// during the refresh itself: a revision must never say "current" for an actor whose
+    /// refreshed attributes did not reach the database, or the next request would trust
+    /// the stale copy it loads.
+    fn commit_revisions(&self, ts_mgr: &TrustedServicesMgr, actor_ident: &str) {
+        for (source, revision) in &self.revisions {
+            ts_mgr.record_revision(actor_ident, source, *revision);
+        }
+    }
+}
+
+/// Refresh the actor's attributes (see [refresh_expired_attributes]), persist it to the
+/// store if anything changed, and only then record the source revisions. Used by the
+/// request path and by the attribute-change reconciliation in `event_mgr`.
 ///
 /// Returns TRUE if the actor was changed and written back.
+///
+/// ### Errors
+/// - `StoreError` if the write back fails. No revision is recorded, so the next request
+///   retries the whole refresh.
+/// - `AttributesIndeterminate` if a revision-stale source could not be reached. The
+///   actor has been stripped of that source's attributes and persisted in that state,
+///   but callers must treat the result as a denial rather than evaluate it: absence is
+///   not the same as "known to have no such attribute", and some policy conditions are
+///   satisfied by a missing key.
 pub(crate) async fn refresh_and_persist_actor(
     asm: &Assembly,
     actor: &mut Actor,
 ) -> Result<bool, ServiceError> {
-    if !refresh_expired_attributes(&asm.ts_mgr, actor).await {
-        return Ok(false);
+    let outcome = refresh_expired_attributes(&asm.ts_mgr, actor).await;
+    if outcome.changed {
+        asm.actor_mgr.update_actor(actor).await?;
     }
-    asm.actor_mgr.update_actor(actor).await?;
-    Ok(true)
+
+    // No CN means refresh_expired_attributes did nothing at all.
+    let Some(actor_ident) = actor.get_cn().map(|cn| cn.to_string()) else {
+        return Ok(outcome.changed);
+    };
+    outcome.commit_revisions(&asm.ts_mgr, &actor_ident);
+
+    if !outcome.indeterminate.is_empty() {
+        return Err(ServiceError::AttributesIndeterminate(format!(
+            "actor {} could not be refreshed from source(s): {}",
+            actor_ident,
+            outcome.indeterminate.join(", ")
+        )));
+    }
+    Ok(outcome.changed)
 }
 
 /// Refresh the actor's attributes from the trusted service manager where needed: any
@@ -305,17 +353,24 @@ pub(crate) async fn refresh_and_persist_actor(
 /// returned on the revision path (the old snapshot's data is invalid by definition).
 ///
 /// A failed TTL lookup changes nothing, so a service outage cannot strip attributes.
-/// A failed lookup for a revision-stale source fails closed: all of that source's
-/// attributes are removed before policy evaluation, and the sentinel REVISION_NEVER is
-/// recorded so the source stays stale — the next request retries and restores the
-/// attributes once the service is reachable again.
+/// The leftovers stay expired, and libeval already refuses to satisfy an allow condition
+/// from an expired attribute, so that path is fail-closed without any help from here.
 ///
-/// Returns TRUE if any attribute was added, replaced, or removed.
+/// A failed lookup for a revision-stale source is different: there is no expired copy to
+/// fall back on, so the source's attributes are stripped and the source is reported as
+/// *indeterminate*. The caller must deny rather than evaluate the remaining claims --
+/// absence is not "known to have no such attribute". REVISION_NEVER is queued so the
+/// source stays stale and the next request retries.
 ///
-async fn refresh_expired_attributes(ts_mgr: &TrustedServicesMgr, actor: &mut Actor) -> bool {
+/// Nothing is recorded with the trusted-service manager here; see [RefreshOutcome].
+async fn refresh_expired_attributes(
+    ts_mgr: &TrustedServicesMgr,
+    actor: &mut Actor,
+) -> RefreshOutcome {
+    let mut outcome = RefreshOutcome::default();
     let actor_ident = match actor.get_cn() {
         Some(cn) => cn.to_string(),
-        None => return false,
+        None => return outcome,
     };
 
     let mut sources = HashSet::new();
@@ -333,7 +388,6 @@ async fn refresh_expired_attributes(ts_mgr: &TrustedServicesMgr, actor: &mut Act
         .collect();
     sources.extend(stale.keys().cloned());
 
-    let mut changed = false;
     for source in &sources {
         let stale_rev = stale.get(source);
         for ts_result in ts_mgr
@@ -348,39 +402,42 @@ async fn refresh_expired_attributes(ts_mgr: &TrustedServicesMgr, actor: &mut Act
                         if let Err(e) = actor.add_attribute(attr) {
                             warn!(target: VREQ, "failed to add attribute for actor {}: {}", actor_ident, e);
                         } else {
-                            changed = true;
+                            outcome.changed = true;
                         }
                     }
                     if let Some(&rev) = stale_rev {
                         // Revision refresh: the old snapshot's data is invalid, so drop
-                        // everything the service did not just return. Record the
+                        // everything the service did not just return. Queue the
                         // revision even when zero attributes came back — that is what
                         // detects both removed and newly added attributes.
-                        changed |=
+                        outcome.changed |=
                             prune_from_source(actor, source, |a| !returned.contains(a.get_key()));
-                        ts_mgr.record_revision(&actor_ident, source, rev);
+                        outcome.revisions.push((source.clone(), rev));
                     } else {
                         // TTL refresh: whatever the service did not just set for this
                         // source is gone; drop the leftovers rather than carry a
                         // permanently expired copy.
-                        changed |= prune_from_source(actor, source, |a| a.is_expired());
+                        outcome.changed |= prune_from_source(actor, source, |a| a.is_expired());
                     }
                 }
                 Err(e) => {
                     warn!(target: VREQ, "ts service attr lookup failed for actor {}: {}", actor_ident, e);
                     if stale_rev.is_some() {
-                        // Stale-revision attributes must never satisfy an
-                        // allow policy just because their TTL has not run out. The
-                        // sentinel keeps the source stale so the next request retries
-                        // (the strip would otherwise leave nothing marking it relevant).
-                        changed |= prune_from_source(actor, source, |_| true);
-                        ts_mgr.record_revision(&actor_ident, source, REVISION_NEVER);
+                        // Stale-revision attributes must never satisfy an allow policy
+                        // just because their TTL has not run out, so strip them -- but
+                        // the strip alone is not fail-closed, hence the indeterminate
+                        // report. The sentinel keeps the source stale so the next
+                        // request retries (the strip would otherwise leave nothing
+                        // marking it relevant).
+                        outcome.changed |= prune_from_source(actor, source, |_| true);
+                        outcome.revisions.push((source.clone(), REVISION_NEVER));
+                        outcome.indeterminate.push(source.clone());
                     }
                 }
             }
         }
     }
-    changed
+    outcome
 }
 
 /// Removes every attribute on `actor` from `source` that matches `pred`.
@@ -1322,6 +1379,16 @@ mod tests {
         (mgr, fake)
     }
 
+    /// Refresh an actor and commit the resulting revisions, as the request path does once
+    /// the actor is persisted. Returns whether the actor changed.
+    async fn refresh_and_commit(mgr: &TrustedServicesMgr, actor: &mut Actor) -> bool {
+        let outcome = refresh_expired_attributes(mgr, actor).await;
+        if let Some(cn) = actor.get_cn().map(|cn| cn.to_string()) {
+            outcome.commit_revisions(mgr, &cn);
+        }
+        outcome.changed
+    }
+
     /// An actor with a CN and one attribute (expired or still fresh) from the given source.
     fn actor_with_attr(cn: &str, source: &str, expired: bool) -> Actor {
         let mut actor = Actor::new();
@@ -1356,7 +1423,7 @@ mod tests {
         let mut actor = actor_with_attr("someone.zpr.org", FAKE_SOURCE, true);
         assert!(actor.get_attribute(FAKE_ATTR_KEY).unwrap().is_expired());
 
-        assert!(refresh_expired_attributes(&mgr, &mut actor).await);
+        assert!(refresh_and_commit(&mgr, &mut actor).await);
         assert!(!actor.get_attribute(FAKE_ATTR_KEY).unwrap().is_expired());
         assert_eq!(*fake.calls.lock().unwrap(), vec!["someone.zpr.org"]);
     }
@@ -1376,7 +1443,7 @@ mod tests {
             .unwrap();
         mgr.record_revision("someone.zpr.org", FAKE_SOURCE, fake.current_revision());
 
-        assert!(!refresh_expired_attributes(&mgr, &mut actor).await);
+        assert!(!refresh_and_commit(&mgr, &mut actor).await);
         assert!(fake.calls.lock().unwrap().is_empty());
     }
 
@@ -1395,7 +1462,7 @@ mod tests {
             )
             .unwrap();
 
-        assert!(refresh_expired_attributes(&mgr, &mut actor).await);
+        assert!(refresh_and_commit(&mgr, &mut actor).await);
         assert_eq!(
             actor.get_attribute(FAKE_ATTR_KEY).unwrap().get_value(),
             ["engineering".to_string()]
@@ -1403,7 +1470,7 @@ mod tests {
         assert_eq!(*fake.calls.lock().unwrap(), vec!["someone.zpr.org"]);
 
         // The revision was recorded, so the next pass is a no-op.
-        assert!(!refresh_expired_attributes(&mgr, &mut actor).await);
+        assert!(!refresh_and_commit(&mgr, &mut actor).await);
         assert_eq!(fake.calls.lock().unwrap().len(), 1);
     }
 
@@ -1442,7 +1509,7 @@ mod tests {
         mgr.update_services(vec![Arc::new(EmptyTrustedService)]);
         let mut actor = actor_with_attr("someone.zpr.org", FAKE_SOURCE, true);
 
-        assert!(refresh_expired_attributes(&mgr, &mut actor).await);
+        assert!(refresh_and_commit(&mgr, &mut actor).await);
         assert!(actor.get_attribute(FAKE_ATTR_KEY).is_none());
         // The unexpired CN from another source is untouched.
         assert!(actor.get_attribute(key::CN).is_some());
@@ -1458,7 +1525,7 @@ mod tests {
         // recorded up front so it is not stale, isolating the unroutable-source path.
         let mut internal = actor_with_attr("someone.zpr.org", SOURCE_ZPR, true);
         mgr.record_revision("someone.zpr.org", FAKE_SOURCE, fake.current_revision());
-        assert!(!refresh_expired_attributes(&mgr, &mut internal).await);
+        assert!(!refresh_and_commit(&mgr, &mut internal).await);
         assert!(fake.calls.lock().unwrap().is_empty());
 
         // No CN means no ident to look up.
@@ -1471,7 +1538,7 @@ mod tests {
                     .value("engineering"),
             )
             .unwrap();
-        assert!(!refresh_expired_attributes(&mgr, &mut no_cn).await);
+        assert!(!refresh_and_commit(&mgr, &mut no_cn).await);
         assert!(fake.calls.lock().unwrap().is_empty());
     }
 
@@ -1484,16 +1551,16 @@ mod tests {
         let mut actor = actor_with_attr("someone.zpr.org", FAKE_SOURCE, false);
 
         // No record yet: stale, so the source is queried despite nothing being expired.
-        assert!(refresh_expired_attributes(&mgr, &mut actor).await);
+        assert!(refresh_and_commit(&mgr, &mut actor).await);
         assert_eq!(fake.calls.lock().unwrap().len(), 1);
 
         // Revision recorded: a second pass is a no-op.
-        assert!(!refresh_expired_attributes(&mgr, &mut actor).await);
+        assert!(!refresh_and_commit(&mgr, &mut actor).await);
         assert_eq!(fake.calls.lock().unwrap().len(), 1);
 
         // A flush bumps the revision: stale again.
         fake.flush().await.unwrap();
-        assert!(refresh_expired_attributes(&mgr, &mut actor).await);
+        assert!(refresh_and_commit(&mgr, &mut actor).await);
         assert_eq!(fake.calls.lock().unwrap().len(), 2);
     }
 
@@ -1507,12 +1574,12 @@ mod tests {
         let mut actor = actor_with_attr("someone.zpr.org", FAKE_SOURCE, false);
         assert!(!actor.get_attribute(FAKE_ATTR_KEY).unwrap().is_expired());
 
-        assert!(refresh_expired_attributes(&mgr, &mut actor).await);
+        assert!(refresh_and_commit(&mgr, &mut actor).await);
         assert!(actor.get_attribute(FAKE_ATTR_KEY).is_none());
         assert!(actor.get_attribute(key::CN).is_some());
 
         // The zero-attribute response was recorded: no further refresh churn.
-        assert!(!refresh_expired_attributes(&mgr, &mut actor).await);
+        assert!(!refresh_and_commit(&mgr, &mut actor).await);
     }
 
     /// A trusted service whose lookups always fail, standing in for an outage.
@@ -1556,13 +1623,13 @@ mod tests {
         mgr.update_services(vec![failing.clone()]);
         let mut actor = actor_with_attr("someone.zpr.org", FAKE_SOURCE, false);
 
-        assert!(refresh_expired_attributes(&mgr, &mut actor).await);
+        assert!(refresh_and_commit(&mgr, &mut actor).await);
         assert!(actor.get_attribute(FAKE_ATTR_KEY).is_none());
         assert!(actor.get_attribute(key::CN).is_some());
 
         // No revision was recorded on failure, so the next request retries the source
         // (nothing left to strip, so no change is reported).
-        assert!(!refresh_expired_attributes(&mgr, &mut actor).await);
+        assert!(!refresh_and_commit(&mgr, &mut actor).await);
         assert_eq!(failing.calls.load(std::sync::atomic::Ordering::SeqCst), 2);
     }
 
@@ -1580,8 +1647,49 @@ mod tests {
         // Mark the actor current for this source so only the TTL path triggers.
         mgr.record_revision("someone.zpr.org", FAKE_SOURCE, 1);
 
-        assert!(!refresh_expired_attributes(&mgr, &mut actor).await);
+        let outcome = refresh_expired_attributes(&mgr, &mut actor).await;
+        assert!(!outcome.changed);
         assert!(actor.get_attribute(FAKE_ATTR_KEY).unwrap().is_expired());
         assert_eq!(failing.calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+        // The retained attributes are expired, and libeval will not satisfy an allow
+        // from an expired attribute, so there is nothing indeterminate to report.
+        assert!(outcome.indeterminate.is_empty());
+    }
+
+    /// TS-1: a revision-stale source that cannot be reached is reported as indeterminate,
+    /// so the request path denies instead of evaluating the stripped claim set. Stripping
+    /// alone is not fail-closed -- a policy condition can be satisfied by a missing key.
+    #[tokio::test]
+    async fn test_refresh_revision_stale_failure_reports_indeterminate() {
+        let mgr = TrustedServicesMgr::new();
+        mgr.update_services(vec![Arc::new(FailingTrustedService {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        })]);
+        let mut actor = actor_with_attr("someone.zpr.org", FAKE_SOURCE, false);
+
+        let outcome = refresh_expired_attributes(&mgr, &mut actor).await;
+        assert_eq!(outcome.indeterminate, vec![FAKE_SOURCE.to_string()]);
+        assert!(actor.get_attribute(FAKE_ATTR_KEY).is_none());
+    }
+
+    /// TS-2: a refresh does not record its revisions itself. The caller commits them only
+    /// after the actor is persisted, so a failed write cannot leave a source marked
+    /// current while the database still holds the stale attributes.
+    #[tokio::test]
+    async fn test_refresh_defers_revision_recording() {
+        let (mgr, fake) = ts_mgr_with_fake();
+        let mut actor = actor_with_attr("someone.zpr.org", FAKE_SOURCE, false);
+
+        let outcome = refresh_expired_attributes(&mgr, &mut actor).await;
+        assert_eq!(
+            outcome.revisions,
+            vec![(FAKE_SOURCE.to_string(), fake.current_revision())]
+        );
+        // Uncommitted: the source is still stale, so a dropped write costs a re-fetch
+        // rather than a silently skipped one.
+        assert!(!mgr.stale_sources_for_actor("someone.zpr.org").is_empty());
+
+        outcome.commit_revisions(&mgr, "someone.zpr.org");
+        assert!(mgr.stale_sources_for_actor("someone.zpr.org").is_empty());
     }
 }

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -318,10 +318,8 @@ async fn refresh_expired_attributes(ts_mgr: &TrustedServicesMgr, actor: &mut Act
         None => return false,
     };
 
-    let mut attr_sources = HashSet::new();
     let mut sources = HashSet::new();
     for attr in actor.attrs_iter() {
-        attr_sources.insert(attr.get_source().to_string());
         if attr.is_expired() {
             sources.insert(attr.get_source().to_string());
         }
@@ -330,7 +328,7 @@ async fn refresh_expired_attributes(ts_mgr: &TrustedServicesMgr, actor: &mut Act
     // Sources whose snapshot revision the actor has not caught up with, and the
     // revision to record once a refresh from them succeeds.
     let stale: HashMap<String, u64> = ts_mgr
-        .stale_sources_for_actor(&actor_ident, &attr_sources)
+        .stale_sources_for_actor(&actor_ident)
         .into_iter()
         .collect();
     sources.extend(stale.keys().cloned());
@@ -807,6 +805,7 @@ mod tests {
     use crate::test_helpers::{
         make_actor_with_services_defexp, make_container_bytes, make_node_actor_defexp,
     };
+    use crate::trusted_services::TrustedServiceInterface;
     use libeval::attribute::{AttributeSource, ROLE_ADAPTER, SOURCE_ZPR};
     use libeval::eval_result::Direction;
     use libeval::policy::Policy;
@@ -1362,7 +1361,8 @@ mod tests {
         assert_eq!(*fake.calls.lock().unwrap(), vec!["someone.zpr.org"]);
     }
 
-    /// The hot path: no expired attributes means no trusted-service round trip at all.
+    /// The hot path: nothing expired and every source's revision already recorded means
+    /// no trusted-service round trip at all.
     #[tokio::test]
     async fn test_refresh_expired_attributes_skips_when_nothing_expired() {
         let (mgr, fake) = ts_mgr_with_fake();
@@ -1374,9 +1374,37 @@ mod tests {
                     .value("someone.zpr.org"),
             )
             .unwrap();
+        mgr.record_revision("someone.zpr.org", FAKE_SOURCE, fake.current_revision());
 
         assert!(!refresh_expired_attributes(&mgr, &mut actor).await);
         assert!(fake.calls.lock().unwrap().is_empty());
+    }
+
+    /// An actor holding no attribute from a configured source (the service vended
+    /// nothing at connect time) is still refreshed from it, so attributes that show up
+    /// later are picked up instead of being ignored forever.
+    #[tokio::test]
+    async fn test_refresh_queries_source_with_no_prior_attributes() {
+        let (mgr, fake) = ts_mgr_with_fake();
+        let mut actor = Actor::new();
+        actor
+            .add_attribute(
+                Attribute::builder(key::CN)
+                    .expires_in(Duration::from_secs(600))
+                    .value("someone.zpr.org"),
+            )
+            .unwrap();
+
+        assert!(refresh_expired_attributes(&mgr, &mut actor).await);
+        assert_eq!(
+            actor.get_attribute(FAKE_ATTR_KEY).unwrap().get_value(),
+            ["engineering".to_string()]
+        );
+        assert_eq!(*fake.calls.lock().unwrap(), vec!["someone.zpr.org"]);
+
+        // The revision was recorded, so the next pass is a no-op.
+        assert!(!refresh_expired_attributes(&mgr, &mut actor).await);
+        assert_eq!(fake.calls.lock().unwrap().len(), 1);
     }
 
     /// A trusted service that knows nothing about any actor: every lookup succeeds and
@@ -1426,8 +1454,10 @@ mod tests {
     async fn test_refresh_expired_attributes_handles_unrefreshable() {
         let (mgr, fake) = ts_mgr_with_fake();
 
-        // SOURCE_ZPR is internal -- no trusted service vends it.
+        // SOURCE_ZPR is internal -- no trusted service vends it. The fake's revision is
+        // recorded up front so it is not stale, isolating the unroutable-source path.
         let mut internal = actor_with_attr("someone.zpr.org", SOURCE_ZPR, true);
+        mgr.record_revision("someone.zpr.org", FAKE_SOURCE, fake.current_revision());
         assert!(!refresh_expired_attributes(&mgr, &mut internal).await);
         assert!(fake.calls.lock().unwrap().is_empty());
 
@@ -1462,7 +1492,6 @@ mod tests {
         assert_eq!(fake.calls.lock().unwrap().len(), 1);
 
         // A flush bumps the revision: stale again.
-        use crate::trusted_services::TrustedServiceInterface;
         fake.flush().await.unwrap();
         assert!(refresh_expired_attributes(&mgr, &mut actor).await);
         assert_eq!(fake.calls.lock().unwrap().len(), 2);


### PR DESCRIPTION
 - Tracks actors even when a trusted service previously returned no attributes:
      - Every configured source without a recorded actor revision is now considered stale.
      - If a source later begins supplying attributes for that actor, they will be discovered after a flush or refresh.

  - Makes refresh persistence and revision tracking transactional:
      - Refreshed attributes are persisted before the actor’s source revision is marked current.
      - If persistence fails, the revision remains stale so the next request retries instead of trusting old database data.

  - Handles unavailable trusted attributes explicitly:
      - A failed revision-driven refresh marks the actor’s claims as indeterminate.
      - Visa-request processing denies rather than evaluating a partial claim set.
      - New connection authorization also fails if any configured trusted service cannot be queried.
      - Adds a dedicated AttributesIndeterminate error.

  - Improves policy-update handling:
      - Actors behind live visas are refreshed before visa revalidation.
      - Connected nodes are refreshed even when they have no live visas, before their join policy is re-evaluated.
      - Invalid nodes are excluded from subsequent topology reconciliation.

  - Avoids unnecessary trusted-service revision changes:
      - Policy updates reuse existing provider instances when their declarations are unchanged.
      - Their cached data and revisions therefore remain stable.
      - Providers are rebuilt only when trusted-service configuration actually changes.

  - Hardens evaluator handling of unsupported or malformed conditions:
      - Valueless EQ, NE, and EXCLUDES, plus set-valued EQ/NE, are treated as indeterminate.
      - They cannot satisfy an allow, but remain fail-closed for deny evaluation.
      - Valueless EXCLUDES no longer risks a panic.

  - Tightens file-provider TTL validation:
      - A TTL equal to the 60-second refresh floor is now rejected, because elapsed construction time would make it immediately
        stale.

      - The TTL must be strictly greater than the floor.

  - Adds extensive tests around empty results, provider outages, persistence races, policy-update refreshes, unchanged provider
    reuse, malformed conditions, and TTL boundaries.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>