### PR TITLE
Update zpr-dashboard to show both subtrate addresses

### DIFF
--- a/zpr-dashboard/AGENTS.md
+++ b/zpr-dashboard/AGENTS.md
@@ -1,0 +1,52 @@
+# zpr-dashboard
+
+This is a TUI (terminal UI) written in go that uses the HTTPS API offered by the visa
+service (see ../vs) to display information about the running Visa
+Service.
+
+## Architecture Overview
+
+The app is a Bubble Tea (charm.land v2) program using the Elm/MVU pattern:
+a single `Model` with `Init`/`Update`/`View`, all mutation driven by messages.
+
+Layers (each package only depends on the ones below it):
+
+- `cmd/zpr-dashboard` — entrypoint: load config, run the tea program.
+- `internal/app` — the only stateful layer. `Model.Update` handles input and
+  data messages; per-tab UI/data state lives in the `state` struct
+  (`state.go`). Each data domain (visas, actors, services, policies,
+  revocations, denies) follows the same pattern: a `tick*Msg` on a 5s
+  interval schedules a `fetch*Cmd` that runs the HTTP call off the UI thread
+  and returns a `*SnapshotMsg{data, err}`.
+- `internal/pages` — pure layout functions (one per tab), no state. They take
+  the viewport plus data slices and compose components with lipgloss joins.
+- `internal/components` — pure render functions returning strings, one file
+  per pane. Shared helpers (panels, tables, line clamping) are in `panel.go`.
+- `internal/dataplane` — HTTP client for the vs admin API (TLS with pinned
+  CA, API key header). `dataplane.Shared()` is the process-wide singleton
+  (`sync.OnceValues`). One file per resource; JSON decoding and sorting
+  happen here, so panes receive display-ready slices.
+- `internal/config`, `internal/styles`, `internal/charts`, `internal/timefmt`
+  — leaf utilities (TOML config, lipgloss styles/colors, ASCII charts, time
+  formatting).
+
+Conventions:
+
+- Rendering is stateless: pages/components never fetch or mutate; all data
+  flows down from `app` as function arguments.
+- Sort in the dataplane fetcher (or in `Update` when selection indexes into
+  the slice), never at render time.
+- On fetch error, keep the last good data and record the error in
+  `state.*.fetchErr`; panes render an error note instead of blanking.
+- Panels clamp to their width/height budget (`clampLines`,
+  `tableRowsThatFit*`) — an overflowing panel breaks the whole layout.
+- Not-yet-real features are gated behind `config.ShowStatic()` and labelled
+  "(Placeholder)".
+- Tests are table-driven `_test.go` files beside the code; components are
+  tested by asserting on rendered strings.
+
+## Go Workflow
+
+- Run `make test` after Go changes.
+- Check formatting with `test -z "$(gofmt -l .)"`; `gofmt -l .` alone only
+  lists unformatted files and does not return a failing exit status.

--- a/zpr-dashboard/CLAUDE.md
+++ b/zpr-dashboard/CLAUDE.md
@@ -1,0 +1,2 @@
+@AGENTS.md
+

--- a/zpr-dashboard/Makefile
+++ b/zpr-dashboard/Makefile
@@ -23,6 +23,10 @@ $(BIN): $(shell find . -name '*.go') go.mod go.sum
 run:
 	$(GO) run $(CMD_PATH)
 
+.PHONY: test
+test:
+	$(GO) test ./...
+
 .PHONY: status
 status:
 	$(GO) run $(SIM_PATH) status

--- a/zpr-dashboard/internal/components/topology.go
+++ b/zpr-dashboard/internal/components/topology.go
@@ -2,7 +2,6 @@ package components
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"charm.land/lipgloss/v2"
@@ -34,9 +33,9 @@ func NetworkTopology(
 	size := width - 5
 
 	nodeSize := int(float32(size) * 0.30)
-	peerSize := int(float32(size) * 0.30)
-	substrateSize := int(float32(size) * 0.27)
-	statusSize := size - nodeSize - peerSize - substrateSize
+	actorSize := int(float32(size) * 0.18)
+	substrateSize := int(float32(size) * 0.37)
+	statusSize := size - nodeSize - actorSize - substrateSize
 
 	// The stale-data warning below takes a line away from the table.
 	extra := 0
@@ -44,29 +43,20 @@ func NetworkTopology(
 		extra = 1
 	}
 
-	// Rows with a known CN are two lines high, so fit them by rendered height.
-	cells := make([][2]string, len(network))
+	// Every link renders both its endpoints, so every row is two lines high.
 	heights := make([]int, len(network))
-	for i, link := range network {
-		cells[i] = [2]string{
-			topologyNodeCell(link.NodeA, actors, nodeSize),
-			topologyNodeCell(link.NodeB, actors, peerSize),
-		}
-		heights[i] = max(cellLines(cells[i][0]), cellLines(cells[i][1]))
+	for i := range heights {
+		heights[i] = topologyRowLines
 	}
 
 	fits, hidden := tableRowsThatFitHeights(heights, budget, extra)
 
-	t := panelTable(size, []string{"Node", "Link To", "Substrate", "Status"},
-		[]int{nodeSize, peerSize, substrateSize, statusSize})
+	t := panelTable(size, []string{"Node", "Actor", "Substrate", "Status"},
+		[]int{nodeSize, actorSize, substrateSize, statusSize})
 
-	for i, link := range network[:fits] {
-		t.Row(
-			cells[i][0],
-			cells[i][1],
-			ansi.Truncate(orDash(link.Substrate), substrateSize, "..."),
-			linkStatus(link.CType),
-		)
+	for _, link := range network[:fits] {
+		node, actor, substrate := topologyLinkCells(link, actors, nodeSize, actorSize, substrateSize)
+		t.Row(node, actor, substrate, linkStatus(link.CType))
 	}
 
 	body := "\n" + t.Render()
@@ -83,21 +73,34 @@ func NetworkTopology(
 	return detailPanel(width, height, title, subtitle, body)
 }
 
-// topologyNodeCell shows a node address and, when known, its actor CN below it.
-func topologyNodeCell(addr string, actors []dataplane.ActorDescriptor, width int) string {
-	cell := ansi.Truncate(orDash(addr), width, "...")
-	actor, ok := actorByAddr(actors, addr)
-	if !ok || actor.CName == "" {
-		return cell
-	}
+// topologyRowLines is the height of one link's row: a line per endpoint.
+const topologyRowLines = 2
 
-	cn := ansi.Truncate(actor.CName, width, "...")
-	return cell + "\n" + styles.SubtitleStyle.Render(cn)
+// peerMarker indents endpoint B's line beneath endpoint A's.
+const peerMarker = " ↳ "
+
+// topologyLinkCells renders one link as two-line cells: endpoint A on the
+// first line, endpoint B indented beneath it under a ↳ marker.
+func topologyLinkCells(link dataplane.NodeConnection, actors []dataplane.ActorDescriptor,
+	nodeSize, actorSize, substrateSize int) (node, actor, substrate string) {
+	node = ansi.Truncate(orDash(link.NodeA), nodeSize, "...") + "\n" +
+		peerMarker + ansi.Truncate(orDash(link.NodeB), max(1, nodeSize-lipgloss.Width(peerMarker)), "...")
+
+	actor = styles.SubtitleStyle.Render(topologyActorName(link.NodeA, actors, actorSize)) + "\n" +
+		styles.SubtitleStyle.Render(topologyActorName(link.NodeB, actors, actorSize))
+
+	substrate = ansi.Truncate(orDash(link.SubstrateA), substrateSize, "...") + "\n" +
+		ansi.Truncate(orDash(link.SubstrateB), substrateSize, "...")
+
+	return node, actor, substrate
 }
 
-// cellLines counts the terminal lines a rendered table cell occupies.
-func cellLines(cell string) int {
-	return strings.Count(cell, "\n") + 1
+// topologyActorName is the CN of the actor at addr, or a dash when no actor
+// claims that address.
+func topologyActorName(addr string, actors []dataplane.ActorDescriptor, width int) string {
+	// A miss yields the zero descriptor, whose empty CN becomes the dash.
+	actor, _ := actorByAddr(actors, addr)
+	return ansi.Truncate(orDash(actor.CName), width, "...")
 }
 
 // linkStatus renders a ctype with the colour the CLI uses: up green,

--- a/zpr-dashboard/internal/components/topology_test.go
+++ b/zpr-dashboard/internal/components/topology_test.go
@@ -17,8 +17,10 @@ var testActors = []dataplane.ActorDescriptor{
 }
 
 var testNetwork = []dataplane.NodeConnection{
-	{NodeA: "fd5a:5052:90de::1", NodeB: "fd5a:5052:90de::2", CType: "DOWN", Substrate: "129.22.31.2:5000"},
-	{NodeA: "fd5a:5052:90de::1", NodeB: "fd5a:5052:90de::9", CType: "UP", Substrate: "10.8.22.1:5000"},
+	{NodeA: "fd5a:5052:90de::1", NodeB: "fd5a:5052:90de::2", CType: "DOWN",
+		SubstrateA: "129.22.31.2:5000", SubstrateB: "[fd5a:5052:90de::2]:5000"},
+	{NodeA: "fd5a:5052:90de::1", NodeB: "fd5a:5052:90de::9", CType: "UP",
+		SubstrateA: "129.22.31.2:5000", SubstrateB: "10.8.22.1:5000"},
 	{NodeA: "fd5a:5052:90de::8", NodeB: "fd5a:5052:90de::9", CType: "INVALID"},
 }
 
@@ -28,29 +30,67 @@ func renderTopology(t *testing.T, network []dataplane.NodeConnection, fetchErr e
 	return NetworkTopology(160, 30, network, testActors, true, 0, fetchErr)
 }
 
-// TestTopologyShowsCNUnderKnownAddress checks a matching actor's CN appears
-// beneath its address and unknown endpoints stay one line.
-func TestTopologyShowsCNUnderKnownAddress(t *testing.T) {
+// TestTopologyLinkCellsPairEndpoints checks each endpoint of a link gets its own
+// line, that endpoint B is marked with the ↳ indent, that both CNs are looked
+// up, and that an endpoint no actor claims shows a dash.
+func TestTopologyLinkCellsPairEndpoints(t *testing.T) {
 	out := renderTopology(t, testNetwork, nil)
-
 	for _, cn := range []string{"node-nyc", "node-lon"} {
 		if !strings.Contains(out, cn) {
 			t.Errorf("expected CN %q in output", cn)
 		}
 	}
 
-	cell := topologyNodeCell("fd5a:5052:90de::9", testActors, 30)
-	if strings.Contains(cell, "\n") {
-		t.Errorf("unknown endpoint should render one line, got %q", cell)
+	// Endpoints ::1 and ::2 are both known actors.
+	node, actor, substrate := topologyLinkCells(testNetwork[0], testActors, 22, 13, 27)
+	for name, cell := range map[string]string{"node": node, "actor": actor, "substrate": substrate} {
+		if lines := strings.Count(cell, "\n") + 1; lines != topologyRowLines {
+			t.Errorf("%s cell has %d lines, want %d: %q", name, lines, topologyRowLines, cell)
+		}
+	}
+
+	nodeLines := strings.Split(node, "\n")
+	if strings.Contains(nodeLines[0], "↳") {
+		t.Errorf("endpoint A should not carry the peer marker, got %q", nodeLines[0])
+	}
+	if !strings.Contains(nodeLines[1], "↳") {
+		t.Errorf("endpoint B should carry the peer marker, got %q", nodeLines[1])
+	}
+
+	if !strings.Contains(actor, "node-nyc") || !strings.Contains(actor, "node-lon") {
+		t.Errorf("expected both endpoints' CNs in the actor cell, got %q", actor)
+	}
+
+	// ::9 belongs to no actor, so its half of the cell is a dash.
+	_, actor, _ = topologyLinkCells(testNetwork[1], testActors, 22, 13, 27)
+	if !strings.Contains(strings.Split(actor, "\n")[1], "—") {
+		t.Errorf("expected a dash for the unknown endpoint's actor, got %q", actor)
 	}
 }
 
-// TestTopologyEmptySubstrateIsDash checks an INVALID link's blank substrate
-// degrades to a dash rather than an empty cell.
+// TestTopologyEmptySubstrateIsDash checks an INVALID link, which carries neither
+// substrate, degrades to a dash on both of its lines.
 func TestTopologyEmptySubstrateIsDash(t *testing.T) {
 	out := renderTopology(t, testNetwork[2:], nil)
 	if !strings.Contains(out, "—") {
 		t.Error("expected a dash for the missing substrate")
+	}
+
+	_, _, substrate := topologyLinkCells(testNetwork[2], testActors, 22, 13, 27)
+	if got := strings.Count(substrate, "—"); got != 2 {
+		t.Errorf("got %d dashes in the substrate cell, want 2: %q", got, substrate)
+	}
+}
+
+// TestTopologySubstrateFitsBracketedIPv6 checks a bracketed IPv6 substrate
+// survives whole at the half-pane width of a 160-column terminal, the narrowest
+// real case the Substrate column has to hold.
+func TestTopologySubstrateFitsBracketedIPv6(t *testing.T) {
+	const substrate = "[fd5a:5052:90de::2]:5000"
+
+	out := NetworkTopology(80, 30, testNetwork, testActors, true, 0, nil)
+	if !strings.Contains(out, substrate) {
+		t.Errorf("substrate %q was truncated at an 80-column pane:\n%s", substrate, out)
 	}
 }
 

--- a/zpr-dashboard/internal/dataplane/network.go
+++ b/zpr-dashboard/internal/dataplane/network.go
@@ -12,10 +12,11 @@ import (
 
 // A single link between two nodes, as reported by GET /admin/network.
 type NodeConnection struct {
-	NodeA     string `json:"node_a_addr"`
-	NodeB     string `json:"node_b_addr"`
-	CType     string `json:"ctype"`            // UP | DOWN | INVALID
-	Substrate string `json:"node_b_substrate"` // "host:port"; empty for INVALID links
+	NodeA      string `json:"node_a_addr"`
+	NodeB      string `json:"node_b_addr"`
+	CType      string `json:"ctype"`            // UP | DOWN | INVALID
+	SubstrateA string `json:"node_a_substrate"` // "host:port"; empty for INVALID links
+	SubstrateB string `json:"node_b_substrate"`
 }
 
 type NetworkDetails struct {

--- a/zpr-dashboard/internal/dataplane/network_test.go
+++ b/zpr-dashboard/internal/dataplane/network_test.go
@@ -23,9 +23,9 @@ func testClient(t *testing.T, body string) *Client {
 // including the empty substrate an INVALID link carries.
 func TestGetNetworkDecodes(t *testing.T) {
 	c := testClient(t, `{"network":[
-		{"node_a_addr":"fd5a:5052:90de::1","node_b_addr":"fd5a:5052:90de::2","ctype":"DOWN","node_b_substrate":"129.22.31.2:5000","link_id":"l1","link_cost":3},
-		{"node_a_addr":"fd5a:5052:90de::1","node_b_addr":"fd5a:5052:90de::3","ctype":"UP","node_b_substrate":"10.8.22.1:5000","link_id":"l2","link_cost":1},
-		{"node_a_addr":"fd5a:5052:90de::4","node_b_addr":"fd5a:5052:90de::5","ctype":"INVALID","node_b_substrate":"","link_id":"","link_cost":0}
+		{"node_a_addr":"fd5a:5052:90de::1","node_b_addr":"fd5a:5052:90de::2","ctype":"DOWN","node_a_substrate":"[fd5a:5052:90de::1]:5000","node_b_substrate":"129.22.31.2:5000","link_id":"l1","link_cost":3},
+		{"node_a_addr":"fd5a:5052:90de::1","node_b_addr":"fd5a:5052:90de::3","ctype":"UP","node_a_substrate":"[fd5a:5052:90de::1]:5000","node_b_substrate":"10.8.22.1:5000","link_id":"l2","link_cost":1},
+		{"node_a_addr":"fd5a:5052:90de::4","node_b_addr":"fd5a:5052:90de::5","ctype":"INVALID","node_a_substrate":"","node_b_substrate":"","link_id":"","link_cost":0}
 	]}`)
 
 	got, err := c.GetNetwork(context.Background())
@@ -34,9 +34,11 @@ func TestGetNetworkDecodes(t *testing.T) {
 	}
 
 	want := []NodeConnection{
-		{"fd5a:5052:90de::1", "fd5a:5052:90de::2", "DOWN", "129.22.31.2:5000"},
-		{"fd5a:5052:90de::1", "fd5a:5052:90de::3", "UP", "10.8.22.1:5000"},
-		{"fd5a:5052:90de::4", "fd5a:5052:90de::5", "INVALID", ""},
+		{NodeA: "fd5a:5052:90de::1", NodeB: "fd5a:5052:90de::2", CType: "DOWN",
+			SubstrateA: "[fd5a:5052:90de::1]:5000", SubstrateB: "129.22.31.2:5000"},
+		{NodeA: "fd5a:5052:90de::1", NodeB: "fd5a:5052:90de::3", CType: "UP",
+			SubstrateA: "[fd5a:5052:90de::1]:5000", SubstrateB: "10.8.22.1:5000"},
+		{NodeA: "fd5a:5052:90de::4", NodeB: "fd5a:5052:90de::5", CType: "INVALID"},
 	}
 
 	if len(got) != len(want) {


### PR DESCRIPTION
Building on previous PR that updates the network API endpoint to return both substrate addresses, this updates the dashboard view so that both are visible.

- Also added a `test` target to makefile.
- Also added bare bones `AGENTS`/`CLAUDE` files for LLM support.
