### PR TITLE
Mk/254 json - Make vs-admin emit regular JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,6 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 name = "admin-api-types"
 version = "0.15.0"
 dependencies = [
- "reqwest",
  "serde",
  "serde_json",
  "serde_with",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,8 +12,6 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 name = "admin-api-types"
 version = "0.15.0"
 dependencies = [
- "chrono",
- "colored",
  "reqwest",
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ ZPR visa service implementation (under active development).
   a visa should be issued.
 - `zpt` - ZPR Policy Tester is a command line tool for testing how `libeval`
   evaluates policy.
-- `vs-admin` - Bare bones administration client for the visa service. Exercises
+- `vs-admin` - CLI based administration client for the visa service. Exercises
   the HTTPS admin api of `vs`.
+- `zpr-dashboard` - CLI based "GUI" dashboard for monitoring visa
+  service activity.
 - `admin-api-types` - Library crate for data structures used by `vs` and
   `vs-admin`.
 - `integration-test` - Shell-based integration tests. Includes evaluation tests

--- a/admin-api-types/Cargo.toml
+++ b/admin-api-types/Cargo.toml
@@ -5,7 +5,8 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-reqwest.workspace = true
 serde.workspace = true
-serde_json.workspace = true
 serde_with.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/admin-api-types/Cargo.toml
+++ b/admin-api-types/Cargo.toml
@@ -5,8 +5,6 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-chrono.workspace = true
-colored.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/admin-api-types/src/admin_api_types.rs
+++ b/admin-api-types/src/admin_api_types.rs
@@ -165,35 +165,6 @@ impl PartialOrd for ServiceDescriptor {
 }
 
 #[serde_as]
-#[derive(Debug, Serialize, Deserialize, Eq)]
-pub struct HostRecordBrief {
-    #[serde_as(as = "TimestampSeconds<i64>")]
-    pub ctime: SystemTime,
-    pub cn: String,
-    pub zpr_addr: String,
-    pub ident: String,
-    pub node: bool,
-}
-
-impl PartialEq for HostRecordBrief {
-    fn eq(&self, other: &Self) -> bool {
-        self.cn == other.cn
-    }
-}
-
-impl Ord for HostRecordBrief {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.cn.cmp(&other.cn)
-    }
-}
-
-impl PartialOrd for HostRecordBrief {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-#[serde_as]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct NodeRecordBrief {
     // Number of visas pending install on the node

--- a/admin-api-types/src/admin_api_types.rs
+++ b/admin-api-types/src/admin_api_types.rs
@@ -1,4 +1,3 @@
-use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use serde_with::base64::Base64;
 use serde_with::{TimestampSeconds, serde_as};
@@ -203,13 +202,6 @@ pub struct NodeRecordBrief {
 pub struct AuthRevokeDescriptor {
     pub ty: String,
     pub cn: String,
-}
-
-pub fn reason_for(sc: StatusCode) -> String {
-    match sc.canonical_reason() {
-        Some(reason) => reason.to_string(),
-        None => "unknown".to_string(),
-    }
 }
 
 /// Simple struct with a "cn" field.

--- a/admin-api-types/src/admin_api_types.rs
+++ b/admin-api-types/src/admin_api_types.rs
@@ -4,7 +4,6 @@ use serde_with::base64::Base64;
 use serde_with::{TimestampSeconds, serde_as};
 
 use std::collections::HashMap;
-use std::fmt;
 use std::net::IpAddr;
 use std::time::SystemTime;
 
@@ -25,15 +24,6 @@ pub struct NamedListEntry {
 pub enum VisaMatchDirection {
     Forward,
     Reverse,
-}
-
-impl fmt::Display for VisaMatchDirection {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            VisaMatchDirection::Forward => write!(f, "forward"),
-            VisaMatchDirection::Reverse => write!(f, "reverse"),
-        }
-    }
 }
 
 #[serde_as]
@@ -236,37 +226,6 @@ pub struct NodeRecordBrief {
     pub pending_revocation: u32,
     // Port of the VSS the node is connected to
     pub vss_port: Option<u16>,
-}
-
-#[serde_as]
-#[derive(Debug, Deserialize, Eq)]
-#[allow(dead_code)]
-pub struct ServiceRecord {
-    #[serde_as(as = "TimestampSeconds<i64>")]
-    pub ctime: SystemTime,
-    pub cn: String,
-    pub zpr_addr: String,
-    pub ident: String,
-    pub node: bool,
-    pub services: Vec<String>,
-}
-
-impl PartialEq for ServiceRecord {
-    fn eq(&self, other: &Self) -> bool {
-        self.cn == other.cn
-    }
-}
-
-impl Ord for ServiceRecord {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.cn.cmp(&other.cn)
-    }
-}
-
-impl PartialOrd for ServiceRecord {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
 }
 
 #[derive(Serialize, Deserialize)]

--- a/admin-api-types/src/admin_api_types.rs
+++ b/admin-api-types/src/admin_api_types.rs
@@ -1,5 +1,3 @@
-use chrono::{DateTime, SecondsFormat, Utc};
-use colored::{Color, Colorize};
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use serde_with::base64::Base64;
@@ -16,22 +14,10 @@ pub struct ListEntry {
     pub id: u64,
 }
 
-impl fmt::Display for ListEntry {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "{} {}", "id".dimmed(), self.id,)
-    }
-}
-
 /// NamedListEntry is a list with a string ID.
 #[derive(Serialize, Deserialize)]
 pub struct NamedListEntry {
     pub id: String,
-}
-
-impl fmt::Display for NamedListEntry {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "{} {}", "id".dimmed(), self.id)
-    }
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -90,63 +76,6 @@ impl PartialOrd for VisaDescriptor {
     }
 }
 
-impl fmt::Display for VisaDescriptor {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let now = Utc::now();
-        let dt_exp: DateTime<Utc> = self.expires.into();
-        let dt_created: DateTime<Utc> = self.created.into();
-
-        let remain = dt_exp.signed_duration_since(now);
-
-        write!(f, "{} {}  ", "id:".dimmed(), self.id)?;
-        write!(
-            f,
-            "{} {}  ",
-            "requesting node:".dimmed(),
-            self.requesting_node.yellow()
-        )?;
-        write!(f, "{} {}  ", "policy id:".dimmed(), self.policy_id)?;
-        write!(
-            f,
-            "{} [{}] {}  ",
-            "zpl:".dimmed(),
-            self.direction,
-            self.zpl.yellow()
-        )?;
-        write!(
-            f,
-            "{}:{} {} {}:{}  ",
-            self.source_addr.as_ref().unwrap_or(&"-".into()).yellow(),
-            self.source_port.unwrap_or(0),
-            "->".bold().green(),
-            self.dest_addr.as_ref().unwrap_or(&"-".into()).yellow(),
-            self.dest_port.unwrap_or(0),
-        )?;
-        write!(f, "{} {}  ", "proto:".dimmed(), self.proto)?;
-        write!(
-            f,
-            "{} {}  ",
-            "created:".dimmed(),
-            dt_created.to_rfc3339_opts(SecondsFormat::Secs, true).cyan()
-        )?;
-        write!(
-            f,
-            "{} {} ({}:{:02}:{:02} remain)  ",
-            "exp:".dimmed(),
-            dt_exp.to_rfc3339_opts(SecondsFormat::Secs, true).cyan(),
-            remain.num_hours(),
-            remain.num_minutes() % 60,
-            remain.num_seconds() % 60,
-        )?;
-        if !self.signals.is_empty() {
-            write!(f, "{} [{}]  ", "signals:".dimmed(), self.signals.join(", "))?;
-        }
-        write!(f, "{} {}\n", "session_key:".dimmed(), self.session_key,)?;
-
-        Ok(())
-    }
-}
-
 /// Intentionally match the zpr::vsapi_types KeySet and KeyFormat, but
 /// reproduced here to prevent coupling of the API types from the internal types
 /// Note these keys are encrypted.
@@ -162,46 +91,16 @@ pub struct ApiKeySet {
     pub egress_key: Vec<u8>,
 }
 
-// Due to encryption, didn't want to leak too much information in the display,
-// so only have the length of the keys
-impl fmt::Display for ApiKeySet {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} {}  ", "format:".dimmed(), self.format)?;
-        write!(
-            f,
-            "{} {}B  ",
-            "ingress_key:".dimmed(),
-            self.ingress_key.len()
-        )?;
-        write!(f, "{} {}B\n", "egress_key:".dimmed(), self.egress_key.len())
-    }
-}
-
 #[derive(Default, Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub enum ApiKeyFormat {
     #[default]
     ZprKF01,
 }
 
-impl fmt::Display for ApiKeyFormat {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ApiKeyFormat::ZprKF01 => write!(f, "ZprKF01"),
-        }
-    }
-}
-
 #[derive(Serialize, Deserialize)]
 pub struct Revokes {
     pub id: String,
     pub revoked: Vec<u64>,
-}
-
-impl fmt::Display for Revokes {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} {}  ", "id:".dimmed(), self.id)?;
-        write!(f, "{} {:?}\n", "revoked:".dimmed(), self.revoked)
-    }
 }
 
 #[serde_as]
@@ -238,48 +137,8 @@ impl PartialOrd for ActorDescriptor {
     }
 }
 
-impl fmt::Display for ActorDescriptor {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let ts: DateTime<Utc> = self.ctime.into();
-        let auth_exp = match self.auth_exp {
-            Some(ae) => Some(DateTime::<Utc>::from(ae)),
-            None => None,
-        };
-        write!(
-            f,
-            "{} ({} {}) @ {}  ",
-            self.cn,
-            "created:".dimmed(),
-            ts.to_rfc3339_opts(SecondsFormat::Secs, true).cyan(),
-            self.zpr_addr.yellow()
-        )?;
-        write!(f, "{} {}  ", "identity:".dimmed(), self.ident)?;
-
-        write!(f, " {} {}  ", "is node:".dimmed(), self.node)?;
-        write!(f, " {} {:?}  ", "attributes:".dimmed(), self.attrs)?;
-        write!(
-            f,
-            "{} {}  ",
-            "auth exp:".dimmed(),
-            match auth_exp {
-                Some(ae) => ae.to_rfc3339_opts(SecondsFormat::Secs, true).cyan(),
-                None => "No auth".to_string().red(),
-            }
-        )?;
-        write!(
-            f,
-            "{}\n",
-            match &self.node_details {
-                Some(nd) => format!("[{} {}]", "node details:".green(), nd,),
-                None => "".normal().to_string(),
-            },
-        )
-    }
-}
-
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
-#[allow(dead_code)]
 pub struct ApiAttribute {
     pub key: String,
     pub value: Vec<String>,
@@ -315,20 +174,8 @@ impl PartialOrd for ServiceDescriptor {
     }
 }
 
-impl fmt::Display for ServiceDescriptor {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} {}  ", "name:".dimmed(), self.service_name)?;
-        write!(f, "{} {}  ", "cn:".dimmed(), self.actor_cn)?;
-        write!(f, "{} {}  ", "zpr_addr:".dimmed(), self.zpr_addr)?;
-        write!(f, "{} {}\n", "dock_zpr_addr:".dimmed(), self.dock_zpr_addr)?;
-        write!(f, "{} {}\n", "kind:".dimmed(), self.service_kind)?;
-        write!(f, "{} {}\n", "endpoints:".dimmed(), self.service_endpoints)
-    }
-}
-
 #[serde_as]
 #[derive(Debug, Serialize, Deserialize, Eq)]
-#[allow(dead_code)]
 pub struct HostRecordBrief {
     #[serde_as(as = "TimestampSeconds<i64>")]
     pub ctime: SystemTime,
@@ -353,25 +200,6 @@ impl Ord for HostRecordBrief {
 impl PartialOrd for HostRecordBrief {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
-    }
-}
-
-impl fmt::Display for HostRecordBrief {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let ts: DateTime<Utc> = self.ctime.into();
-        writeln!(
-            f,
-            "{} ({} {}) @ {} {}",
-            self.cn,
-            "created:".dimmed(),
-            ts.to_rfc3339_opts(SecondsFormat::Secs, true).cyan(),
-            self.zpr_addr.yellow(),
-            if self.node {
-                "[node]".green()
-            } else {
-                "".normal()
-            },
-        )
     }
 }
 
@@ -410,98 +238,6 @@ pub struct NodeRecordBrief {
     pub vss_port: Option<u16>,
 }
 
-impl fmt::Display for NodeRecordBrief {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let last_contact = match self.last_contact {
-            Some(lc) => Some(DateTime::<Utc>::from(lc)),
-            None => None,
-        };
-        let last_vreq = match self.last_vreq {
-            Some(lr) => Some(DateTime::<Utc>::from(lr)),
-            None => None,
-        };
-        write!(
-            f,
-            "{} {}  ",
-            "pending installs:".dimmed(),
-            self.pending_install
-        )?;
-        write!(
-            f,
-            "{} {}  ",
-            "SYNC:".dimmed(),
-            if self.in_sync {
-                "YES".green()
-            } else {
-                "NO".red()
-            }
-        )?;
-        write!(
-            f,
-            "{} {}  ",
-            "last_contact:".dimmed(),
-            match last_contact {
-                Some(lc) => lc.to_rfc3339_opts(SecondsFormat::Secs, true).cyan(),
-                None => "never".to_string().red(),
-            }
-        )?;
-        // [vreqs: VAL (vreqs_appr: VAL | vreqs_den: VAL ) (vinstalled: [VAL, VAL, VAL] | venqueued: [VAL, VAL])]'
-        write!(f, "[{} {} ", "vreqs:".dimmed(), self.visa_requests)?;
-        write!(
-            f,
-            "({} {} | {} {}) ",
-            "vreqs_appr:".dimmed(),
-            self.approved_vreqs,
-            "vreqs_den:".dimmed(),
-            self.denied_vreqs
-        )?;
-        write!(
-            f,
-            "({}{:?} | {} {:?})]  ",
-            "vinstalled:".dimmed(),
-            self.visas,
-            "venqueued:".dimmed(),
-            self.visas_enqueued
-        )?;
-
-        write!(
-            f,
-            "{} {}  ",
-            "last_request:".dimmed(),
-            match last_vreq {
-                Some(lr) => lr.to_rfc3339_opts(SecondsFormat::Secs, true).cyan(),
-                None => "never".to_string().red(),
-            }
-        )?;
-        // [creqs: VAL (adapters: [VAL, VAL, VAL] | nodes: [VAL, VAL])]
-        write!(f, "[{} {} ", "creqs:".dimmed(), self.connect_requests)?;
-        write!(
-            f,
-            "({} {:?} | {} {:?})]  ",
-            "adapters:".dimmed(),
-            self.adapters,
-            "nodes:".dimmed(),
-            self.links
-        )?;
-
-        write!(
-            f,
-            "{} {}  ",
-            "pending revocations:".dimmed(),
-            self.pending_revocation
-        )?;
-        write!(
-            f,
-            "{} {}\n",
-            "vss_port:".dimmed(),
-            match self.vss_port {
-                Some(port) => port.to_string(),
-                None => "no vss".to_string(),
-            }
-        )
-    }
-}
-
 #[serde_as]
 #[derive(Debug, Deserialize, Eq)]
 #[allow(dead_code)]
@@ -513,26 +249,6 @@ pub struct ServiceRecord {
     pub ident: String,
     pub node: bool,
     pub services: Vec<String>,
-}
-
-impl fmt::Display for ServiceRecord {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        for svc in &self.services {
-            writeln!(
-                f,
-                "{:<36}  {}  @ {} {}\n",
-                svc,
-                self.cn.cyan(),
-                self.zpr_addr.yellow(),
-                if self.node {
-                    "[node]".green()
-                } else {
-                    "".normal()
-                },
-            )?;
-        }
-        Ok(())
-    }
 }
 
 impl PartialEq for ServiceRecord {
@@ -559,45 +275,6 @@ pub struct AuthRevokeDescriptor {
     pub cn: String,
 }
 
-impl fmt::Display for AuthRevokeDescriptor {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} {}  ", "type:".dimmed(), self.ty)?;
-        write!(f, "{} {}\n", "cn:".dimmed(), self.cn)
-    }
-}
-
-// Not exactly an api type, but the version generated by the compiler has some parts
-// to it separated by colons.  This splits them up and makes it possible to pretty
-// print.
-#[allow(dead_code)]
-pub struct PolicyVersion {
-    parts: Vec<String>,
-}
-
-#[allow(dead_code)]
-impl PolicyVersion {
-    pub fn new(version: &str) -> Self {
-        PolicyVersion {
-            parts: version.split(':').map(|s| s.to_string()).collect(),
-        }
-    }
-}
-
-impl fmt::Display for PolicyVersion {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let colors = [Color::Cyan, Color::Green, Color::Blue, Color::BrightBlue];
-        for (i, part) in self.parts.iter().enumerate() {
-            if i > 0 {
-                write!(f, "{}", ":".bold())?;
-            }
-            write!(f, "{}", part.color(colors[i % 4]))?;
-        }
-        writeln!(f, "")?;
-        Ok(())
-    }
-}
-
-#[allow(dead_code)]
 pub fn reason_for(sc: StatusCode) -> String {
     match sc.canonical_reason() {
         Some(reason) => reason.to_string(),
@@ -609,12 +286,6 @@ pub fn reason_for(sc: StatusCode) -> String {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CnEntry {
     pub cn: String,
-}
-
-impl fmt::Display for CnEntry {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "{} {}", "cn".dimmed(), self.cn)
-    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -727,29 +398,6 @@ impl NodeConnectionBuilder {
     }
 }
 
-impl fmt::Display for NetworkDetails {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if self.network.is_empty() {
-            writeln!(f, "No network")?;
-        }
-        for nc in &self.network {
-            writeln!(
-                f,
-                "{}  {} <-> {}  {}",
-                "link:".dimmed(),
-                nc.node_a_addr.to_string().yellow(),
-                nc.node_b_addr.to_string().yellow(),
-                match nc.ctype {
-                    ConnectionType::UP => "up".green(),
-                    ConnectionType::DOWN => "down".red(),
-                    ConnectionType::INVALID => "invalid".yellow(),
-                }
-            )?;
-        }
-        Ok(())
-    }
-}
-
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Stats {
     pub stats: HashMap<String, String>,
@@ -766,45 +414,6 @@ pub struct DenyRecord {
     pub count: u64,
     pub last_deny_ms: u64,
     pub deny_code: String,
-}
-
-// IANA IP protocol numbers, local so admin-api-types need not depend on `zpr`.
-const IP_PROTO_ICMP: u8 = 1;
-const IP_PROTO_TCP: u8 = 6;
-const IP_PROTO_UDP: u8 = 17;
-const IP_PROTO_IPV6_ICMP: u8 = 58;
-
-impl fmt::Display for DenyRecord {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let proto = match self.protocol {
-            IP_PROTO_TCP => "TCP".to_string(),
-            IP_PROTO_UDP => "UDP".to_string(),
-            IP_PROTO_ICMP => "ICMP".to_string(),
-            IP_PROTO_IPV6_ICMP => "IPV6_ICMP".to_string(),
-            other => other.to_string(),
-        };
-        let when = DateTime::from_timestamp_millis(self.last_deny_ms as i64)
-            .map(|dt: DateTime<Utc>| dt.to_rfc3339_opts(SecondsFormat::Millis, true))
-            .unwrap_or_else(|| format!("{}ms", self.last_deny_ms));
-
-        write!(
-            f,
-            "{} {} {} {} {} {} {} {} {} {} {} {}",
-            "src:".dimmed(),
-            self.source_addr.to_string().yellow(),
-            "dst:".dimmed(),
-            self.dest_addr.to_string().yellow(),
-            "proto:".dimmed(),
-            proto,
-            "dport:".dimmed(),
-            self.dest_port,
-            "code:".dimmed(),
-            self.deny_code.red(),
-            "count:".dimmed(),
-            self.count,
-        )?;
-        write!(f, "  {} {}", "last:".dimmed(), when)
-    }
 }
 
 #[cfg(test)]

--- a/vs-admin/src/executor.rs
+++ b/vs-admin/src/executor.rs
@@ -13,13 +13,36 @@ use crate::vsclient::{RoleFilter, VsClient};
 
 pub struct Executor {
     vs_cli: VsClient,
+    pretty: bool,
 }
 
 impl Executor {
-    pub fn new(api_url: String, cert: reqwest::tls::Certificate, api_key: String) -> Self {
+    /// Pass `pretty:true` to indent the JSON output.
+    pub fn new(
+        api_url: String,
+        cert: reqwest::tls::Certificate,
+        api_key: String,
+        pretty: bool,
+    ) -> Self {
         Executor {
+            // Not quiet: the request trace and HTTP error bodies go to stderr, leaving
+            // stdout carrying only the JSON response so it can (eg) be piped to jq.
             vs_cli: VsClient::new(api_url, cert, api_key, false),
+            pretty,
         }
+    }
+
+    /// Renders an admin API response as JSON on stdout; `--pretty` indents it.
+    fn print_json<T: serde::Serialize>(&self, v: &T) -> Result<(), Box<dyn std::error::Error>> {
+        println!(
+            "{}",
+            if self.pretty {
+                serde_json::to_string_pretty(v)?
+            } else {
+                serde_json::to_string(v)?
+            }
+        );
+        Ok(())
     }
 
     pub fn do_cmd_policies(
@@ -67,10 +90,7 @@ impl Executor {
     /// Prints the visa service statistics as name/value pairs.
     pub fn do_cmd_stats(&self) -> Result<(), Box<dyn std::error::Error>> {
         let stats = self.vs_cli.get_stats()?;
-        for (name, value) in &stats.stats {
-            println!("{}: {}", name.bold(), value);
-        }
-        Ok(())
+        self.print_json(&stats)
     }
 
     pub fn do_cmd_actors(
@@ -138,22 +158,17 @@ impl Executor {
 
     fn get_policies(&self) -> Result<(), Box<dyn std::error::Error>> {
         let entries = self.vs_cli.get_policies()?;
-        for (i, entry) in entries.iter().enumerate() {
-            println!("{} {entry}", format!("ENTRY {}", i).bold());
-        }
-        Ok(())
+        self.print_json(&entries)
     }
 
     fn get_policy(&self, id: u64) -> Result<(), Box<dyn std::error::Error>> {
         let entry = self.vs_cli.get_policy(id)?;
-        println!("{entry}");
-        Ok(())
+        self.print_json(&entry)
     }
 
     fn get_curr_policy(&self) -> Result<(), Box<dyn std::error::Error>> {
         let entry = self.vs_cli.get_curr_policy()?;
-        println!("{entry}");
-        Ok(())
+        self.print_json(&entry)
     }
 
     // Push a binary policy file to the visa service.
@@ -168,10 +183,9 @@ impl Executor {
 
         match PolicyBundle::new_from_policy_container(0, policy_buf.into()) {
             Ok(pb) => {
-                println!("{}", "sending policy container".magenta());
+                eprintln!("{}", "sending policy container".magenta());
                 let entry: ListEntry = self.vs_cli.install_policy(&pb)?;
-                println!("{entry}");
-                Ok(())
+                self.print_json(&entry)
             }
             Err(e) => {
                 eprintln!("{} {}", "Error creating policy bundle:".red(), e);
@@ -182,16 +196,12 @@ impl Executor {
 
     fn get_visas(&self) -> Result<(), Box<dyn std::error::Error>> {
         let visas = self.vs_cli.get_visas()?;
-        for visa_id in visas {
-            println!("{} {}", format!("VISA ID").bold(), visa_id);
-        }
-        Ok(())
+        self.print_json(&visas)
     }
 
     fn get_visa(&self, id: u64) -> Result<(), Box<dyn std::error::Error>> {
         let visa = self.vs_cli.get_visa(id)?;
-        println!("{visa}");
-        Ok(())
+        self.print_json(&visa)
     }
 
     /// Prints the recent-denies window, newest first. `last` is a lookback
@@ -202,16 +212,13 @@ impl Executor {
         limit: Option<usize>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let since = last.map(|d| since_from_last(epoch_ms_now(), d));
-        for record in self.vs_cli.get_denies(since, limit)? {
-            println!("{record}");
-        }
-        Ok(())
+        let records = self.vs_cli.get_denies(since, limit)?;
+        self.print_json(&records)
     }
 
     fn revoke_visa(&self, id: u64) -> Result<(), Box<dyn std::error::Error>> {
         let revoke = self.vs_cli.revoke_visa(id)?;
-        println!("{revoke}");
-        Ok(())
+        self.print_json(&revoke)
     }
 
     // Either all actors or just nodes.
@@ -221,91 +228,67 @@ impl Executor {
         } else {
             RoleFilter::All
         };
-        let actor_cns = self.vs_cli.get_actors(filter)?;
-
-        for (i, cn) in actor_cns.iter().enumerate() {
-            println!("{} {}", format!("ACTOR {}", i).bold(), cn);
-        }
-        Ok(())
+        let actors = self.vs_cli.get_actors(filter)?;
+        self.print_json(&actors)
     }
 
     fn get_actor(&self, cn: &str) -> Result<(), Box<dyn std::error::Error>> {
         let actor = self.vs_cli.get_actor(cn)?;
-        println!("{actor}");
-        Ok(())
+        self.print_json(&actor)
     }
 
     fn revoke_actor(&self, cn: &str) -> Result<(), Box<dyn std::error::Error>> {
         let revoke = self.vs_cli.revoke_actor(cn)?;
-        println!("{revoke}");
-        Ok(())
+        self.print_json(&revoke)
     }
 
     fn get_related_visas(&self, cn: &str) -> Result<(), Box<dyn std::error::Error>> {
         let entries = self.vs_cli.get_related_visas(cn)?;
-        for (i, entry) in entries.iter().enumerate() {
-            println!("{} {entry}", format!("ENTRY {}", i).bold());
-        }
-        Ok(())
+        self.print_json(&entries)
     }
 
     /// Prints the IDs of the visas currently installed on the node with the given CN.
     fn get_visas_on_node(&self, cn: &str) -> Result<(), Box<dyn std::error::Error>> {
         let entries = self.vs_cli.get_visas_on_node(cn)?;
-        for (i, entry) in entries.iter().enumerate() {
-            println!("{} {entry}", format!("ENTRY {}", i).bold());
-        }
-        Ok(())
+        self.print_json(&entries)
     }
 
     fn get_services(&self) -> Result<(), Box<dyn std::error::Error>> {
-        let svc_names = self.vs_cli.get_services()?;
-        for (i, id) in svc_names.iter().enumerate() {
-            println!("{} {}", format!("SERVICE {}", i).bold(), id);
-        }
-        Ok(())
+        let services = self.vs_cli.get_services()?;
+        self.print_json(&services)
     }
 
     fn get_service(&self, id: &str) -> Result<(), Box<dyn std::error::Error>> {
         let svc = self.vs_cli.get_service(id)?;
-        println!("{svc}");
-        Ok(())
+        self.print_json(&svc)
     }
 
     /// Refresh a trusted service's attribute data. The visa service then revalidates
     /// active visas against the refreshed attributes asynchronously.
     fn flush_service_cache(&self, id: &str) -> Result<(), Box<dyn std::error::Error>> {
         self.vs_cli.flush_service_cache(id)?;
-        println!("refreshed {id}; active visas are being revalidated");
+        eprintln!("refreshed {id}; active visas are being revalidated");
         Ok(())
     }
 
     fn get_revokes(&self) -> Result<(), Box<dyn std::error::Error>> {
         let entries = self.vs_cli.get_revokes()?;
-        for (i, entry) in entries.iter().enumerate() {
-            println!("{} {entry}", format!("ENTRY {}", i).bold());
-        }
-        Ok(())
+        self.print_json(&entries)
     }
 
     fn get_revoke(&self, id: &str) -> Result<(), Box<dyn std::error::Error>> {
         let entry = self.vs_cli.get_revoke(id)?;
-        println!("{entry}");
-        Ok(())
+        self.print_json(&entry)
     }
 
     fn clear_revokes(&self) -> Result<(), Box<dyn std::error::Error>> {
         let entries = self.vs_cli.clear_revokes()?;
-        for (i, entry) in entries.iter().enumerate() {
-            println!("{} {entry}", format!("ENTRY {}", i).bold());
-        }
-        Ok(())
+        self.print_json(&entries)
     }
 
     fn remove_revoke(&self, id: &str) -> Result<(), Box<dyn std::error::Error>> {
         let entry = self.vs_cli.remove_revoke(id)?;
-        println!("{entry}");
-        Ok(())
+        self.print_json(&entry)
     }
 
     // TODO figure out how we want to get the visa information from the user.
@@ -313,15 +296,12 @@ impl Executor {
     // the parts we care about via arguments on the command line
     fn add_revoke(&self, id: &str) -> Result<(), Box<dyn std::error::Error>> {
         let entry = self.vs_cli.add_revoke(id)?;
-        println!("{entry}");
-        Ok(())
+        self.print_json(&entry)
     }
 
     fn get_network(&self) -> Result<(), Box<dyn std::error::Error>> {
         let network = self.vs_cli.get_network()?;
-
-        println!("{network}");
-        Ok(())
+        self.print_json(&network)
     }
 }
 

--- a/vs-admin/src/executor.rs
+++ b/vs-admin/src/executor.rs
@@ -9,37 +9,37 @@ use admin_api_types::ListEntry;
 
 use zpr::policy_types::PolicyBundle;
 
+use crate::main_args::OutputFormat;
 use crate::vsclient::{RoleFilter, VsClient};
 
 pub struct Executor {
     vs_cli: VsClient,
-    pretty: bool,
+    format: OutputFormat,
 }
 
 impl Executor {
-    /// Pass `pretty:true` to indent the JSON output.
+    /// `format` selects between indented and single-line JSON output.
     pub fn new(
         api_url: String,
         cert: reqwest::tls::Certificate,
         api_key: String,
-        pretty: bool,
+        format: OutputFormat,
     ) -> Self {
         Executor {
             // Not quiet: the request trace and HTTP error bodies go to stderr, leaving
             // stdout carrying only the JSON response so it can (eg) be piped to jq.
             vs_cli: VsClient::new(api_url, cert, api_key, false),
-            pretty,
+            format,
         }
     }
 
-    /// Renders an admin API response as JSON on stdout; `--pretty` indents it.
+    /// Renders an admin API response as JSON on stdout, honoring `--format`.
     fn print_json<T: serde::Serialize>(&self, v: &T) -> Result<(), Box<dyn std::error::Error>> {
         println!(
             "{}",
-            if self.pretty {
-                serde_json::to_string_pretty(v)?
-            } else {
-                serde_json::to_string(v)?
+            match self.format {
+                OutputFormat::Pretty => serde_json::to_string_pretty(v)?,
+                OutputFormat::Compact => serde_json::to_string(v)?,
             }
         );
         Ok(())

--- a/vs-admin/src/gui.rs
+++ b/vs-admin/src/gui.rs
@@ -205,8 +205,8 @@ impl Gui {
         {
             let actor_cns = self.vs_cli.get_actors(RoleFilter::All)?;
             self.actors.clear();
-            for cn in &actor_cns {
-                match self.vs_cli.get_actor(cn) {
+            for entry in &actor_cns {
+                match self.vs_cli.get_actor(&entry.cn) {
                     Ok(a) => {
                         self.actors.push(a);
                     }
@@ -221,8 +221,8 @@ impl Gui {
         {
             let service_ids = self.vs_cli.get_services()?;
             self.services.clear();
-            for sid in &service_ids {
-                match self.vs_cli.get_service(sid) {
+            for entry in &service_ids {
+                match self.vs_cli.get_service(&entry.id) {
                     Ok(s) => {
                         self.services.push(s);
                     }
@@ -236,8 +236,8 @@ impl Gui {
         {
             let visa_ids = self.vs_cli.get_visas()?;
             self.visas.clear();
-            for vid in &visa_ids {
-                match self.vs_cli.get_visa(*vid) {
+            for entry in &visa_ids {
+                match self.vs_cli.get_visa(entry.id) {
                     Ok(v) => {
                         self.visas.push(v);
                     }

--- a/vs-admin/src/gui/details.rs
+++ b/vs-admin/src/gui/details.rs
@@ -7,7 +7,7 @@ use std::time::SystemTime;
 use thousands::Separable;
 
 use super::format::{
-    ago_suffix, auth_hdr, flow_str, hm, remaining_str, session_key_summary, ts_or,
+    ago_suffix, auth_hdr, dir_str, flow_str, hm, remaining_str, session_key_summary, ts_or,
 };
 use super::text::{ATTR_KEY_STYLE, ATTR_VAL_STYLE, HEADING_STYLE, LABEL_W, labeled};
 
@@ -37,7 +37,7 @@ pub(super) fn visa_detail_text(
     lines.extend(labeled("policy", &v.policy_id, width));
     lines.extend(labeled(
         "zpl",
-        &format!("[{}] {}", v.direction, v.zpl),
+        &format!("[{}] {}", dir_str(&v.direction), v.zpl),
         width,
     ));
     let requesting = match cn {

--- a/vs-admin/src/gui/format.rs
+++ b/vs-admin/src/gui/format.rs
@@ -1,6 +1,6 @@
 //! Pure time/string summary helpers for the Details views and header.
 
-use admin_api_types::{ApiKeySet, VisaDescriptor};
+use admin_api_types::{ApiKeySet, VisaDescriptor, VisaMatchDirection};
 use chrono::{DateTime, SecondsFormat, Utc};
 use std::time::SystemTime;
 use thousands::Separable;
@@ -51,6 +51,14 @@ pub(super) fn flow_str(v: &VisaDescriptor) -> String {
     let dport = v.dest_port.unwrap_or(0);
     let proto = v.proto.to_uppercase();
     format!("[{src}]:{sport}  --{proto}-->  [{dst}]:{dport}")
+}
+
+/// Visa direction as the lowercase word used in the zpl line.
+pub(super) fn dir_str(d: &VisaMatchDirection) -> &'static str {
+    match d {
+        VisaMatchDirection::Forward => "forward",
+        VisaMatchDirection::Reverse => "reverse",
+    }
 }
 
 /// One-line session-key summary — never prints key material, only the key
@@ -105,7 +113,9 @@ pub(super) fn ago_suffix(t: SystemTime, now: SystemTime) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{auth_hdr, flow_str, fmt_uptime, remaining_str, session_key_summary, ts_or};
+    use super::{
+        auth_hdr, dir_str, flow_str, fmt_uptime, remaining_str, session_key_summary, ts_or,
+    };
     use admin_api_types::{ApiKeySet, VisaDescriptor, VisaMatchDirection};
     use std::time::{Duration, UNIX_EPOCH};
 
@@ -193,6 +203,13 @@ mod tests {
     fn ts_or_timestamp_or_fallback() {
         assert!(ts_or(Some(UNIX_EPOCH), "never").contains("1970-01-01"));
         assert_eq!(ts_or(None, "never"), "never");
+    }
+
+    /// dir_str renders both directions as the lowercase wire spelling.
+    #[test]
+    fn dir_str_both_directions() {
+        assert_eq!(dir_str(&VisaMatchDirection::Forward), "forward");
+        assert_eq!(dir_str(&VisaMatchDirection::Reverse), "reverse");
     }
 
     /// fmt_uptime rolls seconds into d/h/m/s with zero-padding.

--- a/vs-admin/src/main.rs
+++ b/vs-admin/src/main.rs
@@ -60,7 +60,12 @@ fn main() {
         std::process::exit(1);
     });
 
-    let exec = Executor::new(args.svc_url.clone(), ca_cert.clone(), api_key.clone());
+    let exec = Executor::new(
+        args.svc_url.clone(),
+        ca_cert.clone(),
+        api_key.clone(),
+        args.pretty,
+    );
 
     match args.command {
         Some(SubCmd::Policies { id, path, curr }) => exec.do_cmd_policies(id, path, curr),

--- a/vs-admin/src/main.rs
+++ b/vs-admin/src/main.rs
@@ -64,7 +64,7 @@ fn main() {
         args.svc_url.clone(),
         ca_cert.clone(),
         api_key.clone(),
-        args.pretty,
+        args.format,
     );
 
     match args.command {

--- a/vs-admin/src/main_args.rs
+++ b/vs-admin/src/main_args.rs
@@ -22,6 +22,10 @@ pub struct Cmd {
     /// Path to a file containing the API key for the visa service admin API.
     #[arg(long, value_name = "PATH", conflicts_with = "api_key")]
     pub api_key_file: Option<PathBuf>,
+
+    /// Indent the JSON output instead of emitting it on a single line.
+    #[arg(long)]
+    pub pretty: bool,
 }
 
 #[derive(Subcommand)]

--- a/vs-admin/src/main_args.rs
+++ b/vs-admin/src/main_args.rs
@@ -1,5 +1,14 @@
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
+
+/// How `vs-admin` renders JSON responses on stdout.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, ValueEnum)]
+pub enum OutputFormat {
+    /// Indented, human-readable JSON.
+    Pretty,
+    /// Single-line JSON.
+    Compact,
+}
 
 #[derive(Parser)]
 #[command(version, about = "Visa Service Admin Tool", long_about = None)]
@@ -23,9 +32,9 @@ pub struct Cmd {
     #[arg(long, value_name = "PATH", conflicts_with = "api_key")]
     pub api_key_file: Option<PathBuf>,
 
-    /// Indent the JSON output instead of emitting it on a single line.
-    #[arg(long)]
-    pub pretty: bool,
+    /// Output format for JSON responses.
+    #[arg(long, value_enum, default_value = "pretty", value_name = "FMT")]
+    pub format: OutputFormat,
 }
 
 #[derive(Subcommand)]
@@ -214,6 +223,32 @@ mod tests {
         assert!(try_parse_visas(&["--denies", "--id", "7"]).is_err());
         assert!(try_parse_visas(&["--denies", "--id", "7", "--revoke"]).is_err());
         assert!(try_parse_visas(&["--denies", "--on-node", "node-1"]).is_err());
+    }
+
+    /// Output defaults to pretty, accepts both format names, and no longer takes `--pretty`.
+    #[test]
+    fn format_defaults_to_pretty() {
+        let parse = |extra: &[&str]| {
+            let mut argv = vec![
+                "vs-admin",
+                "--svc-url",
+                "https://[::1]:8182",
+                "--ca-cert",
+                "ca.pem",
+                "--api-key",
+                "k",
+            ];
+            argv.extend_from_slice(extra);
+            argv.push("stats");
+            Cmd::try_parse_from(argv)
+        };
+        assert_eq!(parse(&[]).unwrap().format, OutputFormat::Pretty);
+        assert_eq!(
+            parse(&["--format", "compact"]).unwrap().format,
+            OutputFormat::Compact
+        );
+        assert!(parse(&["--pretty"]).is_err());
+        assert!(parse(&["--format", "bogus"]).is_err());
     }
 
     /// The clap definition itself is well formed (catches bad `requires`/`conflicts_with` names).

--- a/vs-admin/src/vsclient.rs
+++ b/vs-admin/src/vsclient.rs
@@ -53,7 +53,7 @@ impl VsClient {
     fn ht_get(&self, url: &str) -> Result<reqwest::blocking::Response, VsaError> {
         let client = self.build_client()?;
         if !self.quiet {
-            print!("{}", format!(">> get {url}").dimmed());
+            eprint!("{}", format!(">> get {url}").dimmed());
         }
         let resp = client
             .get(url)
@@ -62,7 +62,7 @@ impl VsClient {
 
         let stat = resp.status();
         if !self.quiet {
-            println!("  {}", stat);
+            eprintln!("  {}", stat);
         }
 
         if stat.is_success() {
@@ -75,7 +75,7 @@ impl VsClient {
     fn ht_post(&self, url: &str) -> Result<reqwest::blocking::Response, VsaError> {
         let client = self.build_client()?;
         if !self.quiet {
-            print!("{}", format!(">> post {url}").dimmed());
+            eprint!("{}", format!(">> post {url}").dimmed());
         }
         let resp = client
             .post(url)
@@ -84,7 +84,7 @@ impl VsClient {
 
         let stat = resp.status();
         if !self.quiet {
-            println!("  {}", stat);
+            eprintln!("  {}", stat);
         }
 
         if stat.is_success() {
@@ -101,7 +101,7 @@ impl VsClient {
     ) -> Result<reqwest::blocking::Response, VsaError> {
         let client = self.build_client()?;
         if !self.quiet {
-            print!("{}", format!(">> post {url}").dimmed());
+            eprint!("{}", format!(">> post {url}").dimmed());
         }
         let resp = client
             .post(url)
@@ -111,7 +111,7 @@ impl VsClient {
 
         let stat = resp.status();
         if !self.quiet {
-            println!("  {}", stat);
+            eprintln!("  {}", stat);
         }
 
         if stat.is_success() {
@@ -124,7 +124,7 @@ impl VsClient {
     fn ht_delete(&self, url: &str) -> Result<reqwest::blocking::Response, VsaError> {
         let client = self.build_client()?;
         if !self.quiet {
-            print!("{}", format!(">> delete {url}").dimmed());
+            eprint!("{}", format!(">> delete {url}").dimmed());
         }
         let resp = client
             .delete(url)
@@ -133,7 +133,7 @@ impl VsClient {
 
         let stat = resp.status();
         if !self.quiet {
-            println!("  {}", stat);
+            eprintln!("  {}", stat);
         }
 
         if stat.is_success() {
@@ -170,7 +170,7 @@ impl VsClient {
     /// `GET <api_url>/admin/actors[?role=node|adapter]`
     ///
     /// Returns a list of CN values.
-    pub fn get_actors(&self, filter: RoleFilter) -> Result<Vec<String>, VsaError> {
+    pub fn get_actors(&self, filter: RoleFilter) -> Result<Vec<CnEntry>, VsaError> {
         let query = match filter {
             RoleFilter::NodesOnly => "?role=node",
             RoleFilter::AdaptersOnly => "?role=adapter",
@@ -180,8 +180,7 @@ impl VsClient {
             "{}/admin/actors{}",
             self.api_url, query
         ))?;
-        let cn_list: Vec<String> = entry_vec.into_iter().map(|e| e.cn).collect();
-        Ok(cn_list)
+        Ok(entry_vec)
     }
 
     /// `GET <api_url>/admin/actors/<cn>`
@@ -196,13 +195,12 @@ impl VsClient {
     /// `GET <api_url>/admin/services`
     ///
     /// Returns a list of service IDs (whihch are names)
-    pub fn get_services(&self) -> Result<Vec<String>, VsaError> {
+    pub fn get_services(&self) -> Result<Vec<NamedListEntry>, VsaError> {
         let entry_vec = self.request_get_list_entries::<NamedListEntry>(&format!(
             "{}/admin/services",
             self.api_url
         ))?;
-        let service_ids: Vec<String> = entry_vec.into_iter().map(|e| e.id).collect();
-        Ok(service_ids)
+        Ok(entry_vec)
     }
 
     /// `GET <api_url>/admin/services/<id>`
@@ -226,11 +224,10 @@ impl VsClient {
     }
 
     /// `GET <api_url>/admin/visas`
-    pub fn get_visas(&self) -> Result<Vec<u64>, VsaError> {
+    pub fn get_visas(&self) -> Result<Vec<ListEntry>, VsaError> {
         let entry_vec =
             self.request_get_list_entries::<ListEntry>(&format!("{}/admin/visas", self.api_url))?;
-        let visa_ids: Vec<u64> = entry_vec.into_iter().map(|e| e.id).collect();
-        Ok(visa_ids)
+        Ok(entry_vec)
     }
 
     /// `GET <api_url>/admin/visas/<id>`

--- a/vs-admin/src/vsclient.rs
+++ b/vs-admin/src/vsclient.rs
@@ -8,7 +8,7 @@ use zpr::policy_types::PolicyBundle;
 
 use admin_api_types::{
     ActorDescriptor, AuthRevokeDescriptor, CnEntry, DenyRecord, ListEntry, NamedListEntry,
-    NetworkDetails, Revokes, ServiceDescriptor, Stats, VisaDescriptor, reason_for,
+    NetworkDetails, Revokes, ServiceDescriptor, Stats, VisaDescriptor,
 };
 
 use crate::error::VsaError;
@@ -151,7 +151,7 @@ impl VsClient {
             "{} {}: {}",
             "HTTP Error".red(),
             error_resp.status(),
-            reason_for(error_resp.status())
+            error_resp.status().canonical_reason().unwrap_or("unknown")
         );
         if let Ok(txt) = error_resp.text() {
             eprintln!("       {}", txt);


### PR DESCRIPTION
`vs-admin` now emits regular json -- the big idea is that user can just pipe it to `jq` if they want to do anything useful with the output.

* Removes all the increasingly complex `fmt::Display` implementations from the api types crate.
* Moved all the auxiliary output (eg status messages, errors) to `stderr` to keep the stdout pipeline clear for parsing.
* Removed some unused code and did some general tidying.