### PR TITLE
Fix visa-counts in actors & services panes

### DIFF
--- a/zpr-dashboard/internal/components/actor_attrs_test.go
+++ b/zpr-dashboard/internal/components/actor_attrs_test.go
@@ -284,19 +284,25 @@ func TestActorServicesOfferedEndpoints(t *testing.T) {
 }
 
 // offeredFixture returns the actor, services and visas the Visas-column tests
-// share: service alpha answers on two addresses, quiet on one and gets nothing.
+// share: alpha and beta answer on the same actor address and are told apart by
+// port alone, alpha also answers on a dock address, and quiet gets nothing.
 func offeredFixture() ([]dataplane.ActorDescriptor, []dataplane.ServiceDescriptor, []dataplane.VisaDescriptor) {
 	actors := []dataplane.ActorDescriptor{{CName: "alpha-cn"}}
 	services := []dataplane.ServiceDescriptor{
-		{ServiceName: "alpha", ActorCN: "alpha-cn", ZprAddress: "fd5a:5052:90de::30", DockZprAddress: "fd5a:5052:90de::99"},
-		{ServiceName: "quiet", ActorCN: "alpha-cn", ZprAddress: "fd5a:5052:90de::31"},
+		{ServiceName: "alpha", ActorCN: "alpha-cn", ZprAddress: "fd5a:5052:90de::30", DockZprAddress: "fd5a:5052:90de::99", Endpoints: "TCP/443"},
+		{ServiceName: "beta", ActorCN: "alpha-cn", ZprAddress: "fd5a:5052:90de::30", Endpoints: "TCP/9000"},
+		{ServiceName: "quiet", ActorCN: "alpha-cn", ZprAddress: "fd5a:5052:90de::31", Endpoints: "TCP/8080"},
 	}
 	visas := []dataplane.VisaDescriptor{
-		{ID: 1, DestAddr: strPtr("fd5a:5052:90de::30")},
-		{ID: 2, DestAddr: strPtr("fd5a:5052:90de::30")},
-		{ID: 3, DestAddr: strPtr("fd5a:5052:90de::99")},
-		{ID: 4, DestAddr: strPtr("fd5a:5052:90de::40")},
-		{ID: 5, SourceAddr: strPtr("fd5a:5052:90de::31"), DestAddr: strPtr("fd5a:5052:90de::40")},
+		// Forward and reverse halves of one flow towards alpha.
+		{ID: 1, Direction: "forward", Proto: "TCP", SourceAddr: strPtr("fd5a:5052:90de::40"), DestAddr: strPtr("fd5a:5052:90de::30"), SourcePort: intPtr(0), DestPort: intPtr(443)},
+		{ID: 2, Direction: "reverse", Proto: "TCP", SourceAddr: strPtr("fd5a:5052:90de::30"), DestAddr: strPtr("fd5a:5052:90de::40"), SourcePort: intPtr(443), DestPort: intPtr(0)},
+		// Towards alpha on its dock address.
+		{ID: 3, Direction: "forward", Proto: "TCP", SourceAddr: strPtr("fd5a:5052:90de::40"), DestAddr: strPtr("fd5a:5052:90de::99"), SourcePort: intPtr(0), DestPort: intPtr(443)},
+		// Nobody's service.
+		{ID: 4, Direction: "forward", Proto: "TCP", SourceAddr: strPtr("fd5a:5052:90de::31"), DestAddr: strPtr("fd5a:5052:90de::40"), SourcePort: intPtr(0), DestPort: intPtr(22)},
+		// Same address as alpha, beta's port.
+		{ID: 5, Direction: "forward", Proto: "TCP", SourceAddr: strPtr("fd5a:5052:90de::40"), DestAddr: strPtr("fd5a:5052:90de::30"), SourcePort: intPtr(0), DestPort: intPtr(9000)},
 	}
 
 	return actors, services, visas
@@ -318,17 +324,23 @@ func rowCell(t *testing.T, out, svc string) string {
 	return ""
 }
 
-// TestActorServicesOfferedVisaCounts checks the Visas column counts visas
-// whose destination is either service address, and ignores everything else.
+// TestActorServicesOfferedVisaCounts checks the Visas column counts the visas
+// granted for each service's endpoints — both directions, and per port rather
+// than per address, so two services on one address differ.
 func TestActorServicesOfferedVisaCounts(t *testing.T) {
 	actors, services, visas := offeredFixture()
 
 	out := ansi.Strip(ActorServicesOffered(80, 20, actors, 0, services, visas, nil, nil))
 
+	// Forward, its reverse half, and the dock-address visa.
 	if got := rowCell(t, out, "alpha"); got != "3" {
 		t.Errorf("alpha count = %q, want 3:\n%s", got, out)
 	}
-	// ::31 only ever appears as a source, and ::40 is nobody's service.
+	// Same address as alpha, so an address-only match would report 3 here too.
+	if got := rowCell(t, out, "beta"); got != "1" {
+		t.Errorf("beta count = %q, want 1:\n%s", got, out)
+	}
+	// ::31 only ever appears as a forward source, and ::40 is nobody's service.
 	if got := rowCell(t, out, "quiet"); got != "0" {
 		t.Errorf("quiet count = %q, want 0:\n%s", got, out)
 	}
@@ -341,7 +353,7 @@ func TestActorServicesOfferedVisaError(t *testing.T) {
 
 	out := ansi.Strip(ActorServicesOffered(80, 20, actors, 0, services, visas, nil, errors.New("stale")))
 
-	for _, svc := range []string{"alpha", "quiet"} {
+	for _, svc := range []string{"alpha", "beta", "quiet"} {
 		if got := rowCell(t, out, svc); got != "ERR" {
 			t.Errorf("%s count = %q, want ERR:\n%s", svc, got, out)
 		}
@@ -354,3 +366,6 @@ func TestActorServicesOfferedVisaError(t *testing.T) {
 
 // strPtr returns a pointer to s, for the optional visa address fields.
 func strPtr(s string) *string { return &s }
+
+// intPtr returns a pointer to n, for the optional visa port fields.
+func intPtr(n int) *int { return &n }

--- a/zpr-dashboard/internal/components/actor_services.go
+++ b/zpr-dashboard/internal/components/actor_services.go
@@ -55,7 +55,7 @@ func ActorServicesOffered(
 		// A failed visa refresh must not read as a current count of zero.
 		count := "ERR"
 		if activeVisasFetchErr == nil {
-			count = strconv.Itoa(len(inboundVisas(activeVisas, svc)))
+			count = strconv.Itoa(len(visasForService(activeVisas, svc)))
 		}
 
 		t.Row(

--- a/zpr-dashboard/internal/components/service_visas.go
+++ b/zpr-dashboard/internal/components/service_visas.go
@@ -8,17 +8,17 @@ import (
 	"neboagency.com/zpr-dashborad/internal/timefmt"
 )
 
-// inboundVisas returns the visas granted towards svc, i.e. those whose
-// destination is an address the service answers on. Input order is preserved.
-func inboundVisas(visas []dataplane.VisaDescriptor, svc dataplane.ServiceDescriptor) []dataplane.VisaDescriptor {
-	var inbound []dataplane.VisaDescriptor
+// visasForService returns the visas granted for traffic to svc's endpoints,
+// forward and reverse. Input order is preserved.
+func visasForService(visas []dataplane.VisaDescriptor, svc dataplane.ServiceDescriptor) []dataplane.VisaDescriptor {
+	var matched []dataplane.VisaDescriptor
 	for _, visa := range visas {
-		if svc.Hosts(visa.Dest()) {
-			inbound = append(inbound, visa)
+		if svc.Targets(visa) {
+			matched = append(matched, visa)
 		}
 	}
 
-	return inbound
+	return matched
 }
 
 func ServiceVisas(
@@ -41,27 +41,29 @@ func ServiceVisas(
 
 	svc := services[selectedIndex]
 
-	inbound := inboundVisas(visas, svc)
+	matched := visasForService(visas, svc)
 
-	if len(inbound) == 0 {
+	if len(matched) == 0 {
 		return detailPanel(width, height, title, subtitle, panelNote("No visas towards this service"))
 	}
 
 	tableWidth := width - 5
-	idSize := int(float32(tableWidth) * 0.14)
-	sourceSize := int(float32(tableWidth) * 0.38)
-	protoSize := int(float32(tableWidth) * 0.16)
-	expireSize := int(float32(tableWidth) * 0.32)
+	idSize := int(float32(tableWidth) * 0.12)
+	peerSize := int(float32(tableWidth) * 0.32)
+	dirSize := int(float32(tableWidth) * 0.14)
+	protoSize := int(float32(tableWidth) * 0.14)
+	expireSize := tableWidth - idSize - peerSize - dirSize - protoSize
 
 	t := panelTable(tableWidth,
-		[]string{"ID", "Source", "Proto", "Expires"},
-		[]int{idSize, sourceSize, protoSize, expireSize},
+		[]string{"ID", "Peer", "Dir", "Proto", "Expires"},
+		[]int{idSize, peerSize, dirSize, protoSize, expireSize},
 	)
 
-	for _, visa := range inbound {
+	for _, visa := range matched {
 		t.Row(
 			ansi.Truncate(strconv.FormatInt(visa.ID, 10), idSize, "..."),
-			ansi.Truncate(endpointLabel(visa.Source(), actors), sourceSize, "..."),
+			ansi.Truncate(endpointLabel(visa.Peer(), actors), peerSize, "..."),
+			ansi.Truncate(visa.Direction, dirSize, "..."),
 			ansi.Truncate(visa.Proto, protoSize, "..."),
 			ansi.Truncate(timefmt.Expiry(visa.Expires), expireSize, "..."),
 		)

--- a/zpr-dashboard/internal/components/service_visas_test.go
+++ b/zpr-dashboard/internal/components/service_visas_test.go
@@ -1,0 +1,66 @@
+package components
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"neboagency.com/zpr-dashborad/internal/dataplane"
+)
+
+// serviceVisaFixture returns one service plus a forward visa towards it, its
+// reverse half, and an unrelated visa on the same address but another port.
+func serviceVisaFixture() ([]dataplane.ServiceDescriptor, []dataplane.VisaDescriptor, []dataplane.ActorDescriptor) {
+	const svc, peer = "fd5a:5052:90de::30", "fd5a:5052:90de::40"
+
+	services := []dataplane.ServiceDescriptor{
+		{ServiceName: "alpha", ActorCN: "alpha-cn", ZprAddress: svc, Endpoints: "TCP/443"},
+	}
+	visas := []dataplane.VisaDescriptor{
+		{ID: 1, Direction: "forward", Proto: "TCP", SourceAddr: strPtr(peer), DestAddr: strPtr(svc), SourcePort: intPtr(0), DestPort: intPtr(443)},
+		{ID: 2, Direction: "reverse", Proto: "TCP", SourceAddr: strPtr(svc), DestAddr: strPtr(peer), SourcePort: intPtr(443), DestPort: intPtr(0)},
+		{ID: 3, Direction: "forward", Proto: "TCP", SourceAddr: strPtr(peer), DestAddr: strPtr(svc), SourcePort: intPtr(0), DestPort: intPtr(9000)},
+	}
+	actors := []dataplane.ActorDescriptor{{CName: "peer-cn", ZprAddress: peer}}
+
+	return services, visas, actors
+}
+
+// TestServiceVisasBothDirections checks both halves of a flow are listed with
+// their direction, the peer is the far end in either direction, and a visa on
+// another port of the same address is excluded.
+func TestServiceVisasBothDirections(t *testing.T) {
+	services, visas, actors := serviceVisaFixture()
+
+	out := ansi.Strip(ServiceVisas(80, 20, services, 0, visas, actors, nil))
+
+	for _, want := range []string{"forward", "reverse", "peer-cn"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in the table:\n%s", want, out)
+		}
+	}
+	// The peer resolves to a CN in both rows, so the raw address never shows.
+	if strings.Contains(out, "fd5a:5052:90de::40") {
+		t.Errorf("expected the peer address to be replaced by its CN:\n%s", out)
+	}
+	// Visa 3 shares the service address but not its declared port.
+	if rows := strings.Count(out, "peer-cn"); rows != 2 {
+		t.Errorf("expected 2 matching rows, got %d:\n%s", rows, out)
+	}
+}
+
+// TestServiceVisasFitsBudget checks the pane stays inside its width and height.
+func TestServiceVisasFitsBudget(t *testing.T) {
+	services, visas, actors := serviceVisaFixture()
+
+	const width, height = 60, 8
+	out := ServiceVisas(width, height, services, 0, visas, actors, nil)
+
+	if w := lipgloss.Width(out); w > width {
+		t.Errorf("pane width = %d, want <= %d:\n%s", w, width, ansi.Strip(out))
+	}
+	if h := lipgloss.Height(out); h > height {
+		t.Errorf("pane height = %d, want <= %d:\n%s", h, height, ansi.Strip(out))
+	}
+}

--- a/zpr-dashboard/internal/dataplane/services.go
+++ b/zpr-dashboard/internal/dataplane/services.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"strconv"
 	"strings"
 )
 
@@ -30,6 +31,10 @@ type Endpoint struct {
 	Port  string
 }
 
+// ponytail: parses the server's display string
+// ("TCP/443,ICMP/128,TCP/8000-8080"). If admin_service.rs changes that format
+// counts silently fall to zero — upgrade path is structured endpoints on
+// ServiceDescriptor.
 func (s ServiceDescriptor) ServiceEndpoints() []Endpoint {
 	if s.Endpoints == "" {
 		return nil
@@ -46,6 +51,87 @@ func (s ServiceDescriptor) ServiceEndpoints() []Endpoint {
 	}
 
 	return endpoints
+}
+
+// visaProto canonicalises the protocol name a visa payload carries.
+func visaProto(proto string) string {
+	switch p := strings.ToUpper(strings.TrimSpace(proto)); p {
+	case "PROTO_6":
+		return "TCP"
+	case "PROTO_17":
+		return "UDP"
+	case "PROTO_58":
+		return "ICMP"
+	default:
+		return p
+	}
+}
+
+// endpointProto canonicalises the protocol name a declared endpoint carries.
+// An endpoint says IPV6_ICMP or PROTO_58 where a visa just says ICMP, while an
+// endpoint's plain ICMP (or PROTO_1) is IPv4 and must not match those visas.
+func endpointProto(proto string) string {
+	switch p := strings.ToUpper(strings.TrimSpace(proto)); p {
+	case "IPV6_ICMP":
+		return "ICMP"
+	case "ICMP", "PROTO_1":
+		return "ICMPV4"
+	default:
+		return visaProto(p)
+	}
+}
+
+// Matches reports whether proto/port fall within this declared endpoint. An
+// endpoint with no port (or port zero) constrains the protocol only; malformed
+// ports fail closed.
+func (e Endpoint) Matches(proto string, port int) bool {
+	canon := endpointProto(e.Proto)
+	if canon != visaProto(proto) {
+		return false
+	}
+
+	spec := strings.TrimSpace(e.Port)
+	if spec == "" || spec == "0" {
+		return true
+	}
+
+	lowText, highText, isRange := strings.Cut(spec, "-")
+	low, err := strconv.Atoi(strings.TrimSpace(lowText))
+	if err != nil {
+		return false
+	}
+	if !isRange {
+		return port == low
+	}
+
+	high, err := strconv.Atoi(strings.TrimSpace(highText))
+	if err != nil || high < low {
+		return false
+	}
+	if canon == "ICMP" {
+		// An ICMPv6 range names a request/response type pair, not a span.
+		return port == low || port == high
+	}
+
+	return port >= low && port <= high
+}
+
+// Targets reports whether the visa was granted for traffic to this service:
+// its service-side address is one the service answers on and its protocol and
+// port fall within one of the service's declared endpoints.
+func (s ServiceDescriptor) Targets(v VisaDescriptor) bool {
+	addr, port, ok := v.ServiceSide()
+	if !ok || !s.Hosts(addr) {
+		return false
+	}
+
+	for _, endpoint := range s.ServiceEndpoints() {
+		if endpoint.Matches(v.Proto, port) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // The server formats the trusted-service api name with Rust's Debug.

--- a/zpr-dashboard/internal/dataplane/services_test.go
+++ b/zpr-dashboard/internal/dataplane/services_test.go
@@ -1,0 +1,175 @@
+package dataplane
+
+import "testing"
+
+// svcAddr is the actor address the Targets fixtures answer on.
+const svcAddr = "fd5a:5052:90de::30"
+
+// visaFor builds a visa with the given direction, protocol and ports.
+func visaFor(direction, proto, src, dst string, srcPort, dstPort int) VisaDescriptor {
+	return VisaDescriptor{
+		Direction:  direction,
+		Proto:      proto,
+		SourceAddr: &src,
+		DestAddr:   &dst,
+		SourcePort: &srcPort,
+		DestPort:   &dstPort,
+	}
+}
+
+// TestServiceTargets covers the address, direction, protocol and port rules
+// that decide whether a visa was granted for a service's endpoints.
+func TestServiceTargets(t *testing.T) {
+	peer := "fd5a:5052:90de::40"
+
+	cases := []struct {
+		name      string
+		endpoints string
+		dock      string
+		visa      VisaDescriptor
+		want      bool
+	}{
+		{
+			name:      "forward tcp hit",
+			endpoints: "TCP/443",
+			visa:      visaFor("forward", "TCP", peer, svcAddr, 0, 443),
+			want:      true,
+		},
+		{
+			name:      "reverse tcp hit, service on the source side",
+			endpoints: "TCP/443",
+			visa:      visaFor("reverse", "TCP", svcAddr, peer, 443, 0),
+			want:      true,
+		},
+		{
+			name:      "right address, wrong port",
+			endpoints: "TCP/443",
+			visa:      visaFor("forward", "TCP", peer, svcAddr, 0, 9000),
+			want:      false,
+		},
+		{
+			name:      "right port, wrong protocol",
+			endpoints: "TCP/443",
+			visa:      visaFor("forward", "UDP", peer, svcAddr, 0, 443),
+			want:      false,
+		},
+		{
+			name:      "port inside a declared range",
+			endpoints: "TCP/8000-8080",
+			visa:      visaFor("forward", "TCP", peer, svcAddr, 0, 8042),
+			want:      true,
+		},
+		{
+			name:      "port outside a declared range",
+			endpoints: "TCP/8000-8080",
+			visa:      visaFor("forward", "TCP", peer, svcAddr, 0, 8081),
+			want:      false,
+		},
+		{
+			name:      "endpoint with no port matches any port",
+			endpoints: "TCP/",
+			visa:      visaFor("forward", "TCP", peer, svcAddr, 0, 31337),
+			want:      true,
+		},
+		{
+			name:      "icmp type matches",
+			endpoints: "IPV6_ICMP/128",
+			visa:      visaFor("forward", "ICMP", peer, svcAddr, 128, 0),
+			want:      true,
+		},
+		{
+			name:      "icmp type mismatch",
+			endpoints: "IPV6_ICMP/128",
+			visa:      visaFor("forward", "ICMP", peer, svcAddr, 129, 0),
+			want:      false,
+		},
+		{
+			name:      "icmp range matches its low value",
+			endpoints: "IPV6_ICMP/128-129",
+			visa:      visaFor("forward", "ICMP", peer, svcAddr, 128, 0),
+			want:      true,
+		},
+		{
+			name:      "icmp range matches its high value",
+			endpoints: "IPV6_ICMP/128-129",
+			visa:      visaFor("reverse", "ICMP", svcAddr, peer, 129, 0),
+			want:      true,
+		},
+		{
+			name:      "icmp range excludes an intermediate value",
+			endpoints: "IPV6_ICMP/128-135",
+			visa:      visaFor("forward", "ICMP", peer, svcAddr, 130, 0),
+			want:      false,
+		},
+		{
+			name:      "PROTO_58 spelling normalizes to the visa's ICMP",
+			endpoints: "PROTO_58/128",
+			visa:      visaFor("forward", "ICMP", peer, svcAddr, 128, 0),
+			want:      true,
+		},
+		{
+			name:      "endpoint ICMP is IPv4 and misses an IPv6 visa",
+			endpoints: "ICMP/128",
+			visa:      visaFor("forward", "ICMP", peer, svcAddr, 128, 0),
+			want:      false,
+		},
+		{
+			name:      "endpoint PROTO_1 is IPv4 and misses an IPv6 visa",
+			endpoints: "PROTO_1/128",
+			visa:      visaFor("forward", "ICMP", peer, svcAddr, 128, 0),
+			want:      false,
+		},
+		{
+			name:      "PROTO_6 normalizes to TCP",
+			endpoints: "PROTO_6/443",
+			visa:      visaFor("forward", "TCP", peer, svcAddr, 0, 443),
+			want:      true,
+		},
+		{
+			name:      "PROTO_17 normalizes to UDP",
+			endpoints: "PROTO_17/53",
+			visa:      visaFor("forward", "UDP", peer, svcAddr, 0, 53),
+			want:      true,
+		},
+		{
+			name:      "malformed port fails closed",
+			endpoints: "TCP/https",
+			visa:      visaFor("forward", "TCP", peer, svcAddr, 0, 443),
+			want:      false,
+		},
+		{
+			name:      "reversed range fails closed",
+			endpoints: "TCP/8080-8000",
+			visa:      visaFor("forward", "TCP", peer, svcAddr, 0, 8042),
+			want:      false,
+		},
+		{
+			name:      "dock address hit",
+			endpoints: "TCP/443",
+			dock:      "fd5a:5052:90de::99",
+			visa:      visaFor("forward", "TCP", peer, "fd5a:5052:90de::99", 0, 443),
+			want:      true,
+		},
+		{
+			name:      "visa with no five-tuple",
+			endpoints: "TCP/443",
+			visa:      VisaDescriptor{Direction: "forward", Proto: "N/A"},
+			want:      false,
+		},
+		{
+			name:      "service with no declared endpoints",
+			endpoints: "",
+			visa:      visaFor("forward", "TCP", peer, svcAddr, 0, 443),
+			want:      false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			svc := ServiceDescriptor{ZprAddress: svcAddr, DockZprAddress: c.dock, Endpoints: c.endpoints}
+			if got := svc.Targets(c.visa); got != c.want {
+				t.Errorf("Targets() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/zpr-dashboard/internal/dataplane/visas.go
+++ b/zpr-dashboard/internal/dataplane/visas.go
@@ -48,6 +48,36 @@ func (v VisaDescriptor) Port() (int, bool) {
 	return derefInt(v.DestPort)
 }
 
+// ServiceSide returns the address and port at the service end of the visa: the
+// destination for a forward visa, the source for a reverse one. ok is false
+// when the visa carries no five-tuple (proto "N/A").
+func (v VisaDescriptor) ServiceSide() (addr string, port int, ok bool) {
+	addr, portField := v.Dest(), v.DestPort
+	if v.Direction == "reverse" {
+		addr, portField = v.Source(), v.SourcePort
+	}
+	if v.Proto == "ICMP" {
+		// The icmp type is carried in source_port in both directions.
+		portField = v.SourcePort
+	}
+
+	port, hasPort := derefInt(portField)
+	if addr == "" || !hasPort {
+		return "", 0, false
+	}
+
+	return addr, port, true
+}
+
+// Peer returns the address at the far end from the service.
+func (v VisaDescriptor) Peer() string {
+	if v.Direction == "reverse" {
+		return v.Dest()
+	}
+
+	return v.Source()
+}
+
 func (v VisaDescriptor) ICMP() (icmpType, icmpCode int, ok bool) {
 	if v.Proto != "ICMP" {
 		return 0, 0, false


### PR DESCRIPTION
This was doing visa counts based only on addresses and was ignoring ports/protocols. Now counts visas per service using protocols in the visas.

