### PR TITLE
Ic/vsa2 a pub key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,7 +847,22 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "fiat-crypto 0.3.0",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -1120,7 +1135,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "ed25519",
  "serde",
  "sha2",
@@ -1311,6 +1326,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filedescriptor"
@@ -2186,6 +2207,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 name = "libeval"
 version = "0.15.0"
 dependencies = [
+ "base64",
  "bytes",
  "capnp",
  "enumset",
@@ -5191,6 +5213,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "rand_core 0.10.1",
+ "zeroize",
+]
+
+[[package]]
 name = "x509-parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5349,8 +5382,8 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zpr"
-version = "0.21.0"
-source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.21.0#b212ca1a81464ee0534161fe6c6c8fd27f6a5b80"
+version = "0.22.0"
+source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.21.1#f58b46b7c26f31cba69cc7761b03bd470cbd66ee"
 dependencies = [
  "base64",
  "bytes",
@@ -5366,6 +5399,7 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "url",
+ "x25519-dalek",
  "zerocopy",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,5 @@ serde_with = { version = "3.18.0", default-features = false, features = ["std", 
 thiserror = "2.0.18"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.20"
-zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.21.0", features = ["vsapi", "policy"]}
+zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.21.1", features = ["vsapi", "policy"]}
 

--- a/libeval/Cargo.toml
+++ b/libeval/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 description = "Packet/Actor evaluator library; a component of the ZPR visa service"
 
 [dependencies]
+base64.workspace = true
 bytes.workspace = true
 capnp.workspace = true
 enumset = "1.1.10"

--- a/libeval/src/attribute.rs
+++ b/libeval/src/attribute.rs
@@ -47,6 +47,9 @@ pub mod key {
 
     /// Link cost
     pub const LINK_COST: &str = "link.zpr.cost";
+
+    /// A2A DH Public Key
+    pub const A2A_DH_PUBKEY: &str = "zpr.a2a_dh_pubkey";
 }
 
 #[derive(Debug, Error)]

--- a/libeval/src/lib.rs
+++ b/libeval/src/lib.rs
@@ -8,5 +8,6 @@ pub mod joinpolicy;
 pub mod logging;
 pub mod pio;
 pub mod policy;
+pub mod pubkey;
 pub mod route;
 pub mod visa;

--- a/libeval/src/pubkey.rs
+++ b/libeval/src/pubkey.rs
@@ -1,0 +1,74 @@
+use base64::{Engine as _, engine::general_purpose};
+use thiserror::Error;
+use zpr::vsapi_types::{KeyFormat, PublicKey};
+
+const ZPRKF01_FMT: &str = "ZprKF01";
+
+/// Failures parsing a stored `FMT:BASE64` public key value.
+#[derive(Debug, Error)]
+pub enum PubKeyError {
+    #[error("public key value is not FMT:KEY")]
+    Malformed,
+
+    #[error("unknown public key format: '{0}'")]
+    UnknownFormat(String),
+
+    #[error("public key base64 decode error: {0}")]
+    Base64(#[from] base64::DecodeError),
+}
+
+/// Render pubkeys as FMT:BASE64 for storage in an attribute value.
+pub fn encode_public_key(key: &PublicKey) -> String {
+    let fmt = match key.format {
+        KeyFormat::ZprKF01 => ZPRKF01_FMT,
+    };
+    format!(
+        "{fmt}:{}",
+        general_purpose::STANDARD.encode(&key.public_key)
+    )
+}
+
+/// Parse an attribute value written by encode_public_key().
+pub fn decode_public_key(s: &str) -> Result<PublicKey, PubKeyError> {
+    let (fmt, b64) = s.split_once(':').ok_or(PubKeyError::Malformed)?;
+    let format = match fmt {
+        ZPRKF01_FMT => KeyFormat::ZprKF01,
+        _ => return Err(PubKeyError::UnknownFormat(fmt.to_string())),
+    };
+    Ok(PublicKey {
+        format,
+        public_key: general_purpose::STANDARD.decode(b64)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A key encodes to its format tag plus standard base64, and decodes back
+    /// unchanged.
+    #[test]
+    fn test_public_key_round_trip() {
+        let key_bytes: Vec<u8> = (0..32u8).collect();
+        let encoded = encode_public_key(&PublicKey::new(&key_bytes));
+        assert_eq!(
+            encoded,
+            "ZprKF01:AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="
+        );
+
+        let decoded = decode_public_key(&encoded).expect("should decode");
+        assert!(matches!(decoded.format, KeyFormat::ZprKF01));
+        assert_eq!(decoded.public_key, key_bytes);
+    }
+
+    /// An unrecognized format tag is rejected, which is what keeps a key written
+    /// by a newer VS from being read as a ZprKF01 key.
+    #[test]
+    fn test_decode_public_key_rejects_unknown_format() {
+        let err = decode_public_key("ZprKF99:AAEC").expect_err("should not decode");
+        match err {
+            PubKeyError::UnknownFormat(fmt) => assert_eq!(fmt, "ZprKF99"),
+            other => panic!("expected UnknownFormat, got {other}"),
+        }
+    }
+}

--- a/vs/src/actor_mgr.rs
+++ b/vs/src/actor_mgr.rs
@@ -11,7 +11,7 @@ use std::time::SystemTime;
 use tracing::{debug, info, warn};
 
 use zpr::policy_types::{Scope, ServiceType};
-use zpr::vsapi_types::ServiceDescriptor;
+use zpr::vsapi_types::{PublicKey, ServiceDescriptor};
 
 use crate::assembly::Assembly;
 use crate::config;
@@ -292,6 +292,14 @@ impl ActorMgr {
             Ok(cn) => Ok(cn),
             Err(e) => Err(ServiceError::from(e)),
         }
+    }
+
+    /// Returns actors public key or None if no key is stored for it.
+    pub async fn get_a2a_dh_pubkey_by_zpr_addr(
+        &self,
+        zpra: &IpAddr,
+    ) -> Result<Option<PublicKey>, ServiceError> {
+        Ok(self.actor_db.get_a2a_dh_pubkey_by_zpr_addr(zpra).await?)
     }
 
     pub async fn get_actor_by_cn(&self, cn: &str) -> Result<Option<Actor>, ServiceError> {

--- a/vs/src/connection_control.rs
+++ b/vs/src/connection_control.rs
@@ -30,7 +30,7 @@ use libeval::eval::EvalContext;
 use libeval::policy::Policy;
 
 use zpr::vsapi::v1 as vsapi;
-use zpr::vsapi_types::{AuthBlob, ChallengeAlg, Claim, ConnectRequest, SelfSignedBlob};
+use zpr::vsapi_types::{AuthBlob, ChallengeAlg, Claim, ConnectRequest, PublicKey, SelfSignedBlob};
 
 use crate::assembly::Assembly;
 use crate::auth;
@@ -138,12 +138,17 @@ impl ConnectionControl {
         challenge_response: &[u8],
         remote: SocketAddr,
         node_req_addr: IpAddr,
+        a2a_dh_pubkey: Option<&PublicKey>,
     ) -> Result<Actor, ServiceError> {
         // Massage this node authentication request into something that looks like a generic
         // adapter request.
 
         let mut authd_claims: Vec<Attribute> = Vec::new();
         authd_claims.push(Attribute::builder(key::SUBSTRATE_ADDR).value(remote.to_string()));
+        match a2a_dh_pubkey.and_then(a2a_dh_pubkey_claim) {
+            Some(attr) => authd_claims.push(attr),
+            None => warn!(target: CC, "node {cn} sent no usable A2A DH public key"),
+        }
 
         let mut unauthd_claims: Vec<Attribute> = Vec::new();
         unauthd_claims.push(Attribute::builder(key::ZPR_ADDR).value(node_req_addr.to_string()));
@@ -201,6 +206,10 @@ impl ConnectionControl {
         authd_claims.push(Attribute::builder(key::CONNECT_VIA).value(connect_via.to_string()));
         authd_claims
             .push(Attribute::builder(key::SUBSTRATE_ADDR).value(req.substrate_addr.to_string()));
+        match a2a_dh_pubkey_claim(&req.a2a_dh_public_key) {
+            Some(attr) => authd_claims.push(attr),
+            None => warn!(target: CC, "adapter via {connect_via} sent no usable A2A DH public key"),
+        }
 
         let actor = match &req.blobs[0] {
             AuthBlob::SS(ssb) => match ssb.alg {
@@ -619,6 +628,13 @@ fn scrub_adapter_claims(claims: Vec<Claim>) -> Result<Vec<Attribute>, ServiceErr
     Ok(scrubbed_claims)
 }
 
+/// The A2A DH public key as an attribute claim, or None if it is not a usable X25519 key.
+fn a2a_dh_pubkey_claim(key: &PublicKey) -> Option<Attribute> {
+    (key.public_key.len() == 32).then(|| {
+        Attribute::builder(key::A2A_DH_PUBKEY).value(libeval::pubkey::encode_public_key(key))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -851,6 +867,7 @@ mod tests {
                 &[],
                 "127.0.0.1:1234".parse().unwrap(),
                 "fd5a:5052::1".parse().unwrap(),
+                None,
             )
             .await;
         assert!(matches!(result, Err(ServiceError::AuthenticationFailed(_))));
@@ -880,6 +897,7 @@ mod tests {
                 b"not-a-valid-rsa-sig",
                 "127.0.0.1:1234".parse().unwrap(),
                 "fd5a:5052::1".parse().unwrap(),
+                None,
             )
             .await;
         assert!(matches!(result, Err(ServiceError::AuthenticationFailed(_))));
@@ -907,6 +925,7 @@ mod tests {
                 &bad_sig,
                 "127.0.0.1:1234".parse().unwrap(),
                 "fd5a:5052::1".parse().unwrap(),
+                None,
             )
             .await;
         assert!(matches!(result, Err(ServiceError::AuthenticationFailed(_))));
@@ -974,6 +993,7 @@ mod tests {
                 &sig,
                 "127.0.0.1:1234".parse().unwrap(),
                 "fd5a:5052::1".parse().unwrap(),
+                None,
             )
             .await;
         assert!(
@@ -1006,6 +1026,7 @@ mod tests {
                 &sig,
                 "127.0.0.1:1234".parse().unwrap(),
                 "fd5a:5052::1".parse().unwrap(),
+                None,
             )
             .await
             .expect("authentication should succeed");
@@ -1031,5 +1052,12 @@ mod tests {
         // Due to libeval not actually paying attention to what attributes are part of "identity",
         // it will add the CN claim.
         assert_eq!(identity[1], cn);
+    }
+
+    /// A 32-byte X25519 key becomes a claim, any other length does not.
+    #[test]
+    fn test_a2a_dh_pubkey_claim_length_gate() {
+        assert!(a2a_dh_pubkey_claim(&PublicKey::new(&[7u8; 32])).is_some());
+        assert!(a2a_dh_pubkey_claim(&PublicKey::new(&[7u8; 31])).is_none());
     }
 }

--- a/vs/src/db/actor.rs
+++ b/vs/src/db/actor.rs
@@ -15,10 +15,12 @@ use dashmap::DashMap;
 use libeval::actor::Actor;
 use libeval::attribute::Attribute;
 use libeval::attribute::key;
+use libeval::pubkey::decode_public_key;
 use std::collections::HashSet;
 use std::net::IpAddr;
 use std::sync::Arc;
 use tracing::{debug, error, warn};
+use zpr::vsapi_types::PublicKey;
 
 use crate::db::{DbConnection, DbOp, KeyString, ZAddr, gen_timestamp};
 use crate::error::StoreError;
@@ -355,6 +357,27 @@ impl ActorRepo {
             }
         }
         Ok(attrs)
+    }
+
+    /// Load and decode the actor's A2A DH public key. Returns Ok(None) when no key is stored.
+    pub async fn get_a2a_dh_pubkey_by_zpr_addr(
+        &self,
+        zpra: &IpAddr,
+    ) -> Result<Option<PublicKey>, StoreError> {
+        let attrs = self.get_actor_attrs(zpra, &[key::A2A_DH_PUBKEY]).await?;
+        let Some(attr) = attrs.first() else {
+            return Ok(None);
+        };
+        let value = attr
+            .get_single_value()
+            .map_err(|e| StoreError::InvalidData(format!("actor {zpra}: {e}")))?;
+        let pubkey = decode_public_key(value).map_err(|e| {
+            StoreError::InvalidData(format!(
+                "invalid {} for actor {zpra}: {e}",
+                key::A2A_DH_PUBKEY
+            ))
+        })?;
+        Ok(Some(pubkey))
     }
 
     /// Get a list of services offered by the actor.
@@ -780,6 +803,73 @@ mod test {
         assert_eq!(attrs[0].get_single_value().unwrap(), "actor-attrs");
         assert_eq!(attrs[1].get_key(), key::ROLE);
         assert_eq!(attrs[1].get_single_value().unwrap(), ROLE_ADAPTER);
+    }
+
+    /// An actor that never sent a key reads back as absent rather than as an error.
+    #[tokio::test]
+    async fn test_get_a2a_dh_pubkey_none_when_absent() {
+        let db = Arc::new(FakeDb::new());
+        let repo = ActorRepo::new(db);
+        let actor = make_actor_for_pubkey_test("fd5a:5052::60", "no-key", None);
+        let zpr_addr: IpAddr = "fd5a:5052::60".parse().unwrap();
+
+        repo.add_actor(&actor).await.unwrap();
+
+        let pubkey = repo.get_a2a_dh_pubkey_by_zpr_addr(&zpr_addr).await.unwrap();
+        assert!(pubkey.is_none());
+    }
+
+    /// A stored FMT:BASE64 value decodes back to the raw 32 key bytes.
+    #[tokio::test]
+    async fn test_get_a2a_dh_pubkey_decodes_stored_value() {
+        let db = Arc::new(FakeDb::new());
+        let repo = ActorRepo::new(db);
+        let actor = make_actor_for_pubkey_test(
+            "fd5a:5052::61",
+            "keyed",
+            Some("ZprKF01:AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="),
+        );
+        let zpr_addr: IpAddr = "fd5a:5052::61".parse().unwrap();
+
+        repo.add_actor(&actor).await.unwrap();
+
+        let pubkey = repo
+            .get_a2a_dh_pubkey_by_zpr_addr(&zpr_addr)
+            .await
+            .unwrap()
+            .expect("actor has a stored key");
+        assert_eq!(pubkey.public_key, (0..32u8).collect::<Vec<u8>>());
+    }
+
+    #[tokio::test]
+    async fn test_get_a2a_dh_pubkey_rejects_unknown_format() {
+        let db = Arc::new(FakeDb::new());
+        let repo = ActorRepo::new(db);
+        let actor = make_actor_for_pubkey_test("fd5a:5052::62", "bad-key", Some("ZprKF99:AAEC"));
+        let zpr_addr: IpAddr = "fd5a:5052::62".parse().unwrap();
+
+        repo.add_actor(&actor).await.unwrap();
+
+        let err = repo
+            .get_a2a_dh_pubkey_by_zpr_addr(&zpr_addr)
+            .await
+            .unwrap_err();
+        match err {
+            StoreError::InvalidData(_) => {}
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    fn make_actor_for_pubkey_test(zpr_addr: &str, cn: &str, pubkey_value: Option<&str>) -> Actor {
+        let mut attrs = vec![
+            (key::ROLE, ROLE_ADAPTER),
+            (key::CN, cn),
+            (key::ZPR_ADDR, zpr_addr),
+        ];
+        if let Some(value) = pubkey_value {
+            attrs.push((key::A2A_DH_PUBKEY, value));
+        }
+        make_actor_defexp(&attrs)
     }
 
     #[tokio::test]

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -1534,7 +1534,17 @@ mod tests {
 
         let visawmd = asm
             .visa_mgr
-            .create_visa(&asm, &src, &pdesc, &hit, &route, "", 0, 0)
+            .create_visa(
+                &asm,
+                &src,
+                &pdesc,
+                &hit,
+                &route,
+                "",
+                0,
+                0,
+                SystemTime::now() + config::MAX_VISA_LIFETIME,
+            )
             .await
             .unwrap();
 
@@ -1562,7 +1572,17 @@ mod tests {
 
         let visawmd = asm
             .visa_mgr
-            .create_visa(&asm, &src, &pdesc, &hit, &route, "", 0, 0)
+            .create_visa(
+                &asm,
+                &src,
+                &pdesc,
+                &hit,
+                &route,
+                "",
+                0,
+                0,
+                SystemTime::now() + config::MAX_VISA_LIFETIME,
+            )
             .await
             .unwrap();
 

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -417,11 +417,14 @@ impl VisaMgr {
             metadata.signal_msgs.push(sig.message.clone());
         }
 
+        let ingress_key = a2a_dh_pubkey_bytes(asm, &pdesc.five_tuple.source_addr).await?;
+        let egress_key = a2a_dh_pubkey_bytes(asm, &pdesc.five_tuple.dest_addr).await?;
+
         let pep = DockPep {
             pep,
             source_addr: pdesc.five_tuple.source_addr.clone(),
             dest_addr: pdesc.five_tuple.dest_addr.clone(),
-            session_key: KeySet::new("secret".as_bytes(), "secret".as_bytes()),
+            session_key: KeySet::new(&ingress_key, &egress_key),
         };
 
         let visa = Visa {
@@ -798,6 +801,18 @@ impl VisaMgr {
             Ok(md) => Ok(Some(md)),
             Err(StoreError::NotFound(_)) => Ok(None),
             Err(e) => Err(ServiceError::from(e)),
+        }
+    }
+}
+
+/// Gets public key as bytes.
+/// Returns empty bytes when the actor's key is not found.
+async fn a2a_dh_pubkey_bytes(asm: &Assembly, addr: &IpAddr) -> Result<Vec<u8>, ServiceError> {
+    match asm.actor_mgr.get_a2a_dh_pubkey_by_zpr_addr(addr).await? {
+        Some(key) => Ok(key.public_key),
+        None => {
+            debug!(target: VISA, "actor {addr} sent no A2A DH public key; visa session key will be empty");
+            Ok(Vec::new())
         }
     }
 }
@@ -1438,6 +1453,92 @@ mod tests {
         // The egress node dst is not the target here, so this just confirms the visa
         // was created for the right endpoints.
         let _ = dst;
+    }
+
+    // --- A2A DH session key tests ---
+    // create_visa reads both adapters' stored zpr.a2a_dh_pubkey attributes and carries
+    // them in the DockPep session key.
+
+    use libeval::attribute::{Attribute, key};
+    use libeval::pubkey::encode_public_key;
+    use zpr::vsapi_types::PublicKey;
+
+    const SRC_ADAPTER: &str = "fd5a:5052:1234::a100";
+    const DST_ADAPTER: &str = "fd5a:5052:1234::a200";
+
+    async fn add_keyed_adapter(asm: &Assembly, zpr_addr: &str, cn: &str, key_bytes: &[u8]) {
+        let mut actor = make_adapter_actor_defexp(zpr_addr, cn);
+        actor
+            .add_attribute(
+                Attribute::builder(key::A2A_DH_PUBKEY)
+                    .value(encode_public_key(&PublicKey::new(key_bytes))),
+            )
+            .unwrap();
+        asm.actor_mgr
+            .hack_add_adapter_no_node(&actor)
+            .await
+            .unwrap();
+    }
+
+    /// Both adapters' keys land in the session key, source as ingress and dest as egress.
+    #[tokio::test]
+    async fn test_create_visa_session_key_carries_adapter_pubkeys() {
+        let asm = make_multihop_assembly().await;
+        let src: IpAddr = MH_SRC.parse().unwrap();
+        let dst: IpAddr = MH_DST.parse().unwrap();
+
+        let src_key: Vec<u8> = (0..32u8).collect();
+        let dst_key: Vec<u8> = (32..64u8).collect();
+        add_keyed_adapter(&asm, SRC_ADAPTER, "src-adapter", &src_key).await;
+        add_keyed_adapter(&asm, DST_ADAPTER, "dst-adapter", &dst_key).await;
+
+        let pdesc = PacketDesc::new_tcp_with_addr(
+            SRC_ADAPTER.parse().unwrap(),
+            DST_ADAPTER.parse().unwrap(),
+            12345,
+            80,
+        )
+        .unwrap();
+        let hit = Hit::new_no_signal(0, Direction::Forward);
+        let route = asm.topo_mgr.get_best_route(&src, &dst).unwrap();
+
+        let visawmd = asm
+            .visa_mgr
+            .create_visa(&asm, &src, &pdesc, &hit, &route, "", 0, 0)
+            .await
+            .unwrap();
+
+        let session_key = &visawmd.visa.dock_pep.as_ref().unwrap().session_key;
+        assert_eq!(session_key.ingress_key, src_key);
+        assert_eq!(session_key.egress_key, dst_key);
+    }
+
+    /// Endpoints with no stored key produce an empty session key rather than failing the visas.
+    #[tokio::test]
+    async fn test_create_visa_session_key_empty_without_pubkeys() {
+        let asm = make_multihop_assembly().await;
+        let src: IpAddr = MH_SRC.parse().unwrap();
+        let dst: IpAddr = MH_DST.parse().unwrap();
+
+        let pdesc = PacketDesc::new_tcp_with_addr(
+            SRC_ADAPTER.parse().unwrap(),
+            DST_ADAPTER.parse().unwrap(),
+            12345,
+            80,
+        )
+        .unwrap();
+        let hit = Hit::new_no_signal(0, Direction::Forward);
+        let route = asm.topo_mgr.get_best_route(&src, &dst).unwrap();
+
+        let visawmd = asm
+            .visa_mgr
+            .create_visa(&asm, &src, &pdesc, &hit, &route, "", 0, 0)
+            .await
+            .unwrap();
+
+        let session_key = &visawmd.visa.dock_pep.as_ref().unwrap().session_key;
+        assert!(session_key.ingress_key.is_empty());
+        assert!(session_key.egress_key.is_empty());
     }
 
     // --- Phase 2 manager tests ---

--- a/vs/src/vsapi_worker.rs
+++ b/vs/src/vsapi_worker.rs
@@ -14,8 +14,9 @@ use tracing::{debug, error, info, trace, warn};
 use ::zpr::vsapi::v1 as vsapi;
 use libeval::actor::Actor;
 use libeval::attribute::{Attribute, key};
+use libeval::pubkey::encode_public_key;
 use zpr::vsapi_types::{
-    ConnectRequest, ConnectType, Connection, PacketDesc, Param, ParamValue, SockAddr,
+    ConnectRequest, ConnectType, Connection, PacketDesc, Param, ParamValue, PublicKey, SockAddr,
     VSConnectRequest, VisaOp, pname,
 };
 use zpr::write_to::WriteTo;
@@ -153,6 +154,7 @@ struct VisaServiceImpl {
 
 #[allow(dead_code)]
 struct VSGateImpl {
+    a2a_dh_pubkey: Option<String>,
     asm: Arc<Assembly>,
     remote: SocketAddr,
     remote_cn: String,
@@ -179,6 +181,7 @@ impl VSGateImpl {
         remote: SocketAddr,
         remote_cn: String,
         req_zpr_addr: IpAddr,
+        a2a_dh_pubkey: Option<String>,
         reconnect: bool,
     ) -> Self {
         VSGateImpl {
@@ -187,6 +190,7 @@ impl VSGateImpl {
             remote_cn,
             challenge_data: Cell::new([0u8; 32]),
             req_zpr_addr,
+            a2a_dh_pubkey,
             reconnect,
         }
     }
@@ -321,13 +325,17 @@ fn ipaddr_from_capnp(addr: vsapi::ip_addr::Reader) -> Result<std::net::IpAddr, c
 }
 
 impl VisaServiceImpl {
-    /// Helper for the connect routine -- returns the one connect param we require: zpr_addr.
-    /// Older code used to pass in the AAA_PREFIX here but now we send that over the
-    /// VSS.
+    /// Helper for the connect routine -- returns the one connect param we require, zpr_addr,
+    /// plus the node's A2A DH public key if it sent one. Older code used to pass in the
+    /// AAA_PREFIX here but now we send that over the VSS.
     ///
     /// During this transition period we will error out if node passes use AAA_PREFIX.
-    fn parse_my_connect_params(&self, params: &[Param]) -> Result<IpAddr, ServiceError> {
+    fn parse_my_connect_params(
+        &self,
+        params: &[Param],
+    ) -> Result<(IpAddr, Option<String>), ServiceError> {
         let mut node_zpr_addr = None;
+        let mut a2a_dh_pubkey = None;
 
         for pp in params {
             match pp.name.as_str() {
@@ -348,6 +356,18 @@ impl VisaServiceImpl {
                     )));
                 }
 
+                pname::A2A_DH_PUBKEY => match &pp.value {
+                    ParamValue::X25519PubKey(pubkey) => {
+                        a2a_dh_pubkey = Some(encode_public_key(&PublicKey::new(pubkey.as_bytes())))
+                    }
+                    _ => {
+                        return Err(ServiceError::Param(format!(
+                            "param {} has invalid type",
+                            pname::A2A_DH_PUBKEY
+                        )));
+                    }
+                },
+
                 name => info!(target: API, "ignored connect param {}", name),
             }
         }
@@ -355,7 +375,7 @@ impl VisaServiceImpl {
         if node_zpr_addr.is_none() {
             return Err(ServiceError::Param("ZPR_ADDR param missing".into()));
         }
-        Ok(node_zpr_addr.unwrap())
+        Ok((node_zpr_addr.unwrap(), a2a_dh_pubkey))
     }
 
     /// Helper to handle errors during connect call.
@@ -424,8 +444,8 @@ impl vsapi::visa_service::Server for VisaServiceImpl {
             }
         };
 
-        let node_zpr_addr = match self.parse_my_connect_params(&parsed_params) {
-            Ok(addr) => addr,
+        let (node_zpr_addr, a2a_dh_pubkey) = match self.parse_my_connect_params(&parsed_params) {
+            Ok(addr_and_key) => addr_and_key,
             Err(e) => {
                 return self.ok_with_connect_error(
                     results,
@@ -484,6 +504,7 @@ impl vsapi::visa_service::Server for VisaServiceImpl {
             self.remote,
             vs_connect_request.cn,
             node_zpr_addr,
+            a2a_dh_pubkey,
             vs_connect_request.ctype == ConnectType::Reconnect,
         ));
 
@@ -677,6 +698,13 @@ impl vsapi::v_s_gate::Server for VSGateImpl {
                 );
             }
         };
+
+        match &self.a2a_dh_pubkey {
+            Some(encoded_key) => node_actor
+                .add_attribute(Attribute::builder(key::A2A_DH_PUBKEY).value(encoded_key))
+                .unwrap(),
+            None => warn!(target: API, "node {} sent no A2A DH public key", self.remote_cn),
+        }
 
         // At this point we may have taken an IP addr and assigned it to the actor.
         let mut undo = AuthenticateUndo::default();
@@ -973,10 +1001,17 @@ impl vsapi::v_s_handle::Server for VSHandleImpl {
             capnp::Error::failed(format!("failed to parse ConnectionRequest: {}", e))
         })?;
 
+        // PublicKey::try_from does not check length. Store nothing unless it is a real X25519 key.
+        let key_len = creq.a2a_dh_public_key.public_key.len();
+        let encoded_pubkey = if key_len == 32 {
+            Some(encode_public_key(&creq.a2a_dh_public_key))
+        } else {
+            None
+        };
+
         let connect_via = self.node.get_zpr_addr().unwrap();
         self.update_last_seen_time(connect_via).await;
-
-        let actor = match self
+        let mut actor = match self
             .asm
             .cc
             .authenticate_adapter_or_node(self.asm.clone(), creq, connect_via)
@@ -995,6 +1030,17 @@ impl vsapi::v_s_handle::Server for VSHandleImpl {
                 return Ok(());
             }
         };
+
+        match encoded_pubkey {
+            Some(key) => actor
+                .add_attribute(Attribute::builder(key::A2A_DH_PUBKEY).value(key))
+                .unwrap(),
+            None => warn!(
+                target: API,
+                "adapter {:?} sent no usable A2A DH public key ({key_len} bytes)",
+                actor.get_cn(),
+            ),
+        }
 
         let actor_addr = actor.get_zpr_addr().unwrap().clone(); // MUST have an addr by now.
 

--- a/vs/src/vsapi_worker.rs
+++ b/vs/src/vsapi_worker.rs
@@ -153,7 +153,7 @@ struct VisaServiceImpl {
 
 #[allow(dead_code)]
 struct VSGateImpl {
-    a2a_dh_pubkey: Option<String>,
+    a2a_dh_pubkey: Option<PublicKey>,
     asm: Arc<Assembly>,
     remote: SocketAddr,
     remote_cn: String,
@@ -180,7 +180,7 @@ impl VSGateImpl {
         remote: SocketAddr,
         remote_cn: String,
         req_zpr_addr: IpAddr,
-        a2a_dh_pubkey: Option<String>,
+        a2a_dh_pubkey: Option<PublicKey>,
         reconnect: bool,
     ) -> Self {
         VSGateImpl {
@@ -295,16 +295,6 @@ fn write_error(bldr: &mut vsapi::error::Builder, code: vsapi::ErrorCode, message
     bldr.set_retry_in(0);
 }
 
-/// Helper for encoding an A2A DH public key for storage as an attribute, or None if it is not a
-/// usable X25519 key.
-fn encode_a2a_dh_pubkey(key: &PublicKey) -> Option<String> {
-    if key.public_key.len() == 32 {
-        Some(libeval::pubkey::encode_public_key(key))
-    } else {
-        None
-    }
-}
-
 /// Convert a vsapi schema IpAddr into a rust ip address.
 fn ipaddr_from_capnp(addr: vsapi::ip_addr::Reader) -> Result<std::net::IpAddr, capnp::Error> {
     match addr.which()? {
@@ -342,7 +332,7 @@ impl VisaServiceImpl {
     fn parse_my_connect_params(
         &self,
         params: &[Param],
-    ) -> Result<(IpAddr, Option<String>), ServiceError> {
+    ) -> Result<(IpAddr, Option<PublicKey>), ServiceError> {
         let mut node_zpr_addr = None;
         let mut a2a_dh_pubkey = None;
 
@@ -367,7 +357,7 @@ impl VisaServiceImpl {
 
                 pname::A2A_DH_PUBKEY => match &pp.value {
                     ParamValue::X25519PubKey(pubkey) => {
-                        a2a_dh_pubkey = encode_a2a_dh_pubkey(&PublicKey::new(pubkey.as_bytes()));
+                        a2a_dh_pubkey = Some(PublicKey::new(pubkey.as_bytes()));
                     }
                     _ => {
                         return Err(ServiceError::Param(format!(
@@ -686,6 +676,7 @@ impl vsapi::v_s_gate::Server for VSGateImpl {
                 challenge_response,
                 self.remote,
                 self.req_zpr_addr,
+                self.a2a_dh_pubkey.as_ref(),
             )
             .await
         {
@@ -707,13 +698,6 @@ impl vsapi::v_s_gate::Server for VSGateImpl {
                 );
             }
         };
-
-        match &self.a2a_dh_pubkey {
-            Some(encoded_key) => node_actor
-                .add_attribute(Attribute::builder(key::A2A_DH_PUBKEY).value(encoded_key))
-                .unwrap(),
-            None => warn!(target: API, "node {} sent no A2A DH public key", self.remote_cn),
-        }
 
         // At this point we may have taken an IP addr and assigned it to the actor.
         let mut undo = AuthenticateUndo::default();
@@ -1010,12 +994,9 @@ impl vsapi::v_s_handle::Server for VSHandleImpl {
             capnp::Error::failed(format!("failed to parse ConnectionRequest: {}", e))
         })?;
 
-        let key_len = creq.a2a_dh_public_key.public_key.len();
-        let encoded_pubkey = encode_a2a_dh_pubkey(&creq.a2a_dh_public_key);
-
         let connect_via = self.node.get_zpr_addr().unwrap();
         self.update_last_seen_time(connect_via).await;
-        let mut actor = match self
+        let actor = match self
             .asm
             .cc
             .authenticate_adapter_or_node(self.asm.clone(), creq, connect_via)
@@ -1034,17 +1015,6 @@ impl vsapi::v_s_handle::Server for VSHandleImpl {
                 return Ok(());
             }
         };
-
-        match encoded_pubkey {
-            Some(key) => actor
-                .add_attribute(Attribute::builder(key::A2A_DH_PUBKEY).value(key))
-                .unwrap(),
-            None => warn!(
-                target: API,
-                "adapter {:?} sent no usable A2A DH public key ({key_len} bytes)",
-                actor.get_cn(),
-            ),
-        }
 
         let actor_addr = actor.get_zpr_addr().unwrap().clone(); // MUST have an addr by now.
 

--- a/vs/src/vsapi_worker.rs
+++ b/vs/src/vsapi_worker.rs
@@ -14,7 +14,6 @@ use tracing::{debug, error, info, trace, warn};
 use ::zpr::vsapi::v1 as vsapi;
 use libeval::actor::Actor;
 use libeval::attribute::{Attribute, key};
-use libeval::pubkey::encode_public_key;
 use zpr::vsapi_types::{
     ConnectRequest, ConnectType, Connection, PacketDesc, Param, ParamValue, PublicKey, SockAddr,
     VSConnectRequest, VisaOp, pname,
@@ -296,6 +295,16 @@ fn write_error(bldr: &mut vsapi::error::Builder, code: vsapi::ErrorCode, message
     bldr.set_retry_in(0);
 }
 
+/// Helper for encoding an A2A DH public key for storage as an attribute, or None if it is not a
+/// usable X25519 key.
+fn encode_a2a_dh_pubkey(key: &PublicKey) -> Option<String> {
+    if key.public_key.len() == 32 {
+        Some(libeval::pubkey::encode_public_key(key))
+    } else {
+        None
+    }
+}
+
 /// Convert a vsapi schema IpAddr into a rust ip address.
 fn ipaddr_from_capnp(addr: vsapi::ip_addr::Reader) -> Result<std::net::IpAddr, capnp::Error> {
     match addr.which()? {
@@ -358,7 +367,7 @@ impl VisaServiceImpl {
 
                 pname::A2A_DH_PUBKEY => match &pp.value {
                     ParamValue::X25519PubKey(pubkey) => {
-                        a2a_dh_pubkey = Some(encode_public_key(&PublicKey::new(pubkey.as_bytes())))
+                        a2a_dh_pubkey = encode_a2a_dh_pubkey(&PublicKey::new(pubkey.as_bytes()));
                     }
                     _ => {
                         return Err(ServiceError::Param(format!(
@@ -1001,13 +1010,8 @@ impl vsapi::v_s_handle::Server for VSHandleImpl {
             capnp::Error::failed(format!("failed to parse ConnectionRequest: {}", e))
         })?;
 
-        // PublicKey::try_from does not check length. Store nothing unless it is a real X25519 key.
         let key_len = creq.a2a_dh_public_key.public_key.len();
-        let encoded_pubkey = if key_len == 32 {
-            Some(encode_public_key(&creq.a2a_dh_public_key))
-        } else {
-            None
-        };
+        let encoded_pubkey = encode_a2a_dh_pubkey(&creq.a2a_dh_public_key);
 
         let connect_via = self.node.get_zpr_addr().unwrap();
         self.update_last_seen_time(connect_via).await;


### PR DESCRIPTION
Tests 9, 10 and 11 of adding A2A public keys. Three commits based on the steps from Chris.

Step 9. Added a pubkey module in libeval with encode_public_key/decode_public_key which serialize a PublicKey as FMT:BASE64 for storage in an attribute value. Added the zpr.a2a_dh_pubkey attribute key. Also bumped the zpr dep to v0.21.1 to pick up the PublicKey and Param changes from steps 5 and 7.

Step 10: Receiving the keys in vsapi_worker. Adapters come in through authorize_connect off the ConnectRequest and nodes are through the new A2A_DH_PUBKEY connect param. Parse_my_connect_params now returns the pubkey alongside zpr_addr and VSGateImpl holds onto until authenticate is called. Both sides add the attribute before the actor gets persisted. ConnectRequest carries a zero length key when the adapter didn't send one and PublicKey::try_from doesn't check the length, so the adapter side only stores the attribute if the key is 32 bytes. That way a missing key is an absent attribute rather than an empty one. The node side doesn't need that check since a bad length param is already rejected in zpr-common. 

Step 11. create_visa now looks up both adapters' zpr.a2a_dh_pubkey and fills them into the DockPep session_key, source into ingress_key and dest into egress_key. Added get_a2a_dh_pubkey_by_zpr_addr on ActorRepo which does the decode, and a passthrough on ActorMgr. If an actor has no key stored the session key is just empty, since KeySet has no way to say absent.

One thing to note when working through steps 1-11 so far is that earlier names have differed pubkey vs pub_key. Chris mentioned to default to one so I decided on pubkey. Once all functionality is done I am going to go back through to fix any stranded differences