### PR TITLE
mods to /admin/network to return both substrate addrs

### DIFF
--- a/admin-api-types/src/admin_api_types.rs
+++ b/admin-api-types/src/admin_api_types.rs
@@ -637,6 +637,7 @@ pub struct NodeConnection {
     pub node_a_addr: IpAddr,
     pub node_b_addr: IpAddr,
     pub ctype: ConnectionType,
+    pub node_a_substrate: String, // stringified NetAddr
     pub node_b_substrate: String, // stringified NetAddr
     pub link_id: String,
     pub link_attrs: Vec<ApiAttribute>,
@@ -664,6 +665,7 @@ pub struct NodeConnectionBuilder {
     node_a_addr: IpAddr,
     node_b_addr: IpAddr,
     ctype: ConnectionType,
+    node_a_substrate: String,
     node_b_substrate: String,
     link_id: String,
     link_attrs: Vec<ApiAttribute>,
@@ -677,6 +679,7 @@ impl NodeConnectionBuilder {
             node_a_addr: a,
             node_b_addr: b,
             ctype: ConnectionType::DOWN,
+            node_a_substrate: String::new(),
             node_b_substrate: String::new(),
             link_id: String::new(),
             link_attrs: Vec::new(),
@@ -686,6 +689,12 @@ impl NodeConnectionBuilder {
 
     pub fn link_id(mut self, link_id: String) -> Self {
         self.link_id = link_id;
+        self
+    }
+
+    /// Sets node A's stringified substrate address, ie the local end of the link.
+    pub fn node_a_substrate(mut self, node_a_substrate: String) -> Self {
+        self.node_a_substrate = node_a_substrate;
         self
     }
 
@@ -719,6 +728,7 @@ impl NodeConnectionBuilder {
             node_a_addr: self.node_a_addr,
             node_b_addr: self.node_b_addr,
             ctype: self.ctype,
+            node_a_substrate: self.node_a_substrate,
             node_b_substrate: self.node_b_substrate,
             link_id: self.link_id,
             link_attrs: self.link_attrs,

--- a/admin-http-api.txt
+++ b/admin-http-api.txt
@@ -1,4 +1,4 @@
-Admin HTTP API  - Current as of 7/31/2026
+Admin HTTP API  - Current as of 8/10/2026
 -----------------------------------------
 
 This document describes the admin HTTPS API implemented by the server and
@@ -100,11 +100,15 @@ Common Types
 |                 |                                                          |
 | NodeConnection  | { "node_a_addr": string, "node_b_addr": string,          |
 |                 |   "ctype": "UP" | "DOWN" | "INVALID",                     |
+|                 |   "node_a_substrate": string,                            |
 |                 |   "node_b_substrate": string, "link_id": string,         |
 |                 |   "link_attrs": ApiAttribute[], "link_cost": number }    |
-|                 |   addrs are ZPR (IPv6) addresses; node_b_substrate is a  |
-|                 |   stringified NetAddr ("host:port"). link_id, link_attrs |
-|                 |   and link_cost come from the policy's link description. |
+|                 |   addrs are ZPR (IPv6) addresses; node_a_substrate and    |
+|                 |   node_b_substrate are stringified NetAddrs              |
+|                 |   ("host:port"), the substrate address of each end of the |
+|                 |   link. IPv6 hosts are bracketed, for example            |
+|                 |   "[fd5a:5052::1]:5000". link_id, link_attrs and         |
+|                 |   link_cost come from the policy's link description.     |
 |                 |                                                          |
 | Revokes         | { "id": string, "revoked": number[] }                    |
 |                 |                                                          |
@@ -342,7 +346,7 @@ GET /admin/network
     reached first.
     ctype is UP if a connected node reports the link, DOWN if the policy
     declares it but no node reports it, and INVALID otherwise.
-    INVALID entries carry no node_b_substrate, link_id, or link_cost.
+    INVALID entries carry no substrate addresses, link_id, or link_cost.
 
 GET /admin/stats
 ----------------

--- a/libeval/src/policy.rs
+++ b/libeval/src/policy.rs
@@ -83,6 +83,10 @@ pub struct Peer {
 
     /// Substrate (physical/underlay) address used to reach the remote peer.
     pub remote_substrate: NetAddr,
+
+    /// Substrate (physical/underlay) address of *this* node (the node this peer list is
+    /// keyed under) on this link.
+    pub local_substrate: NetAddr,
 }
 
 #[derive(Debug, Clone)]
@@ -315,6 +319,7 @@ fn load_peer_table(peerings: &[Peering]) -> Option<HashMap<IpAddr, Vec<Peer>>> {
             link_id: p.link_id.clone(),
             remote_zpr_addr: p.node_b,
             remote_substrate: p.substrate_b.clone(),
+            local_substrate: p.substrate_a.clone(),
         };
         table
             .entry(p.node_a)
@@ -326,6 +331,7 @@ fn load_peer_table(peerings: &[Peering]) -> Option<HashMap<IpAddr, Vec<Peer>>> {
             link_id: p.link_id.clone(),
             remote_zpr_addr: p.node_a,
             remote_substrate: p.substrate_a.clone(),
+            local_substrate: p.substrate_b.clone(),
         };
         table
             .entry(p.node_b)
@@ -715,6 +721,10 @@ mod test {
             p.remote_substrate,
             NetAddr::new_for_ip_or_host("10.0.0.2", 5001)
         );
+        assert_eq!(
+            p.local_substrate,
+            NetAddr::new_for_ip_or_host("10.0.0.1", 5000)
+        );
     }
 
     #[test]
@@ -740,6 +750,10 @@ mod test {
         assert_eq!(
             p.remote_substrate,
             NetAddr::new_for_ip_or_host("10.0.0.1", 5000)
+        );
+        assert_eq!(
+            p.local_substrate,
+            NetAddr::new_for_ip_or_host("10.0.0.2", 5001)
         );
     }
 

--- a/vs/src/admin_service.rs
+++ b/vs/src/admin_service.rs
@@ -22,7 +22,7 @@ use hyper::body::Incoming;
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use tower_service::Service;
 
-use zpr::policy_types::{PolicyBundle, Scope};
+use zpr::policy_types::{NetAddr, NetworkHost, PolicyBundle, Scope};
 use zpr::vsapi_types::{DockPepType, KeyFormat, KeySet, Visa};
 
 use libeval::attribute::{Attribute, ROLE_NODE, key};
@@ -970,6 +970,15 @@ async fn add_revoke(EPath(id): EPath<String>) -> impl IntoResponse {
     (StatusCode::NOT_IMPLEMENTED, Json(()).into_response())
 }
 
+/// Stringify a substrate address as a parseable `host:port`. IPv6 hosts get bracketed
+/// (`[fd5a:5052::1]:5000`); IPv4 and hostname forms are left plain.
+fn stringify_netaddr(addr: &NetAddr) -> String {
+    match &addr.host {
+        NetworkHost::Ip(ip) => SocketAddr::new(*ip, addr.port).to_string(),
+        NetworkHost::Hostname(h) => format!("{}:{}", h, addr.port),
+    }
+}
+
 async fn get_network(
     Extension(perm): Extension<Permission>,
     State(state): State<SharedState>,
@@ -1008,10 +1017,8 @@ async fn get_network(
                 let mut bldr =
                     NodeConnection::builder(node_addr.clone(), peer.remote_zpr_addr.clone())
                         .link_id(peer.link_id.clone())
-                        .node_b_substrate(format!(
-                            "{}:{}",
-                            peer.remote_substrate.host, peer.remote_substrate.port
-                        ));
+                        .node_a_substrate(stringify_netaddr(&peer.local_substrate))
+                        .node_b_substrate(stringify_netaddr(&peer.remote_substrate));
 
                 if let Ok(link_desc) = psnap
                     .policy()
@@ -2050,7 +2057,10 @@ mod tests {
             assert!(matches!(nc.ctype, ConnectionType::DOWN));
             assert_eq!(nc.link_id, "link-ab");
             assert_eq!(nc.link_cost, 7);
-            assert_eq!(nc.node_b_substrate, format!("{}:0", nc.node_b_addr));
+            // The fixture uses each node's ZPR (IPv6) address as its substrate, so both
+            // ends must come back bracketed and parseable.
+            assert_eq!(nc.node_a_substrate, format!("[{}]:0", nc.node_a_addr));
+            assert_eq!(nc.node_b_substrate, format!("[{}]:0", nc.node_b_addr));
             assert_eq!(nc.link_attrs.len(), 1);
         }
     }

--- a/vs/src/policy_mgr.rs
+++ b/vs/src/policy_mgr.rs
@@ -730,14 +730,19 @@ mod tests {
         assert!(snap2.links_for_node(&a).is_empty());
     }
 
+    /// Build a `Peer` whose substrate is a plain IP address (no hostname), so
+    /// `peers_to_links` resolves it without any DNS lookup.
     fn ip_peer(link_id: &str, ip: IpAddr, port: u16) -> Peer {
+        let substrate = NetAddr {
+            host: NetworkHost::Ip(ip),
+            port,
+        };
         Peer {
             link_id: link_id.to_string(),
             remote_zpr_addr: "fd5a:5052::1".parse().unwrap(),
-            remote_substrate: NetAddr {
-                host: NetworkHost::Ip(ip),
-                port,
-            },
+            // ponytail: local end is irrelevant to peers_to_links, so reuse the remote one.
+            local_substrate: substrate.clone(),
+            remote_substrate: substrate,
         }
     }
 
@@ -793,6 +798,10 @@ mod tests {
             remote_zpr_addr: "fd5a:5052::2".parse().unwrap(),
             remote_substrate: NetAddr {
                 host: NetworkHost::Hostname("some.unresolvable.host".to_string()),
+                port: 4000,
+            },
+            local_substrate: NetAddr {
+                host: NetworkHost::Ip(ip),
                 port: 4000,
             },
         };
@@ -917,6 +926,10 @@ mod tests {
             remote_zpr_addr: "fd5a:5052::10".parse().unwrap(),
             remote_substrate: NetAddr {
                 host: NetworkHost::Hostname("peer.example.com".to_string()),
+                port: 5000,
+            },
+            local_substrate: NetAddr {
+                host: NetworkHost::Ip("192.0.2.1".parse().unwrap()),
                 port: 5000,
             },
         };


### PR DESCRIPTION
Update the `admin/network` API endpoint to return BOTH substrate addresses (previously was only returning one).