### PR TITLE
(248ts-stack) mk/248 10 docs

### DIFF
--- a/integration-test/pregen/zpt-test-connect.zpt
+++ b/integration-test/pregen/zpt-test-connect.zpt
@@ -3,7 +3,6 @@ load zpt-test.bin2
 # test connect success
 connect --ac device.zpr.adapter.cn:bas.zpr.org
 
-# test connect fails
+# test connect succeeds as an adapter without a matching join policy
 connect --ac device.zpr.adapter.cn:bazz.zpr.org
-
 

--- a/integration-test/zpt-test-connect.sh
+++ b/integration-test/zpt-test-connect.sh
@@ -10,9 +10,19 @@ PROG_CMD=("$ZPT_BIN" -i "$INPUT" --json)
 obj1="$("${PROG_CMD[@]}" | sed -n '1p')"
 obj2="$("${PROG_CMD[@]}" | sed -n '2p')"
 
-echo "TESTING CONNECT SHUOULD SUCCEED"
-jq -e '.kind=="APPROVE_CONNECTION" and .actor.provider==true' >/dev/null <<<"$obj1"
+echo "TESTING CONNECT SHOULD SUCCEED AS A SERVICE PROVIDER"
+jq -e \
+    '.kind == "APPROVE_CONNECTION"
+     and .actor.attrs["zpr.services"].value == ["bas"]' \
+    >/dev/null <<<"$obj1"
+echo "TEST OK"
+
+echo "TESTING CONNECT WITHOUT A MATCHING JOIN POLICY SHOULD SUCCEED AS AN ADAPTER"
+jq -e \
+    '.kind == "APPROVE_CONNECTION"
+     and .actor.attrs["zpr.role"].value == ["adapter"]
+     and (.actor.attrs | has("zpr.services") | not)' \
+    >/dev/null <<<"$obj2"
 echo "TEST OK"
 
 echo "OK"
-

--- a/vs/src/event_mgr.rs
+++ b/vs/src/event_mgr.rs
@@ -45,9 +45,10 @@ pub enum VsEvent {
     TrustedServiceChange(String),
 }
 
-/// Why a visa sweep is running. The two reasons need different handling because an
-/// attribute change does not move the policy generation, so the `checked_vinst`
-/// gates that make the policy sweep idempotent would make an attribute sweep a
+/// Why a visa sweep is running. The two reasons need different handling because
+/// an attribute change does not move the policy generation, so the
+/// `checked_vinst` gates that make the policy sweep idempotent (ie, do not do
+/// anything if the `vinst` has not changed) would make an attribute sweep a
 /// complete no-op.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum SweepReason {
@@ -187,9 +188,6 @@ async fn set_services_all_nodes(
 
 async fn handle_policy_updated(asm: &Arc<Assembly>, vinst: u64) -> Result<(), ServiceError> {
     /*
-    https://github.com/org-zpr/zpr-visaservice/issues/219
-
-
     When we get here we have already updated policy.
 
     - TODO: request re-auth all nodes.
@@ -201,10 +199,6 @@ async fn handle_policy_updated(asm: &Arc<Assembly>, vinst: u64) -> Result<(), Se
        - We can do a basic check to see that all the services we have do exist in policy.
           - But that won't detect if a service has altered its provider.
           - TO BE SAFE: expire auth from all services - force re-auth of all existing services (after removing non-existing ones)
-
-    - all connected adapters.  Are they still allowed?
-       - Well we could expire all the auth, but that seems drastic.
-       - Instead we will have already killed visas. Probably ok to let them be connected but unable to do anything.
      */
 
     // Grab one consistent policy snapshot and use it for the entire synchronize-to-policy
@@ -229,13 +223,12 @@ async fn handle_policy_updated(asm: &Arc<Assembly>, vinst: u64) -> Result<(), Se
     //
     // Only actors that are actually stale cost a fetch: `PolicyMgr::build_state`
     // carries unchanged trusted-service stores (and their revisions) across a policy
-    // install, so this is a no-op unless the policy changed a trusted-service
-    // declaration.
+    // install, so this is a no-op unless the policy changed a trusted-service.
     //
-    // TODO: when a declaration does change, this refetches every source for every
+    // TODO: When a declaration does change, this refetches every source for every
     // actor in the set, sequentially -- an N x M synchronous fan-out on the event
-    // handler's critical path once services are network-backed and actor/visa counts
-    // are large.
+    // handler's critical path. Once services are network-backed and actor/visa counts
+    // are large this is going to be an issue.
     let connected_node_addrs = asm.actor_mgr.list_node_addrs().await?;
     let mut refresh_set = live_visa_actor_addrs(asm).await;
     refresh_set.extend(connected_node_addrs.iter().copied());
@@ -312,16 +305,17 @@ async fn handle_policy_updated(asm: &Arc<Assembly>, vinst: u64) -> Result<(), Se
     Ok(())
 }
 
-/// A trusted service's attribute data changed (an admin refreshed it). The new data may
-/// invalidate visas that were issued under the old data, so reconcile in two phases:
-/// refresh and persist the actors behind live visas, then re-check those visas.
+/// A trusted service's attribute data changed (eg, an admin refreshed it). The
+/// new data may invalidate visas that were issued under the old data, so
+/// reconcile in two phases: refresh and persist the actors behind live visas,
+/// then re-check those visas.
 ///
-/// Phase order matters: the sweep re-reads actors from the store, so their attributes
-/// have to be reconciled and written back first.
+/// Phase order matters: the sweep re-reads actors from the store, so their
+/// attributes have to be reconciled and written back first.
 ///
-/// Note this only reconciles actors that hold a live visa -- the visa sweep is the only
-/// consumer here. Everyone else is handled lazily on their next visa request by the
-/// revision check in `refresh_expired_attributes`.
+/// Note this only reconciles actors that hold a live visa. Everyone else is
+/// handled lazily on their next visa request by the revision check in
+/// `refresh_expired_attributes`.
 async fn handle_trusted_service_change(asm: &Arc<Assembly>, source_id: &str) {
     // One snapshot for the whole pass, same as the policy handler.
     let psnap = asm.policy_mgr.get_current_snapshot();
@@ -348,18 +342,15 @@ async fn live_visa_actor_addrs(asm: &Arc<Assembly>) -> HashSet<IpAddr> {
 }
 
 /// Refresh (and persist) the attributes of each actor in `zpr_addrs`. Only sources that
-/// are TTL-expired or revision-stale are actually fetched, so an actor already current
-/// costs nothing.
+/// are TTL-expired or revision-stale are actually fetched.
 ///
 /// A failure is logged and skipped rather than aborting the pass: that actor's recorded
 /// revision stays mismatched, so its next visa request refreshes it again. This includes
-/// an unreachable trusted service (`AttributesIndeterminate`) -- the actor has already
-/// been stripped and persisted, and the deny that comes with it belongs to the request
-/// path, not to a background reconcile.
+/// an unreachable trusted service (`AttributesIndeterminate`).
 ///
 /// Returns `(refreshed, unresolved, failed)` counts for logging.
 ///
-/// TODO: sequential, and unbounded in the size of the set. Fine while the only trusted
+/// TODO: Sequential, and unbounded in the size of the set. Fine while the only trusted
 /// service is the in-memory file store; revisit once services are network calls and
 /// actor/visa counts are large.
 async fn refresh_actors(asm: &Arc<Assembly>, zpr_addrs: HashSet<IpAddr>) -> (u32, u32, u32) {
@@ -450,7 +441,7 @@ async fn node_still_valid(asm: &Arc<Assembly>, ectx: &EvalContext, naddr: &IpAdd
 ///
 /// Visas whose actors can't be resolved are skipped (not revoked). A verdict is
 /// only applied while `target_vinst` is still the live policy generation —
-/// otherwise a newer policy sweep is coming and will decide.
+/// otherwise a newer policy sweep is coming and it will decide when it runs.
 ///
 /// [SweepReason::PolicyUpdate] skips any visa already checked at/after
 /// `target_vinst`, bumps `checked_vinst` on allow (canceling any older queued

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -349,8 +349,11 @@ pub(crate) async fn refresh_and_persist_actor(
 /// whose snapshot revision differs from the actor's recorded one (revision
 /// path, e.g. after an admin flush).
 ///
-/// A successful lookup is authoritative for that source: anything the service
-/// did not vend is dropped.
+/// A successful lookup is authoritative for that source, but the two paths drop
+/// different things: the revision path drops every key the service did not just
+/// return (the old snapshot is invalid), while the TTL path only drops leftovers
+/// that are *still* expired after the refresh -- an unexpired attribute the
+/// service omitted survives on its own TTL until the next revision bump.
 ///
 /// A failed TTL lookup changes nothing, so a service outage cannot strip
 /// attributes. The leftovers stay expired, and libeval already refuses to
@@ -417,9 +420,10 @@ async fn refresh_expired_attributes(
                             prune_from_source(actor, source, |a| !returned.contains(a.get_key()));
                         outcome.revisions.push((source.clone(), rev));
                     } else {
-                        // TTL refresh: whatever the service did not just set for this
-                        // source is gone; drop the leftovers rather than carry a
-                        // permanently expired copy.
+                        // TTL refresh: drop the leftovers that are still expired
+                        // rather than carry a permanently expired copy. Unexpired
+                        // attributes the service omitted are left alone -- only a
+                        // revision bump invalidates the whole snapshot.
                         outcome.changed |= prune_from_source(actor, source, |a| a.is_expired());
                     }
                 }

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -246,7 +246,6 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
     };
 
     // If necessary, refresh any expired attributes
-    // TODO: Can we parallize this?
     if let Err(e) = refresh_and_persist_actor(&asm, &mut source_actor).await {
         error!(target: VREQ, "failed to update source actor after refreshing attributes: {}", e);
         return Ok(VisaDecision::Deny(DenyCode::NoReason));
@@ -294,9 +293,10 @@ struct RefreshOutcome {
 }
 
 impl RefreshOutcome {
-    /// Record the pending source revisions against `actor_ident`. Deliberately not done
-    /// during the refresh itself: a revision must never say "current" for an actor whose
-    /// refreshed attributes did not reach the database, or the next request would trust
+    /// Direct [TrustedServicesMgr] to Record the pending source revisions
+    /// against `actor_ident`. Deliberately not done during the refresh itself:
+    /// a revision must never say "current" for an actor whose refreshed
+    /// attributes did not reach the database, or the next request would trust
     /// the stale copy it loads.
     fn commit_revisions(&self, ts_mgr: &TrustedServicesMgr, actor_ident: &str) {
         for (source, revision) in &self.revisions {
@@ -344,25 +344,28 @@ pub(crate) async fn refresh_and_persist_actor(
     Ok(outcome.changed)
 }
 
-/// Refresh the actor's attributes from the trusted service manager where needed: any
-/// source with an expired attribute (TTL path), plus any source whose snapshot revision
-/// differs from the actor's recorded one (revision path, e.g. after an admin flush).
+/// Refresh the actor's attributes from the trusted service manager where
+/// needed: any source with an expired attribute (TTL path), plus any source
+/// whose snapshot revision differs from the actor's recorded one (revision
+/// path, e.g. after an admin flush).
 ///
-/// A successful lookup is authoritative for that source: anything the service did not
-/// vend is dropped — still-expired leftovers on the TTL path, *everything* not just
-/// returned on the revision path (the old snapshot's data is invalid by definition).
+/// A successful lookup is authoritative for that source: anything the service
+/// did not vend is dropped.
 ///
-/// A failed TTL lookup changes nothing, so a service outage cannot strip attributes.
-/// The leftovers stay expired, and libeval already refuses to satisfy an allow condition
-/// from an expired attribute, so that path is fail-closed without any help from here.
+/// A failed TTL lookup changes nothing, so a service outage cannot strip
+/// attributes. The leftovers stay expired, and libeval already refuses to
+/// satisfy an allow condition from an expired attribute, so that path is
+/// fail-closed in this failure case.
 ///
-/// A failed lookup for a revision-stale source is different: there is no expired copy to
-/// fall back on, so the source's attributes are stripped and the source is reported as
-/// *indeterminate*. The caller must deny rather than evaluate the remaining claims --
-/// absence is not "known to have no such attribute". REVISION_NEVER is queued so the
-/// source stays stale and the next request retries.
+/// A failed lookup for a revision-stale source (ie, source reports a new
+/// revision) is different: there is no expired copy to fall back on, so the
+/// source's attributes are stripped and the source is reported as
+/// *indeterminate*. The caller must deny rather than evaluate the remaining
+/// claims -- absence is not "known to have no such attribute". REVISION_NEVER
+/// is queued so the source stays stale and the next request retries.
 ///
-/// Nothing is recorded with the trusted-service manager here; see [RefreshOutcome].
+/// Nothing is recorded with the trusted-service manager here; see
+/// [RefreshOutcome].
 async fn refresh_expired_attributes(
     ts_mgr: &TrustedServicesMgr,
     actor: &mut Actor,


### PR DESCRIPTION
 - Updates the ZPT connection integration test for the refactored Actor serialization:
      - Checks the zpr.services attribute instead of the removed cached provider field.
      - Checks the zpr.role attribute instead of cached role state.

  - Corrects the test’s expected behavior:
      - An actor matching a service-providing join policy is approved as a provider.
      - An actor without a matching join policy is still approved as a normal adapter.

  - Adds validation for the test’s second connection result, which previously was captured but not asserted.

  - Tidies and clarifies comments around:
      - Policy- versus attribute-triggered visa sweeps.
      - Trusted-service reconciliation.
      - Revision-driven and TTL-driven attribute refresh.
      - Indeterminate provider failures.
      - Policy-update processing and scaling considerations.

  - Removes stale TODOs and obsolete issue commentary.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>