### PR TITLE
Mk/topovisas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "admin-api-types"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2205,7 +2205,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libeval"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bytes",
  "capnp",
@@ -4515,7 +4515,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vs"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "admin-api-types",
  "arc-swap",
@@ -4569,7 +4569,7 @@ dependencies = [
 
 [[package]]
 name = "vs-admin"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "admin-api-types",
  "base64",
@@ -5404,7 +5404,7 @@ dependencies = [
 
 [[package]]
 name = "zpt"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bytes",
  "capnp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,7 +847,22 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "fiat-crypto 0.3.0",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -1120,7 +1135,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "ed25519",
  "serde",
  "sha2",
@@ -1311,6 +1326,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filedescriptor"
@@ -5191,6 +5212,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "rand_core 0.10.1",
+ "zeroize",
+]
+
+[[package]]
 name = "x509-parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5349,8 +5381,8 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zpr"
-version = "0.21.0"
-source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.21.0#b212ca1a81464ee0534161fe6c6c8fd27f6a5b80"
+version = "0.22.1"
+source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.22.1#017b7b5881dc934fce1a374cf8a4bfc32e7df7ba"
 dependencies = [
  "base64",
  "bytes",
@@ -5366,6 +5398,7 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "url",
+ "x25519-dalek",
  "zerocopy",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 members = ["vs", "libeval", "zpt", "vs-admin", "admin-api-types"]
 
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,5 @@ serde_with = { version = "3.18.0", default-features = false, features = ["std", 
 thiserror = "2.0.18"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.20"
-zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.21.0", features = ["vsapi", "policy"]}
+zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.22.1", features = ["vsapi", "policy"]}
 

--- a/vs/src/actor_mgr.rs
+++ b/vs/src/actor_mgr.rs
@@ -332,13 +332,19 @@ impl ActorMgr {
             actor.get_zpr_addr().copied()
         } else {
             if let Some(actor_addr) = actor.get_zpr_addr() {
-                self.connection_table
-                    .get(actor_addr)
-                    .map(|entry| *entry.value())
+                self.get_docking_node_for_adapter(actor_addr)
             } else {
                 None
             }
         }
+    }
+
+    /// Docking node of an adapter identified by its ZPR address alone -- used where we
+    /// have the address but no actor, e.g. the visa service's own adapter address.
+    pub fn get_docking_node_for_adapter(&self, adapter_addr: &IpAddr) -> Option<IpAddr> {
+        self.connection_table
+            .get(adapter_addr)
+            .map(|entry| *entry.value())
     }
 
     /// Register the docking node for an AAA actor. Called on the request side when an

--- a/vs/src/connection_control.rs
+++ b/vs/src/connection_control.rs
@@ -37,7 +37,6 @@ use crate::auth;
 use crate::config;
 use crate::error::ServiceError;
 use crate::logging::targets::CC;
-use crate::net_mgr;
 
 // TODO: move to libeval
 const CLASS_DEVICE: &str = "device";
@@ -130,6 +129,12 @@ impl ConnectionControl {
     ///
     /// See https://github.com/org-zpr/zpr-visaservice/issues/205
     ///
+    /// The `remote` arg is the TCP peer address of the node.  So it will be a ZPR address and an
+    /// ephemeral socket. Not very useful.  Originally this was supposed to be a substrate address
+    /// but we are not yet told that.
+    ///
+    /// See https://github.com/org-zpr/zpr-visaservice/issues/299
+    ///
     pub async fn authenticate_node(
         &self,
         asm: Arc<Assembly>,
@@ -145,21 +150,17 @@ impl ConnectionControl {
 
         let mut authd_claims: Vec<Attribute> = Vec::new();
 
-        // `remote` is the VSAPI TCP peer, which is the node's substrate address only when the
-        // node connected over the substrate. A node that joined over a link reaches us from
-        // its ZPR address, so take its substrate from the resolved topology instead.
-        //
-        // TODO: May want a node to tell us this.
-        let substrate_addr = if net_mgr::is_zpr_addr(&remote.ip()) {
-            match substrate_addr_from_topology(&asm, &node_req_addr) {
-                Some(sa) => sa,
-                None => {
-                    warn!(target: CC, "node {cn} reached VSAPI over ZPR from {remote} but policy topology gives no substrate address for {node_req_addr}: recording the ZPR address instead");
-                    remote
-                }
+        // Policy might contain the real substrate address.
+        // Otherwise we just use the peer address. Not ideal, but doesn't matter yet since no one is actually
+        // using the SUBSTRATE_ADDR property yet -- BUT code later (db/node.rs) requires that this property
+        // is set.
+        // See: https://github.com/org-zpr/zpr-visaservice/issues/299
+        let substrate_addr = match substrate_addr_from_topology(&asm, &node_req_addr) {
+            Some(sa) => sa,
+            None => {
+                warn!(target: CC, "node {cn} has no substrate address in policy - using peer address {remote}");
+                remote
             }
-        } else {
-            remote
         };
         authd_claims
             .push(Attribute::builder(key::SUBSTRATE_ADDR).value(substrate_addr.to_string()));

--- a/vs/src/connection_control.rs
+++ b/vs/src/connection_control.rs
@@ -37,6 +37,7 @@ use crate::auth;
 use crate::config;
 use crate::error::ServiceError;
 use crate::logging::targets::CC;
+use crate::net_mgr;
 
 // TODO: move to libeval
 const CLASS_DEVICE: &str = "device";
@@ -143,7 +144,25 @@ impl ConnectionControl {
         // adapter request.
 
         let mut authd_claims: Vec<Attribute> = Vec::new();
-        authd_claims.push(Attribute::builder(key::SUBSTRATE_ADDR).value(remote.to_string()));
+
+        // `remote` is the VSAPI TCP peer, which is the node's substrate address only when the
+        // node connected over the substrate. A node that joined over a link reaches us from
+        // its ZPR address, so take its substrate from the resolved topology instead.
+        //
+        // TODO: May want a node to tell us this.
+        let substrate_addr = if net_mgr::is_zpr_addr(&remote.ip()) {
+            match substrate_addr_from_topology(&asm, &node_req_addr) {
+                Some(sa) => sa,
+                None => {
+                    warn!(target: CC, "node {cn} reached VSAPI over ZPR from {remote} but policy topology gives no substrate address for {node_req_addr}: recording the ZPR address instead");
+                    remote
+                }
+            }
+        } else {
+            remote
+        };
+        authd_claims
+            .push(Attribute::builder(key::SUBSTRATE_ADDR).value(substrate_addr.to_string()));
 
         let mut unauthd_claims: Vec<Attribute> = Vec::new();
         unauthd_claims.push(Attribute::builder(key::ZPR_ADDR).value(node_req_addr.to_string()));
@@ -540,6 +559,29 @@ impl ConnectionControl {
     }
 }
 
+/// A node's own substrate address, taken from the resolved topology: for a peer `P` sharing
+/// a link with `node_addr`, `P`'s resolved link points back at `node_addr`'s substrate. That
+/// value is authoritative (it is what policy declares and what every peer dials) and is
+/// already DNS-resolved, so it parses as a `SocketAddr`.
+///
+/// Returns `None` when policy declares no peering for the node, or none of its links appear
+/// in the resolved topology -- both mean policy cannot tell us.
+///
+/// Does not support multi-homed nodes!
+fn substrate_addr_from_topology(asm: &Assembly, node_addr: &IpAddr) -> Option<SocketAddr> {
+    let psnap = asm.policy_mgr.get_current_snapshot();
+    for peer in psnap.policy().get_peers_for_node(node_addr)? {
+        if let Some(link) = psnap
+            .links_for_node(&peer.remote_zpr_addr)
+            .into_iter()
+            .find(|l| l.link_id == peer.link_id)
+        {
+            return Some(SocketAddr::new(link.peer.addr, link.peer.port));
+        }
+    }
+    None
+}
+
 /// Required claims must be present and non-empty.
 fn check_required_claims(claims: &[Claim], required: &[&str]) -> Result<(), ServiceError> {
     let mut required_set = std::collections::HashSet::new();
@@ -634,6 +676,45 @@ mod tests {
 
     fn make_cc(ident: &str) -> ConnectionControl {
         ConnectionControl::new(ident.to_string())
+    }
+
+    /// A node's substrate address comes from its peer's view of their shared link, and is
+    /// `None` when policy declares no peering for it.
+    #[tokio::test]
+    async fn test_substrate_addr_from_topology() {
+        use crate::assembly::tests::new_assembly_for_tests;
+        use crate::db::PolicyRepo;
+        use crate::policy_mgr::PolicyMgr;
+        use crate::test_helpers::{FakeResolver, make_peering, policy_with_peerings};
+        use crate::trusted_services::TrustedServicesMgr;
+        use std::path::PathBuf;
+
+        let a: IpAddr = "fd5a:5052:90de:1::1".parse().unwrap();
+        let b: IpAddr = "fd5a:5052:90de:1::2".parse().unwrap();
+        let unpeered: IpAddr = "fd5a:5052:90de:1::9".parse().unwrap();
+
+        let mut asm = new_assembly_for_tests(None).await;
+        asm.policy_mgr = PolicyMgr::new_with_initial_policy(
+            policy_with_peerings(&[make_peering(a, b, "link-ab", vec![])]),
+            PolicyRepo::new(asm.state_db.clone()),
+            Arc::new(FakeResolver::ip_only()),
+            Arc::new(TrustedServicesMgr::new()),
+            PathBuf::from("."),
+        )
+        .await
+        .unwrap();
+
+        // make_peering uses each node's own address as its substrate, port 0.
+        assert_eq!(
+            substrate_addr_from_topology(&asm, &b),
+            Some(SocketAddr::new(b, 0)),
+            "node B's substrate is the address peer A dials it at"
+        );
+        assert_eq!(
+            substrate_addr_from_topology(&asm, &unpeered),
+            None,
+            "a node with no peering has no policy-derived substrate"
+        );
     }
 
     fn decode_jwt(token: &str, secret: &str) -> Result<JwtClaims, jwt::errors::Error> {

--- a/vs/src/counters.rs
+++ b/vs/src/counters.rs
@@ -104,6 +104,10 @@ pub enum CounterType {
 
     AuthorizeConnectSuccess,
     AuthorizeConnectFailed,
+
+    /// A policy-declared link could not be installed during a VSAPI join. The node is
+    /// connected but has no route over that link until an endpoint reconnects.
+    LinkInstallFailed,
 }
 
 impl CounterType {

--- a/vs/src/db/visa.rs
+++ b/vs/src/db/visa.rs
@@ -654,6 +654,14 @@ impl VisaRepo {
         Ok(visas)
     }
 
+    /// The state a live visa is in on one node, or `None` when the visa is unknown/expired or
+    /// was never staged for that node. Read-only, for explaining a failed state transition.
+    pub fn get_node_visa_state(&self, visa_id: u64, node_addr: &IpAddr) -> Option<NodeVisaState> {
+        let store = self.inner.store.read().unwrap();
+        let entry = live_entry(&store, visa_id)?;
+        entry.node_states.get(node_addr).map(|ns| ns.state)
+    }
+
     /// The visa IDs for a node filtered by state, without cloning the visas.
     pub fn get_visa_ids_for_node_by_state(
         &self,

--- a/vs/src/db/visa.rs
+++ b/vs/src/db/visa.rs
@@ -58,6 +58,9 @@ pub enum NodeVisaState {
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VisaMetadata {
+    /// The node this visa was issued to. NOT necessarily the node the flow ingresses at --
+    /// the visa service also mints visas pre-emptively for flows it originates itself -- so
+    /// do not derive path geometry from it. Use `path` ordering for that.
     pub requesting_node: IpAddr,
     #[serde_as(as = "TimestampSeconds<i64>")]
     pub ctime: SystemTime,
@@ -67,7 +70,10 @@ pub struct VisaMetadata {
     pub zpl: String,
     pub signal_msgs: Vec<String>, // note we do not keep the signal destination
     pub direction: Direction,
-    pub path: Option<Vec<IpAddr>>, // ZPR addresses of nodes on the path only set if a link needs to be traversed.
+    /// ZPR addresses of the nodes on the path, in flow order: ingress node first, egress node
+    /// last. Only set if a link needs to be traversed. Actualization reads each node's role
+    /// off this ordering, so whoever builds one must keep it in flow order.
+    pub path: Option<Vec<IpAddr>>,
     pub five_tuple: VsapiFiveTuple,
 }
 

--- a/vs/src/event_mgr.rs
+++ b/vs/src/event_mgr.rs
@@ -271,8 +271,10 @@ async fn handle_policy_updated(asm: &Arc<Assembly>, vinst: u64) -> Result<(), Se
         // Queue up setTopology messages in parallel.
         let futs = valid_node_addrs.iter().filter_map(|naddr| {
             let links = psnap.links_for_node(naddr);
+            // Same snapshot the links came from: the worker mints bootstrap visas off it.
+            let policy = psnap.policy_arc();
             asm.vss_mgr.get_handle(naddr).map(|vss_handle| async move {
-                if let Err(e) = vss_handle.set_topology(links).await {
+                if let Err(e) = vss_handle.set_topology(links, policy).await {
                     error!(target: EVENT, "failed to set topology for node {}: {}", naddr, e);
                 }
             })

--- a/vs/src/main.rs
+++ b/vs/src/main.rs
@@ -38,6 +38,7 @@ mod router;
 mod signal_worker;
 mod topology_mgr;
 mod trusted_services;
+mod visa_bootstrap;
 mod visa_mgr;
 mod visa_policy;
 mod visa_reconciler;

--- a/vs/src/net_mgr.rs
+++ b/vs/src/net_mgr.rs
@@ -7,6 +7,7 @@ use rand::{RngCore, SeedableRng};
 use std::collections::HashSet;
 use std::net::{IpAddr, Ipv6Addr};
 use std::sync::{Arc, Mutex};
+use zpr::addrs;
 
 use crate::config;
 use crate::error::ServiceError;
@@ -21,6 +22,18 @@ const NODE_AAA_PREFIX_LEN: u8 = 88;
 /// ZPRnet AAA network is a /64.
 pub const AAA_NET: Ipv6Net =
     Ipv6Net::new_assert(Ipv6Addr::new(0xfd5a, 0x5052, 0, 0x0aaa, 0, 0, 0, 0), 64);
+
+/// The whole ZPRnet address space.
+const ZPR_NET: Ipv6Net = Ipv6Net::new_assert(addrs::ZPR_INTERNAL_NETWORK, addrs::ZPRNET_PREFIX_LEN);
+
+/// True if `addr` is a ZPR address, i.e. a peer at this address reached us over ZPR rather
+/// than over the substrate.
+pub fn is_zpr_addr(addr: &IpAddr) -> bool {
+    match addr {
+        IpAddr::V6(v6) => ZPR_NET.contains(v6),
+        IpAddr::V4(_) => false,
+    }
+}
 
 pub struct NetMgr {
     node_addrs: Arc<Mutex<dyn AddrAllocator + Send>>,
@@ -392,6 +405,16 @@ impl AddrAllocator for Addr4Allocator {
 mod tests {
     use super::*;
     use std::str::FromStr;
+
+    /// Only ZPRnet addresses are ZPR addresses: a substrate address (of either family) is
+    /// not, which is what distinguishes a node arriving over a link from the first node.
+    #[test]
+    fn test_is_zpr_addr() {
+        assert!(is_zpr_addr(&"fd5a:5052:90de:1::1".parse().unwrap()));
+        assert!(is_zpr_addr(&"fd5a:5052::1".parse().unwrap()));
+        assert!(!is_zpr_addr(&"fd00:1234::1".parse().unwrap()));
+        assert!(!is_zpr_addr(&"10.0.0.1".parse().unwrap()));
+    }
 
     #[tokio::test]
     async fn v6_allocate_release_adapter_and_node() {

--- a/vs/src/packet.rs
+++ b/vs/src/packet.rs
@@ -1,7 +1,7 @@
 use std::net::IpAddr;
 
-use zpr::vsapi_types::VsapiFiveTuple;
 use zpr::vsapi_types::vsapi_ip_number as ip_proto;
+use zpr::vsapi_types::{PacketDesc, VsapiFiveTuple};
 
 use crate::error::ServiceError;
 
@@ -29,4 +29,13 @@ pub fn make_fivetuple_tcp(
         source_port,
         dest_port,
     })
+}
+
+/// One-line `src:port -> dst:port proto` for logging a request's flow.
+pub fn describe_five_tuple(pdesc: &PacketDesc) -> String {
+    let ft = &pdesc.five_tuple;
+    format!(
+        "{}:{} -> {}:{} proto {}",
+        ft.source_addr, ft.source_port, ft.dest_addr, ft.dest_port, ft.l4_protocol
+    )
 }

--- a/vs/src/policy_mgr.rs
+++ b/vs/src/policy_mgr.rs
@@ -745,7 +745,7 @@ mod tests {
         Peer {
             link_id: link_id.to_string(),
             remote_zpr_addr: "fd5a:5052::1".parse().unwrap(),
-            // ponytail: local end is irrelevant to peers_to_links, so reuse the remote one.
+            // local end is irrelevant to peers_to_links, so reuse the remote one.
             local_substrate: substrate.clone(),
             remote_substrate: substrate,
         }

--- a/vs/src/policy_mgr.rs
+++ b/vs/src/policy_mgr.rs
@@ -426,6 +426,9 @@ impl PolicyResolver {
                         addr: sock_addr.ip(),
                         port: sock_addr.port(),
                     },
+                    visas: Vec::new(), // this is used only when sending topology messages
+                                       // TODO: Probably should be an option.
+                                       // TODO: Why are use re-using a vsapi type here anyway?
                 })
             })
             .collect()

--- a/vs/src/policy_mgr.rs
+++ b/vs/src/policy_mgr.rs
@@ -355,12 +355,6 @@ impl PolicyMgr {
         self.get_current_snapshot().container()
     }
 
-    /// When policy is updated, all the peer tables have their DNS names resolved and cached.
-    /// Use this to get the links specified by policy for a node.
-    pub fn resolved_links_for_node(&self, node: &IpAddr) -> Vec<Link> {
-        self.get_current_snapshot().links_for_node(node)
-    }
-
     /// Consult policy to get a description of the link between `node_a` and `node_b`.
     /// Both arguments are ZPR addresses. A convenience single-shot wrapper over
     /// [PolicySnapshot::describe_link]; callers needing a consistent multi-step view
@@ -643,7 +637,11 @@ mod tests {
         // Start from a no-topology policy (vinst 1).
         let mgr = make_policy_mgr(policy_no_topology()).await;
         assert_eq!(mgr.get_current().vinst(), 1);
-        assert!(mgr.resolved_links_for_node(&ip("fd5a:5052::1")).is_empty());
+        assert!(
+            mgr.get_current_snapshot()
+                .links_for_node(&ip("fd5a:5052::1"))
+                .is_empty()
+        );
 
         // Update to a policy with topology, all IP-addressed so it resolves.
         let peering = make_peering(ip("fd5a:5052::1"), ip("fd5a:5052::2"), "link-1", vec![]);
@@ -656,7 +654,11 @@ mod tests {
         assert_eq!(vinst, 2);
         assert_eq!(mgr.get_current().vinst(), 2);
         // Topology swapped in: node now has a resolved link.
-        assert!(!mgr.resolved_links_for_node(&ip("fd5a:5052::1")).is_empty());
+        assert!(
+            !mgr.get_current_snapshot()
+                .links_for_node(&ip("fd5a:5052::1"))
+                .is_empty()
+        );
         // Container swapped in and round-trips.
         assert_eq!(
             mgr.get_current_container().as_bytes(),

--- a/vs/src/policy_mgr.rs
+++ b/vs/src/policy_mgr.rs
@@ -421,8 +421,8 @@ impl PolicyResolver {
                         port: sock_addr.port(),
                     },
                     visas: Vec::new(), // this is used only when sending topology messages
-                                       // TODO: Probably should be an option.
                                        // TODO: Why are use re-using a vsapi type here anyway?
+                                       // See https://github.com/org-zpr/zpr-visaservice/issues/300
                 })
             })
             .collect()

--- a/vs/src/visa_bootstrap.rs
+++ b/vs/src/visa_bootstrap.rs
@@ -1,0 +1,461 @@
+//! Bootstrap visas: the visas that let a node reach VSAPI *before* it has connected.
+//!
+//! A node declared in policy as a peer of an already-connected node has no actor and no route
+//! until its link comes up, and the way it brings that link up is by reaching the visa service
+//! over VSAPI. Policy evaluation cannot answer for it, so these visas are minted directly from
+//! the policy-declared peering, which *is* the authorization.
+//!
+//! There are two ways a bootstrap visa gets to where it is needed, and both live here:
+//! - [visa_for_link] mints the peer's own visa for a topology send, which carries it to the
+//!   peer's neighbour inside `Link.visas` for hand-off when the peer shows up. This one has to
+//!   be pushed: the peer cannot ask for a visa until it has a VSAPI session, and this visa is
+//!   what lets it open one.
+//! - [visa_for_future_peer_request] answers a *connected* node that saw the peer's traffic --
+//!   the SYN it relays, or the visa service's reply to it -- and has no visa for it. Nothing is
+//!   pre-minted for these: the node has VSAPI up, so it can ask, like it would for any flow.
+//!
+//! Each direction of the session is its own visa -- see
+//! `VisaMgr::vsapi_bootstrap_visa_for_future_peer`, which does the actual minting and stays in
+//! [crate::visa_mgr] because it needs the visa store's internals.
+//!
+//! TODO: This whole module is a HACK to get initial MULTINODE working, and is meant to be
+//! deleted once peers authenticate and route properly before needing VSAPI. Keeping it together
+//! keeps that deletion to one file plus its three call sites.
+
+use std::net::IpAddr;
+use std::sync::Arc;
+
+use libeval::actor::Actor;
+use libeval::eval_result::Direction;
+use libeval::route::{LinkId, NodeId, Route, RouteKind};
+use tracing::{debug, warn};
+use zpr::vsapi_types::Visa;
+use zpr::vsapi_types::vsapi_ip_number as ip_proto;
+
+use crate::assembly::Assembly;
+use crate::config;
+use crate::error::ServiceError;
+use crate::logging::targets::{VREQ, VSS};
+use crate::visareq_worker::{VisaDecision, VisaRequestJob};
+
+/// Stands in for the ZPL source on a bootstrap visa, which has no matching com policy.
+pub const BOOTSTRAP_VISA_ZPL: &str = "<bootstrap: policy peering>";
+
+/// The peer's own SYN visa, actualized for `future_peer`, for `via_node` to carry in the
+/// `Link.visas` of its topology message.
+///
+/// The visa belongs to the peer, not to `via_node`: it holds it and hands it off when the peer
+/// connects. Actualizing for the peer gives it the copy for its end of the path -- ingress with
+/// a fwd_pep handing its VSAPI traffic to `via_node`. Nodes further along the path get their own
+/// copies via the pending-install queue.
+///
+/// Only the forward direction is pushed. The peer is the client of the session, so its own visa
+/// covers the reply it gets back, and nothing else it holds is needed for the handshake. The
+/// reverse visa is for whichever *connected* node the visa service's reply ingresses at, and
+/// that node can ask for it -- it has a working VSAPI session, which is the whole difference
+/// between it and the peer. See [visa_for_future_peer_request], which answers that ask.
+///
+/// Minting is idempotent, so calling this on every topology send is free after the first.
+pub async fn visa_for_link(
+    asm: &Arc<Assembly>,
+    future_peer: &IpAddr,
+    via_node: &IpAddr,
+) -> Result<Visa, ServiceError> {
+    let visa = asm
+        .visa_mgr
+        .vsapi_bootstrap_visa_for_future_peer(asm, future_peer, via_node, Direction::Forward)
+        .await?;
+    let visa = asm
+        .visa_mgr
+        .actualize_visa_for_target_node(visa, future_peer)
+        .await?;
+    debug!(target: VSS, "created bootstrap visa for future peer {future_peer}: {}", visa.issuer_id);
+    Ok(visa)
+}
+
+/// Answer a request for a not-yet-connected peer's VSAPI bootstrap flow from the visa we
+/// already minted, instead of from policy.
+///
+/// Policy cannot answer: the peer has no actor and no route until it connects, and reaching
+/// VSAPI is how it connects. A peering declared in policy *is* the authorization -- the same
+/// argument that justifies [visa_for_link] minting at topology-send time -- so hand a visa back.
+///
+/// Either orientation counts, and both really happen:
+/// - `peer:any -> vs:VSAPI`, the SYN this node relays, if it sees it before installing the copy
+///   [visa_for_link] staged for it.
+/// - `vs:VSAPI -> peer:any`, the visa service's reply, which is never pre-minted -- this is the
+///   only place that visa comes from.
+///
+/// They are two visas, not one: a visa's dock PEP names a source and a destination, and its path
+/// has an ingress end, so the forward visa matches neither the reply's addresses nor its
+/// direction of travel. The direction detected here is what selects the right one. Minting is
+/// idempotent, so a repeated ask returns the same visa.
+///
+/// Returns `None` when this is not that flow (including on a mint failure), leaving the
+/// request to normal evaluation.
+pub async fn visa_for_future_peer_request(
+    asm: &Arc<Assembly>,
+    job: &VisaRequestJob,
+    source_actor: &Option<Actor>,
+    dest_actor: &Option<Actor>,
+) -> Option<VisaDecision> {
+    let ft = &job.packet_desc.five_tuple;
+    if ft.l4_protocol != ip_proto::TCP {
+        return None;
+    }
+    let vs_addr = asm.config.get_vs_addr();
+    let vsapi_port = asm.config.core.vsapi_port.unwrap_or(config::VSAPI_PORT);
+
+    // Which end is the peer, which direction of the flow is this, and is the peer's actor the
+    // missing one? A connected peer's VSAPI traffic must go through policy like anything else.
+    let (peer_addr, direction, peer_actor_missing) =
+        if ft.dest_addr == vs_addr && ft.dest_port == vsapi_port {
+            (ft.source_addr, Direction::Forward, source_actor.is_none())
+        } else if ft.source_addr == vs_addr && ft.source_port == vsapi_port {
+            (ft.dest_addr, Direction::Reverse, dest_actor.is_none())
+        } else {
+            return None;
+        };
+    if !peer_actor_missing {
+        return None;
+    }
+
+    // Only for a peer the requesting node is declared to link with: that node is the one
+    // that would be handed the visa by a topology send, so it is the one allowed to pull it.
+    let policy = asm.policy_mgr.get_current();
+    let peers = policy
+        .get_peers_for_node(&job.requesting_node)
+        .unwrap_or(&[]);
+    if !peers.iter().any(|p| p.remote_zpr_addr == peer_addr) {
+        debug!(target: VREQ, "node {} asked about VSAPI flow with {peer_addr}, which is not one of its {} declared peers: not a bootstrap request", job.requesting_node, peers.len());
+        return None;
+    }
+
+    // The requesting node relays for the peer, so it is `via_node` of the minted path, and
+    // what it needs is its own actualized copy (forwarding-only, or full if it is an end of
+    // the path) -- not the copy the peer gets pushed in `Link.visas`.
+    let visa = match asm
+        .visa_mgr
+        .vsapi_bootstrap_visa_for_future_peer(asm, &peer_addr, &job.requesting_node, direction)
+        .await
+    {
+        Ok(visa) => visa,
+        Err(e) => {
+            warn!(target: VREQ, "failed to mint bootstrap visa for future peer {peer_addr} requested by node {}: {e}", job.requesting_node);
+            return None;
+        }
+    };
+    let route = match bootstrap_route(asm, &peer_addr, &job.requesting_node, direction) {
+        Ok(route) => route,
+        Err(e) => {
+            warn!(target: VREQ, "failed to build the bootstrap route for future peer {peer_addr} via node {}: {e}", job.requesting_node);
+            return None;
+        }
+    };
+    match asm
+        .visa_mgr
+        .actualize_visa_for_target_node(visa, &job.requesting_node)
+        .await
+    {
+        Ok(visa) => {
+            debug!(target: VREQ, "node {} requested the bootstrap visa for future peer {peer_addr}: returning visa {}", job.requesting_node, visa.issuer_id);
+            Some(VisaDecision::Allow(visa, route))
+        }
+        Err(e) => {
+            warn!(target: VREQ, "failed to actualize bootstrap visa for node {} relaying future peer {peer_addr}: {e}", job.requesting_node);
+            None
+        }
+    }
+}
+
+/// The routed part of a future peer's path to VSAPI: `via_node` to the node the visa service
+/// docks on. The peer's own link is not in the router until it connects, so it is not in here --
+/// [path_for_future_peer] and [bootstrap_route] each stitch it on.
+fn vs_segment(
+    asm: &Assembly,
+    future_peer: &IpAddr,
+    via_node: &IpAddr,
+) -> Result<Route, ServiceError> {
+    let vs_addr = asm.config.get_vs_addr();
+    let vs_dock = asm
+        .actor_mgr
+        .get_docking_node_for_adapter(&vs_addr)
+        .ok_or_else(|| {
+            ServiceError::Internal(format!(
+                "visa service {vs_addr} is not docked to a node: cannot path bootstrap visa for {future_peer}"
+            ))
+        })?;
+    asm.topo_mgr
+        .get_best_route(via_node, &vs_dock)
+        .ok_or_else(|| {
+            ServiceError::Internal(format!(
+                "no route from {via_node} to visa service docking node {vs_dock}"
+            ))
+        })
+}
+
+/// Node path a future peer's VSAPI traffic will take: the peer itself, then `via_node`
+/// (the neighbour carrying the peer's topology message, hence its first hop), then
+/// `via_node`'s route to the node the visa service docks on.
+///
+/// The peer's own link is not in the router yet -- it only comes up when the peer
+/// connects -- so the first hop is stitched on from the peering rather than routed.
+pub fn path_for_future_peer(
+    asm: &Assembly,
+    future_peer: &IpAddr,
+    via_node: &IpAddr,
+) -> Result<Vec<IpAddr>, ServiceError> {
+    let segment = vs_segment(asm, future_peer, via_node)?;
+    let mut path = vec![*future_peer];
+    path.extend(
+        asm.topo_mgr
+            .route_to_path(&segment, &NodeId(*via_node))?
+            .into_iter()
+            .map(IpAddr::from),
+    );
+    Ok(path)
+}
+
+/// The route a future peer's VSAPI traffic takes in the given direction: its own link to
+/// `via_node`, then the routed segment on to the visa service's docking node.
+///
+/// It is always [RouteKind::Multihop] -- at least the peer's link is crossed -- and that link
+/// is described by policy rather than by the router, which does not know it yet.
+/// [Direction::Reverse] walks the same links from the far end, so the order flips.
+fn bootstrap_route(
+    asm: &Assembly,
+    future_peer: &IpAddr,
+    via_node: &IpAddr,
+    direction: Direction,
+) -> Result<Route, ServiceError> {
+    let segment = vs_segment(asm, future_peer, via_node)?;
+    let peer_link = asm
+        .policy_mgr
+        .get_current()
+        .describe_link(via_node, future_peer)
+        .map_err(|e| {
+            ServiceError::Internal(format!(
+                "no policy link between {via_node} and future peer {future_peer}: {e}"
+            ))
+        })?;
+    let mut links = vec![LinkId(peer_link.link_id)];
+    links.extend(segment.links);
+    if direction == Direction::Reverse {
+        links.reverse();
+    }
+    Ok(Route {
+        kind: RouteKind::Multihop,
+        links,
+        cost: segment.cost.saturating_add(peer_link.cost),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::assembly::tests::new_assembly_for_tests;
+    use crate::test_helpers::make_node_actor_defexp;
+    use crate::visareq_worker::process_visa_request_for_test;
+    use zpr::vsapi_types::PacketDesc;
+
+    /// Assembly for the bootstrap tests: policy declares one `via_node`<->`future_peer`
+    /// peering, and `via_node` is connected and docks the visa service. The peer is left
+    /// unconnected (no actor, no route) -- callers that want it connected add its actor.
+    async fn build_bootstrap_test_asm(via_node: IpAddr, future_peer: IpAddr) -> Assembly {
+        use crate::db::PolicyRepo;
+        use crate::policy_mgr::PolicyMgr;
+        use crate::test_helpers::{FakeResolver, make_peering, policy_with_peerings};
+        use crate::trusted_services::TrustedServicesMgr;
+        use std::path::PathBuf;
+
+        let mut asm = new_assembly_for_tests(None).await;
+        asm.policy_mgr = PolicyMgr::new_with_initial_policy(
+            policy_with_peerings(&[make_peering(via_node, future_peer, "link-vp", vec![])]),
+            PolicyRepo::new(asm.state_db.clone()),
+            Arc::new(FakeResolver::ip_only()),
+            Arc::new(TrustedServicesMgr::new()),
+            PathBuf::from("."),
+        )
+        .await
+        .unwrap();
+        asm.topo_mgr.add_node(via_node).unwrap();
+        asm.actor_mgr
+            .hack_set_vs_docking_node(&via_node)
+            .await
+            .unwrap();
+        asm
+    }
+
+    /// The two directions of a future peer's VSAPI flow, as a node's dataplane would ask about
+    /// them: the peer's own SYN, and the visa service's reply to it.
+    fn bootstrap_flow_packets(asm: &Assembly, future_peer: &IpAddr) -> (PacketDesc, PacketDesc) {
+        let vs_addr = asm.config.get_vs_addr().to_string();
+        let peer = future_peer.to_string();
+        let vsapi_port = asm.config.core.vsapi_port.unwrap_or(config::VSAPI_PORT);
+        (
+            PacketDesc::new_tcp(&peer, &vs_addr, 40000, vsapi_port).unwrap(),
+            PacketDesc::new_tcp(&vs_addr, &peer, vsapi_port, 40000).unwrap(),
+        )
+    }
+
+    /// A visa request from a connected node on behalf of a policy-declared peer that has not
+    /// connected yet is answered from the pre-minted bootstrap visa. Policy cannot answer it:
+    /// the peer has no actor and no route, which is exactly what reaching VSAPI would fix.
+    #[tokio::test]
+    async fn bootstrap_visa_request_for_future_peer_is_allowed() {
+        let via_node: IpAddr = "fd5a:5052:3000::1".parse().unwrap(); // connected, docks the VS
+        let future_peer: IpAddr = "fd5a:5052:3000::7".parse().unwrap(); // no actor, no route
+        let asm = Arc::new(build_bootstrap_test_asm(via_node, future_peer).await);
+        let (syn_pkt, _reply_pkt) = bootstrap_flow_packets(&asm, &future_peer);
+
+        let visa = match process_visa_request_for_test(asm.clone(), via_node, syn_pkt).await {
+            VisaDecision::Allow(visa, _) => visa,
+            VisaDecision::Deny(code) => panic!("expected allow, got deny {code:?}"),
+        };
+
+        // It is the peer's own visa, held pending-install until the peer connects.
+        let pending = asm
+            .visa_mgr
+            .get_pending_visa_ids_for_node(&future_peer)
+            .await
+            .unwrap();
+        assert_eq!(pending, vec![visa.issuer_id]);
+    }
+
+    /// The reply direction gets its own visa. One visa carries one dock PEP and one path
+    /// orientation, so the forward visa (`peer -> vs:VSAPI`, pathed peer-first) cannot answer
+    /// `vs:VSAPI -> peer`: its PEP would not match the packet and no node on its path would
+    /// forward the reply. The reverse visa must be a distinct visa, addressed and pathed the
+    /// other way, with the requesting node forwarding towards the peer.
+    #[tokio::test]
+    async fn bootstrap_visa_reply_direction_gets_its_own_reverse_visa() {
+        use zpr::vsapi_types::{DockPepType, EndpointT};
+
+        let via_node: IpAddr = "fd5a:5052:3000::1".parse().unwrap(); // connected, docks the VS
+        let future_peer: IpAddr = "fd5a:5052:3000::7".parse().unwrap(); // no actor, no route
+        let asm = Arc::new(build_bootstrap_test_asm(via_node, future_peer).await);
+        let vs_addr = asm.config.get_vs_addr();
+        let vsapi_port = asm.config.core.vsapi_port.unwrap_or(config::VSAPI_PORT);
+        let (syn_pkt, reply_pkt) = bootstrap_flow_packets(&asm, &future_peer);
+
+        let syn_visa = match process_visa_request_for_test(asm.clone(), via_node, syn_pkt).await {
+            VisaDecision::Allow(visa, _) => visa,
+            VisaDecision::Deny(code) => panic!("expected allow for SYN direction, got {code:?}"),
+        };
+        let reply_visa = match process_visa_request_for_test(asm.clone(), via_node, reply_pkt).await
+        {
+            VisaDecision::Allow(visa, _) => visa,
+            VisaDecision::Deny(code) => panic!("expected allow for reply direction, got {code:?}"),
+        };
+
+        assert_ne!(
+            reply_visa.issuer_id, syn_visa.issuer_id,
+            "the reply direction needs its own visa, not the forward one"
+        );
+
+        // The dock PEP must describe the reply packet: vs:VSAPI -> peer:any, server side.
+        let dock_pep = reply_visa.dock_pep.expect("reverse visa must be full");
+        assert_eq!(dock_pep.source_addr, vs_addr);
+        assert_eq!(dock_pep.dest_addr, future_peer);
+        match dock_pep.pep {
+            DockPepType::TCP(tpep) => {
+                assert_eq!(tpep.source_port, vsapi_port);
+                assert_eq!(tpep.dest_port, 0, "reply direction allows any dest port");
+                assert_eq!(tpep.endpoint, EndpointT::Server);
+            }
+            other => panic!("expected a TCP dock PEP, got {other:?}"),
+        }
+
+        // The requesting node is where the reply ingresses, so it must forward to the peer.
+        let fwd_pep = reply_visa
+            .fwd_pep
+            .expect("reply ingress node needs a forwarding PEP towards the peer");
+        assert_eq!(fwd_pep.next_hop, future_peer);
+
+        // Both directions are held for the peer until it connects.
+        let mut pending = asm
+            .visa_mgr
+            .get_pending_visa_ids_for_node(&future_peer)
+            .await
+            .unwrap();
+        pending.sort();
+        let mut expected = vec![syn_visa.issuer_id, reply_visa.issuer_id];
+        expected.sort();
+        assert_eq!(pending, expected);
+    }
+
+    /// The route returned with a bootstrap visa names the links the traffic really crosses: the
+    /// peer's own link, which only policy knows about, plus the routed segment on to the visa
+    /// service's docking node -- ordered from the ingress end of the direction asked about.
+    #[tokio::test]
+    async fn bootstrap_visa_route_spans_peer_link_and_routed_segment() {
+        let via_node: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
+        let dock_node: IpAddr = "fd5a:5052:3000::2".parse().unwrap(); // docks the VS, one hop on
+        let future_peer: IpAddr = "fd5a:5052:3000::7".parse().unwrap();
+
+        let asm = build_bootstrap_test_asm(via_node, future_peer).await;
+        asm.topo_mgr.add_node(dock_node).unwrap();
+        asm.topo_mgr
+            .add_link(via_node, dock_node, LinkId("link-vd".into()), vec![], 1)
+            .unwrap();
+        asm.actor_mgr
+            .hack_set_vs_docking_node(&dock_node)
+            .await
+            .unwrap();
+        let asm = Arc::new(asm);
+        let (syn_pkt, reply_pkt) = bootstrap_flow_packets(&asm, &future_peer);
+
+        let syn_route = match process_visa_request_for_test(asm.clone(), via_node, syn_pkt).await {
+            VisaDecision::Allow(_, route) => route,
+            VisaDecision::Deny(code) => panic!("expected allow for SYN direction, got {code:?}"),
+        };
+        assert!(
+            matches!(syn_route.kind, RouteKind::Multihop),
+            "the peer's own link is always crossed, so this is never a direct route"
+        );
+        assert_eq!(
+            syn_route.links,
+            vec![LinkId("link-vp".into()), LinkId("link-vd".into())],
+            "peer's link first, then the routed segment to the docking node"
+        );
+        assert_eq!(syn_route.cost, 2, "one policy link plus one router link");
+
+        let reply_route = match process_visa_request_for_test(asm.clone(), via_node, reply_pkt)
+            .await
+        {
+            VisaDecision::Allow(_, route) => route,
+            VisaDecision::Deny(code) => panic!("expected allow for reply direction, got {code:?}"),
+        };
+        assert_eq!(
+            reply_route.links,
+            vec![LinkId("link-vd".into()), LinkId("link-vp".into())],
+            "the reply crosses the same links from the other end"
+        );
+    }
+
+    /// A connected peer's VSAPI traffic is not a bootstrap request: it has an actor, so it
+    /// goes through policy like anything else.
+    #[tokio::test]
+    async fn bootstrap_visa_request_declined_for_connected_peer() {
+        let via_node: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
+        let peer: IpAddr = "fd5a:5052:3000::7".parse().unwrap();
+
+        let asm = build_bootstrap_test_asm(via_node, peer).await;
+        // The peer is connected now, so it has an actor.
+        let peer_actor = make_node_actor_defexp(&peer.to_string(), "peer-node", "10.0.0.7:5001");
+        asm.actor_mgr.add_node(&peer_actor, false).await.unwrap();
+        let asm = Arc::new(asm);
+        let (syn_pkt, _reply_pkt) = bootstrap_flow_packets(&asm, &peer);
+
+        // Reaches policy evaluation (which has no matching comm policy) rather than being
+        // short-circuited into an allow.
+        assert!(
+            matches!(
+                process_visa_request_for_test(asm, via_node, syn_pkt).await,
+                VisaDecision::Deny(_)
+            ),
+            "a connected peer must not get a bootstrap visa"
+        );
+    }
+}

--- a/vs/src/visa_bootstrap.rs
+++ b/vs/src/visa_bootstrap.rs
@@ -29,6 +29,7 @@ use std::sync::Arc;
 
 use libeval::actor::Actor;
 use libeval::eval_result::Direction;
+use libeval::policy::Policy;
 use libeval::route::{LinkId, NodeId, Route, RouteKind};
 use tracing::{debug, warn};
 use zpr::vsapi_types::Visa;
@@ -65,8 +66,12 @@ pub const BOOTSTRAP_VISA_ZPL: &str = "<bootstrap: policy peering>";
 /// `via_node` as an intermediary and pushes it a forwarding-only visa for a flow it terminates.
 ///
 /// Minting is idempotent, so calling this on every topology send is free after the first.
+///
+/// `policy` is the view the caller picked the link out of, threaded through so the minted
+/// visas record the generation that actually authorized them.
 pub async fn visas_for_link(
     asm: &Arc<Assembly>,
+    policy: &Arc<Policy>,
     future_peer: &IpAddr,
     via_node: &IpAddr,
 ) -> Result<Vec<Visa>, ServiceError> {
@@ -84,7 +89,7 @@ pub async fn visas_for_link(
     for direction in [Direction::Forward, Direction::Reverse] {
         let visa = asm
             .visa_mgr
-            .vsapi_bootstrap_visa_for_future_peer(asm, future_peer, via_node, direction)
+            .vsapi_bootstrap_visa_for_future_peer(asm, policy, future_peer, via_node, direction)
             .await?;
         let visa = asm
             .visa_mgr
@@ -144,6 +149,10 @@ pub async fn visa_for_future_peer_request(
 
     // Only for a peer the requesting node is declared to link with: that node is the one
     // that would be handed the visa by a topology send, so it is the one allowed to pull it.
+    //
+    // This is the only policy read on this path: the peer selection here, the minted visa's
+    // recorded generation, and the route's link_id all have to agree, so `policy` is threaded
+    // into both calls below rather than re-read in each.
     let policy = asm.policy_mgr.get_current();
     let peers = policy
         .get_peers_for_node(&job.requesting_node)
@@ -158,7 +167,13 @@ pub async fn visa_for_future_peer_request(
     // the path) -- not the copy the peer gets pushed in `Link.visas`.
     let visa = match asm
         .visa_mgr
-        .vsapi_bootstrap_visa_for_future_peer(asm, &peer_addr, &job.requesting_node, direction)
+        .vsapi_bootstrap_visa_for_future_peer(
+            asm,
+            &policy,
+            &peer_addr,
+            &job.requesting_node,
+            direction,
+        )
         .await
     {
         Ok(visa) => visa,
@@ -167,7 +182,7 @@ pub async fn visa_for_future_peer_request(
             return None;
         }
     };
-    let route = match bootstrap_route(asm, &peer_addr, &job.requesting_node, direction) {
+    let route = match bootstrap_route(asm, &policy, &peer_addr, &job.requesting_node, direction) {
         Ok(route) => route,
         Err(e) => {
             warn!(target: VREQ, "failed to build the bootstrap route for future peer {peer_addr} via node {}: {e}", job.requesting_node);
@@ -216,12 +231,19 @@ fn vs_segment(
         })
 }
 
-/// Node path a future peer's VSAPI traffic will take: the peer itself, then `via_node`
-/// (the neighbour carrying the peer's topology message, hence its first hop), then
-/// `via_node`'s route to the node the visa service docks on.
+/// Node path a future peer's VSAPI traffic will take: the peer itself, then
+/// `via_node` (the neighbour carrying the peer's topology message, hence its
+/// first hop), then `via_node`'s route to the node the visa service docks on.
 ///
-/// The peer's own link is not in the router yet -- it only comes up when the peer
-/// connects -- so the first hop is stitched on from the peering rather than routed.
+/// The peer's own link is not in the router yet -- it only comes up when the
+/// peer connects -- so the first hop is stitched on from the peering rather
+/// than routed.
+///
+/// The routed part is read from the live router: the path names the nodes
+/// actualization pushes a copy to, so they have to be nodes whose links are up.
+/// See the comment at the mint site in
+/// `VisaMgr::vsapi_bootstrap_visa_for_future_peer` for why a `PolicySnapshot`
+/// cannot supply this and what does come from policy.
 pub fn path_for_future_peer(
     asm: &Assembly,
     future_peer: &IpAddr,
@@ -242,24 +264,22 @@ pub fn path_for_future_peer(
 /// `via_node`, then the routed segment on to the visa service's docking node.
 ///
 /// It is always [RouteKind::Multihop] -- at least the peer's link is crossed -- and that link
-/// is described by policy rather than by the router, which does not know it yet.
+/// is described by `policy` rather than by the router, which does not know it yet. The caller's
+/// view is threaded in so the link id here matches the peering the caller selected.
 /// [Direction::Reverse] walks the same links from the far end, so the order flips.
 fn bootstrap_route(
     asm: &Assembly,
+    policy: &Arc<Policy>,
     future_peer: &IpAddr,
     via_node: &IpAddr,
     direction: Direction,
 ) -> Result<Route, ServiceError> {
     let segment = vs_segment(asm, future_peer, via_node)?;
-    let peer_link = asm
-        .policy_mgr
-        .get_current()
-        .describe_link(via_node, future_peer)
-        .map_err(|e| {
-            ServiceError::Internal(format!(
-                "no policy link between {via_node} and future peer {future_peer}: {e}"
-            ))
-        })?;
+    let peer_link = policy.describe_link(via_node, future_peer).map_err(|e| {
+        ServiceError::Internal(format!(
+            "no policy link between {via_node} and future peer {future_peer}: {e}"
+        ))
+    })?;
     let mut links = vec![LinkId(peer_link.link_id)];
     links.extend(segment.links);
     if direction == Direction::Reverse {
@@ -468,7 +488,9 @@ mod tests {
         let vs_addr = asm.config.get_vs_addr();
         let vsapi_port = asm.config.core.vsapi_port.unwrap_or(config::VSAPI_PORT);
 
-        let visas = visas_for_link(&asm, &future_peer, &via_node).await.unwrap();
+        let visas = visas_for_link(&asm, &asm.policy_mgr.get_current(), &future_peer, &via_node)
+            .await
+            .unwrap();
         assert_eq!(visas.len(), 2, "one visa per direction of the flow");
         assert_ne!(
             visas[0].issuer_id, visas[1].issuer_id,
@@ -512,7 +534,9 @@ mod tests {
         ids.sort();
         assert_eq!(pending, ids);
 
-        let resent = visas_for_link(&asm, &future_peer, &via_node).await.unwrap();
+        let resent = visas_for_link(&asm, &asm.policy_mgr.get_current(), &future_peer, &via_node)
+            .await
+            .unwrap();
         let mut resent_ids: Vec<u64> = resent.iter().map(|v| v.issuer_id).collect();
         resent_ids.sort();
         assert_eq!(
@@ -547,7 +571,7 @@ mod tests {
         let asm = Arc::new(asm);
 
         assert!(
-            visas_for_link(&asm, &peer, &via_node)
+            visas_for_link(&asm, &asm.policy_mgr.get_current(), &peer, &via_node)
                 .await
                 .unwrap()
                 .is_empty(),

--- a/vs/src/visa_bootstrap.rs
+++ b/vs/src/visa_bootstrap.rs
@@ -21,6 +21,8 @@
 //!
 //! TODO: This whole module is a HACK to get initial MULTINODE working, and is meant to be
 //! deleted once peers authenticate and route properly before needing VSAPI.
+//!
+//! See: https://github.com/org-zpr/zpr-visaservice/issues/301
 
 use std::net::IpAddr;
 use std::sync::Arc;

--- a/vs/src/visa_bootstrap.rs
+++ b/vs/src/visa_bootstrap.rs
@@ -6,13 +6,12 @@
 //! the policy-declared peering, which *is* the authorization.
 //!
 //! There are two ways a bootstrap visa gets to where it is needed, and both live here:
-//! - [visa_for_link] mints the peer's own visa for a topology send, which carries it to the
-//!   peer's neighbour inside `Link.visas` for hand-off when the peer shows up. This one has to
-//!   be pushed: the peer cannot ask for a visa until it has a VSAPI session, and this visa is
-//!   what lets it open one.
+//! - [visas_for_link] mints the peer's own visas for a topology send, which carries them to the
+//!   peer's neighbour inside `Link.visas` for hand-off when the peer shows up. These have to be
+//!   pushed: the peer cannot ask for a visa until it has a VSAPI session, and these are what let
+//!   it open one.
 //! - [visa_for_future_peer_request] answers a *connected* node that saw the peer's traffic --
-//!   the SYN it relays, or the visa service's reply to it -- and has no visa for it. Nothing is
-//!   pre-minted for these: the node has VSAPI up, so it can ask, like it would for any flow.
+//!   the SYN it relays, or the visa service's reply to it -- before its own queued copy landed.
 //!
 //! Each direction of the session is its own visa -- see
 //! `VisaMgr::vsapi_bootstrap_visa_for_future_peer`, which does the actual minting and stays in
@@ -42,36 +41,40 @@ use crate::visareq_worker::{VisaDecision, VisaRequestJob};
 /// Stands in for the ZPL source on a bootstrap visa, which has no matching com policy.
 pub const BOOTSTRAP_VISA_ZPL: &str = "<bootstrap: policy peering>";
 
-/// The peer's own SYN visa, actualized for `future_peer`, for `via_node` to carry in the
-/// `Link.visas` of its topology message.
+/// Both directions of the peer's VSAPI flow, actualized for `future_peer`, for `via_node` to
+/// carry in the `Link.visas` of its topology message.
 ///
-/// The visa belongs to the peer, not to `via_node`: it holds it and hands it off when the peer
-/// connects. Actualizing for the peer gives it the copy for its end of the path -- ingress with
-/// a fwd_pep handing its VSAPI traffic to `via_node`. Nodes further along the path get their own
-/// copies via the pending-install queue.
+/// The visas belong to the peer, not to `via_node`: it holds them and hands them off when the
+/// peer connects. Actualizing for the peer gives it the copy for its end of each path -- the SYN
+/// visa ingresses at the peer, so it gets a fwd_pep handing its VSAPI traffic to `via_node`,
+/// while on the reply visa the peer is egress and forwards nothing. Nodes further along either
+/// path get their own copies via the pending-install queue.
 ///
-/// Only the forward direction is pushed. The peer is the client of the session, so its own visa
-/// covers the reply it gets back, and nothing else it holds is needed for the handshake. The
-/// reverse visa is for whichever *connected* node the visa service's reply ingresses at, and
-/// that node can ask for it -- it has a working VSAPI session, which is the whole difference
-/// between it and the peer. See [visa_for_future_peer_request], which answers that ask.
+/// Both directions are pushed because the peer needs both before it has a session to ask over:
+/// the SYN visa to reach VSAPI, and the reply visa so the visa service's answer is admitted. A
+/// visa carries one dock PEP and one path orientation, so neither can stand in for the other --
+/// see `VisaMgr::vsapi_bootstrap_visa_for_future_peer`.
 ///
 /// Minting is idempotent, so calling this on every topology send is free after the first.
-pub async fn visa_for_link(
+pub async fn visas_for_link(
     asm: &Arc<Assembly>,
     future_peer: &IpAddr,
     via_node: &IpAddr,
-) -> Result<Visa, ServiceError> {
-    let visa = asm
-        .visa_mgr
-        .vsapi_bootstrap_visa_for_future_peer(asm, future_peer, via_node, Direction::Forward)
-        .await?;
-    let visa = asm
-        .visa_mgr
-        .actualize_visa_for_target_node(visa, future_peer)
-        .await?;
-    debug!(target: VSS, "created bootstrap visa for future peer {future_peer}: {}", visa.issuer_id);
-    Ok(visa)
+) -> Result<Vec<Visa>, ServiceError> {
+    let mut visas = Vec::new();
+    for direction in [Direction::Forward, Direction::Reverse] {
+        let visa = asm
+            .visa_mgr
+            .vsapi_bootstrap_visa_for_future_peer(asm, future_peer, via_node, direction)
+            .await?;
+        let visa = asm
+            .visa_mgr
+            .actualize_visa_for_target_node(visa, future_peer)
+            .await?;
+        debug!(target: VSS, "created {direction:?} bootstrap visa for future peer {future_peer}: {}", visa.issuer_id);
+        visas.push(visa);
+    }
+    Ok(visas)
 }
 
 /// Answer a request for a not-yet-connected peer's VSAPI bootstrap flow from the visa we
@@ -79,13 +82,12 @@ pub async fn visa_for_link(
 ///
 /// Policy cannot answer: the peer has no actor and no route until it connects, and reaching
 /// VSAPI is how it connects. A peering declared in policy *is* the authorization -- the same
-/// argument that justifies [visa_for_link] minting at topology-send time -- so hand a visa back.
+/// argument that justifies [visas_for_link] minting at topology-send time -- so hand a visa back.
 ///
-/// Either orientation counts, and both really happen:
-/// - `peer:any -> vs:VSAPI`, the SYN this node relays, if it sees it before installing the copy
-///   [visa_for_link] staged for it.
-/// - `vs:VSAPI -> peer:any`, the visa service's reply, which is never pre-minted -- this is the
-///   only place that visa comes from.
+/// Either orientation counts, and both really happen -- this node saw the traffic before the copy
+/// [visas_for_link] staged for it was installed:
+/// - `peer:any -> vs:VSAPI`, the SYN this node relays.
+/// - `vs:VSAPI -> peer:any`, the visa service's reply to it.
 ///
 /// They are two visas, not one: a visa's dock PEP names a source and a destination, and its path
 /// has an ingress end, so the forward visa matches neither the reply's addresses nor its
@@ -432,6 +434,71 @@ mod tests {
             reply_route.links,
             vec![LinkId("link-vd".into()), LinkId("link-vp".into())],
             "the reply crosses the same links from the other end"
+        );
+    }
+
+    /// A topology send carries both directions of the peer's VSAPI flow, and re-sending
+    /// topology reuses them rather than minting a fresh pair every heartbeat.
+    #[tokio::test]
+    async fn topology_send_carries_both_bootstrap_directions_and_dedups() {
+        use zpr::vsapi_types::DockPepType;
+
+        let via_node: IpAddr = "fd5a:5052:3000::1".parse().unwrap(); // connected, docks the VS
+        let future_peer: IpAddr = "fd5a:5052:3000::7".parse().unwrap(); // no actor, no route
+        let asm = Arc::new(build_bootstrap_test_asm(via_node, future_peer).await);
+        let vs_addr = asm.config.get_vs_addr();
+        let vsapi_port = asm.config.core.vsapi_port.unwrap_or(config::VSAPI_PORT);
+
+        let visas = visas_for_link(&asm, &future_peer, &via_node).await.unwrap();
+        assert_eq!(visas.len(), 2, "one visa per direction of the flow");
+        assert_ne!(
+            visas[0].issuer_id, visas[1].issuer_id,
+            "the two directions are distinct visas"
+        );
+
+        // The dock PEPs are the two orientations, with the wildcard on the peer's side: it is
+        // the client, so its port is unknown until it picks one.
+        let peps: Vec<_> = visas
+            .iter()
+            .map(|v| {
+                let pep = v.dock_pep.as_ref().expect("bootstrap visas are full visas");
+                let DockPepType::TCP(tpep) = &pep.pep else {
+                    panic!("expected a TCP dock PEP, got {:?}", pep.pep)
+                };
+                (
+                    pep.source_addr,
+                    tpep.source_port,
+                    pep.dest_addr,
+                    tpep.dest_port,
+                )
+            })
+            .collect();
+        assert_eq!(
+            peps,
+            vec![
+                (future_peer, 0, vs_addr, vsapi_port),
+                (vs_addr, vsapi_port, future_peer, 0),
+            ],
+            "the peer's SYN to VSAPI, then the visa service's reply"
+        );
+
+        // Both are held for the peer until it connects, and a second send reuses them.
+        let mut pending = asm
+            .visa_mgr
+            .get_pending_visa_ids_for_node(&future_peer)
+            .await
+            .unwrap();
+        pending.sort();
+        let mut ids: Vec<u64> = visas.iter().map(|v| v.issuer_id).collect();
+        ids.sort();
+        assert_eq!(pending, ids);
+
+        let resent = visas_for_link(&asm, &future_peer, &via_node).await.unwrap();
+        let mut resent_ids: Vec<u64> = resent.iter().map(|v| v.issuer_id).collect();
+        resent_ids.sort();
+        assert_eq!(
+            resent_ids, ids,
+            "re-sending topology must not mint duplicates"
         );
     }
 

--- a/vs/src/visa_bootstrap.rs
+++ b/vs/src/visa_bootstrap.rs
@@ -55,12 +55,29 @@ pub const BOOTSTRAP_VISA_ZPL: &str = "<bootstrap: policy peering>";
 /// visa carries one dock PEP and one path orientation, so neither can stand in for the other --
 /// see `VisaMgr::vsapi_bootstrap_visa_for_future_peer`.
 ///
+/// Returns no visas for a peer that has already connected: it has an actor and a route, so it
+/// asks for what it needs over its own VSAPI session. Minting for it is not just redundant but
+/// wrong -- [path_for_future_peer] stitches the peer on in front of `via_node`'s route to the
+/// visa service, and for a connected peer that route can run back through the peer itself,
+/// producing a path that revisits it (`[peer, via_node, peer]`). Actualization then reads
+/// `via_node` as an intermediary and pushes it a forwarding-only visa for a flow it terminates.
+///
 /// Minting is idempotent, so calling this on every topology send is free after the first.
 pub async fn visas_for_link(
     asm: &Arc<Assembly>,
     future_peer: &IpAddr,
     via_node: &IpAddr,
 ) -> Result<Vec<Visa>, ServiceError> {
+    if asm
+        .actor_mgr
+        .get_actor_by_zpr_addr(future_peer)
+        .await?
+        .is_some()
+    {
+        debug!(target: VSS, "peer {future_peer} of node {via_node} is already connected: no bootstrap visas needed");
+        return Ok(Vec::new());
+    }
+
     let mut visas = Vec::new();
     for direction in [Direction::Forward, Direction::Reverse] {
         let visa = asm
@@ -499,6 +516,48 @@ mod tests {
         assert_eq!(
             resent_ids, ids,
             "re-sending topology must not mint duplicates"
+        );
+    }
+
+    /// A topology send to a node whose peer has already connected carries no bootstrap visas.
+    /// Minting them is not merely redundant: here the connected peer is also the node the visa
+    /// service docks on, so the peer's path would run back through itself
+    /// (`[peer, via_node, peer]`) and stage `via_node` a forwarding-only visa for a flow it is
+    /// an endpoint of -- which its dataplane rejects.
+    #[tokio::test]
+    async fn no_bootstrap_visas_for_an_already_connected_peer() {
+        let via_node: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
+        let peer: IpAddr = "fd5a:5052:3000::2".parse().unwrap(); // connected, docks the VS
+
+        let asm = build_bootstrap_test_asm(via_node, peer).await;
+        asm.topo_mgr.add_node(peer).unwrap();
+        asm.topo_mgr
+            .add_link(via_node, peer, LinkId("link-vp".into()), vec![], 1)
+            .unwrap();
+        asm.actor_mgr
+            .add_node(
+                &make_node_actor_defexp(&peer.to_string(), "peer-node", "10.0.0.2:5001"),
+                false,
+            )
+            .await
+            .unwrap();
+        asm.actor_mgr.hack_set_vs_docking_node(&peer).await.unwrap();
+        let asm = Arc::new(asm);
+
+        assert!(
+            visas_for_link(&asm, &peer, &via_node)
+                .await
+                .unwrap()
+                .is_empty(),
+            "a connected peer needs no bootstrap visas"
+        );
+        assert!(
+            asm.visa_mgr
+                .get_pending_visa_ids_for_node(&via_node)
+                .await
+                .unwrap()
+                .is_empty(),
+            "nothing may be staged for the relaying node either"
         );
     }
 

--- a/vs/src/visa_bootstrap.rs
+++ b/vs/src/visa_bootstrap.rs
@@ -18,9 +18,10 @@
 //! `VisaMgr::vsapi_bootstrap_visa_for_future_peer`, which does the actual minting and stays in
 //! [crate::visa_mgr] because it needs the visa store's internals.
 //!
+//! There is also support code in [crate::vss_worker] used when we send the set_topology message.
+//!
 //! TODO: This whole module is a HACK to get initial MULTINODE working, and is meant to be
-//! deleted once peers authenticate and route properly before needing VSAPI. Keeping it together
-//! keeps that deletion to one file plus its three call sites.
+//! deleted once peers authenticate and route properly before needing VSAPI.
 
 use std::net::IpAddr;
 use std::sync::Arc;

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -13,7 +13,9 @@ use crate::logging::targets::VISA;
 use crate::packet::make_fivetuple_tcp;
 use crate::policy_mgr::PolicySnapshot;
 use crate::visa_bootstrap::{BOOTSTRAP_VISA_ZPL, path_for_future_peer};
-use crate::visa_policy::{PolicyOutcome, evaluate_against_policy, route_for_allow};
+use crate::visa_policy::{
+    PolicyOutcome, docking_node_for_addr, evaluate_against_policy, route_for_allow,
+};
 use crate::visareq_worker::{VisaDecision, request_visa_wait_response};
 
 use libeval::eval_result::{Direction, Hit};
@@ -57,24 +59,34 @@ pub enum VisaRecheck {
     Revoke,
 }
 
-/// Canonical forward-order (ingress→…→egress) node path for `route`, or `None`
-/// for a direct route. Mirrors exactly what `create_visa` stores in
-/// `metadata.path` so a re-derived path can be compared against a stored one.
-/// `starting_node` is the visa's `requesting_node`; a reverse hit traverses
-/// from the forward-egress node, so we reverse to restore forward orientation.
-fn canonical_path(
+/// Node path for `route` in flow order: the node the packets enter the fabric at first,
+/// then every node they traverse, ending at the node serving the destination. `None` for a
+/// direct route -- nothing is forwarded, so there is no path worth recording.
+///
+/// Anchored on the docking node of `source_addr` (the actor sending the packets this visa
+/// authorizes), NOT on the node that asked for the visa. Those coincide for an ordinary
+/// request -- a node asks about a packet its own docked actor sent -- but not for visas the
+/// visa service mints pre-emptively on another node's behalf, e.g.
+/// [VisaMgr::post_register_vss_visas_for_node]. Actualization reads each node's role
+/// straight off this ordering, so getting the anchor wrong hands the destination node a
+/// next hop pointing back the way the packets came.
+///
+/// Mirrors exactly what `create_visa` stores in `metadata.path`, so a re-derived path can
+/// be compared against a stored one.
+async fn path_for_flow(
     asm: &Assembly,
-    starting_node: &IpAddr,
+    source_addr: &IpAddr,
     route: &Route,
-    direction: Direction,
 ) -> Result<Option<Vec<IpAddr>>, ServiceError> {
     if !matches!(route.kind, libeval::route::RouteKind::Multihop) {
         return Ok(None);
     }
-    let mut node_id_path = asm.topo_mgr.route_to_path(route, &NodeId(*starting_node))?;
-    if direction == Direction::Reverse {
-        node_id_path.reverse();
-    }
+    let Some(ingress) = docking_node_for_addr(asm, source_addr).await else {
+        return Err(ServiceError::Internal(format!(
+            "cannot orient visa path: source {source_addr} is not docked to any node"
+        )));
+    };
+    let node_id_path = asm.topo_mgr.route_to_path(route, &NodeId(ingress))?;
     Ok(Some(node_id_path.into_iter().map(|id| id.into()).collect()))
 }
 
@@ -154,60 +166,39 @@ impl VisaMgr {
             return Ok(visa);
         }
 
-        // Metadata includes the requesting node addr.
-        // If our `target_node` is first or last then we are in an ingress or egress context.
-        // If target_node is requesting_node then this is ingress, else this is egress.
-
-        let vctx =
-            if (path.first().unwrap() == target_node) || (path.last().unwrap() == target_node) {
-                if target_node == &md.requesting_node {
-                    VCtx::Ingress
-                } else {
-                    VCtx::Egress
-                }
-            } else {
-                VCtx::Intermediary
-            };
+        // The path is in flow order (see [path_for_flow]), so a node's role is its position
+        // on it: packets enter at the front and leave at the back. Deliberately NOT keyed off
+        // `md.requesting_node` -- the requester is not always the ingress node, and treating
+        // it as one told the destination node to forward the flow back towards its source.
+        let vctx = if path.first().unwrap() == target_node {
+            VCtx::Ingress
+        } else if path.last().unwrap() == target_node {
+            VCtx::Egress
+        } else {
+            VCtx::Intermediary
+        };
 
         match vctx {
-            VCtx::Ingress => {
-                // We already know path is at least 2 so there is a forwarding instruction.
-                // We are ingress so we are at one end of the path, so next hop is trivial.
-                let next_hop = if path.first().unwrap() == target_node {
-                    path[1]
-                } else {
-                    path[path.len() - 2]
+            // The flow terminates here, so there is nothing to forward: full visa as-is.
+            VCtx::Egress => Ok(visa),
+
+            // Both other roles forward one hop further along the path -- given [A, B, C, D],
+            // A forwards to B, B to C, C to D. Only the visa contents differ: the ingress
+            // node also docks the flow, an intermediary purely relays it.
+            VCtx::Ingress | VCtx::Intermediary => {
+                let Some(next_hop) = next_hop_in_path(path, target_node) else {
+                    error!(target: VISA, "error actualizing visa for node {target_node} on path {path:?}: no next_hop found");
+                    return Err(ServiceError::Internal(format!("failed to actualize visa")));
                 };
-                let fwd_pep = FwdPep {
-                    next_hop: next_hop,
+                let fpep = FwdPep {
+                    next_hop: *next_hop,
                     style: FwdPepStyle::OneWay, // TODO: Not sure when to set this to symmetric.
                 };
-                visa.fwd_pep = Some(fwd_pep);
-                return Ok(visa);
-            }
-            VCtx::Egress => {
-                // Just return the full visa.
-                return Ok(visa);
-            }
-            VCtx::Intermediary => {
-                // We are an intermediate node, but are we going forward on the path or backwards?
-                //
-                // Given path [A, B, C, D] and and the fact that A requested the visa (and so is ingress) then,
-                // Node D is egress.  Node B needs to forward to C, and C to D.
-
-                // Build a forwardingOnly visa ...
-                match next_hop_in_path(path, target_node, &md.requesting_node) {
-                    Some(next_hop) => {
-                        let fpep = FwdPep {
-                            next_hop: *next_hop,
-                            style: FwdPepStyle::OneWay, // TODO: Not sure when to set this to symmetric.
-                        };
-                        return Ok(to_forwarding_visa(visa, fpep));
-                    }
-                    None => {
-                        error!(target: VISA, "error actualizing visa for ingress node {target_node} on path is {path:?}: no next_hop found");
-                        return Err(ServiceError::Internal(format!("failed to actualize visa")));
-                    }
+                if vctx == VCtx::Ingress {
+                    visa.fwd_pep = Some(fpep);
+                    Ok(visa)
+                } else {
+                    Ok(to_forwarding_visa(visa, fpep))
                 }
             }
         }
@@ -427,13 +418,16 @@ impl VisaMgr {
     }
 
     /// Ask policy for a visa permitting this visa service to talk to the given node VSS addr.
-    /// Creating the visa has side effect of storing it in state and as PENDING on the requesting node.
-    ///
-    /// TODO: Should also be set pending on any intermediary nodes.
+    /// Creating the visa has the side effect of storing it and marking it PENDING on every
+    /// node along the path.
     ///
     /// `node_addr` - node ZPR address hosting the VSS.
     ///
-    /// Returns a visa for the docking node of `node_addr` (based on route of VS->node_addr).
+    /// `node_addr` is passed as the requesting node even though the flow runs the other way:
+    /// it is the node whose reply carries the visa (see
+    /// [VisaMgr::post_register_vss_visas_for_node]), and that is all `requesting_node` still
+    /// selects -- who is excluded from the background push. Path geometry comes from the
+    /// flow's source instead, see [path_for_flow].
     async fn create_vs_to_node_vss_visa(
         &self,
         asm: Arc<Assembly>,
@@ -503,7 +497,7 @@ impl VisaMgr {
         policy_version: u64,
         vinst: u64,
     ) -> Result<VisaWithMetadata, ServiceError> {
-        let path = canonical_path(asm, requesting_node, route, hit.direction)?;
+        let path = path_for_flow(asm, &pdesc.five_tuple.source_addr, route).await?;
         self.create_visa_with_path(
             requesting_node,
             pdesc,
@@ -844,10 +838,10 @@ impl VisaMgr {
         // stored path. Derive the new path exactly as create_visa did so the
         // comparison is apples-to-apples.
         let route = route_for_allow(&hits, default_route)?;
-        match canonical_path(asm, &metadata.requesting_node, &route, hits[0].direction) {
+        match path_for_flow(asm, &src_zpr, &route).await {
             Ok(new_path) if new_path == metadata.path => Ok(VisaRecheck::AllowSameRoute),
             Ok(_) => Ok(VisaRecheck::Revoke),
-            // The old requesting node is no longer on the new route (topology
+            // The source's docking node is no longer on the new route (topology
             // moved under us) -- the route definitely changed, so revoke.
             Err(_) => Ok(VisaRecheck::Revoke),
         }
@@ -1017,23 +1011,11 @@ fn to_forwarding_visa(mut visa: Visa, fwd_pep: FwdPep) -> Visa {
     visa
 }
 
-/// Returns the adjacent node after `target_node` in `path`, stepping forward or backward
-/// according to the specified ingress node.
-///
-/// ### Panics
-/// - if `ingress_node` is not either the first or last node in the path.
-fn next_hop_in_path<'a>(
-    path: &'a [IpAddr],
-    target_node: &IpAddr,
-    ingress_node: &IpAddr,
-) -> Option<&'a IpAddr> {
-    assert!(path.first()? == ingress_node || path.last()? == ingress_node);
+/// The node `target_node` hands off to on `path`: the next one along, since the path runs in
+/// flow order. `None` if `target_node` is the egress node or is not on the path at all.
+fn next_hop_in_path<'a>(path: &'a [IpAddr], target_node: &IpAddr) -> Option<&'a IpAddr> {
     let pos = path.iter().position(|n| n == target_node)?;
-    if path.first()? == ingress_node {
-        path.get(pos + 1)
-    } else {
-        pos.checked_sub(1).and_then(|i| path.get(i))
-    }
+    path.get(pos + 1)
 }
 
 #[cfg(test)]
@@ -1061,9 +1043,8 @@ mod tests {
     #[test]
     fn test_next_hop_empty() {
         let path = vec![];
-        let ingress = "fd5a:5052::1".parse().unwrap();
         let target = "fd5a:5052::2".parse().unwrap();
-        assert_eq!(next_hop_in_path(&path, &target, &ingress), None);
+        assert_eq!(next_hop_in_path(&path, &target), None);
     }
 
     #[test]
@@ -1071,8 +1052,8 @@ mod tests {
         let n0 = "fd5a:5052::1".parse().unwrap();
         let n1 = "fd5a:5052::2".parse().unwrap();
         let path = vec![n0];
-        assert_eq!(next_hop_in_path(&path, &n0, &n0), None);
-        assert_eq!(next_hop_in_path(&path, &n1, &n0), None);
+        assert_eq!(next_hop_in_path(&path, &n0), None);
+        assert_eq!(next_hop_in_path(&path, &n1), None);
     }
 
     #[test]
@@ -1080,10 +1061,9 @@ mod tests {
         let n0 = "fd5a:5052::1".parse().unwrap();
         let n1 = "fd5a:5052::2".parse().unwrap();
         let path = vec![n0, n1];
-        assert_eq!(next_hop_in_path(&path, &n0, &n0), Some(&n1));
-        assert_eq!(next_hop_in_path(&path, &n1, &n0), None);
-        assert_eq!(next_hop_in_path(&path, &n1, &n1), Some(&n0));
-        assert_eq!(next_hop_in_path(&path, &n0, &n1), None);
+        assert_eq!(next_hop_in_path(&path, &n0), Some(&n1));
+        // n1 is the egress end: nothing beyond it.
+        assert_eq!(next_hop_in_path(&path, &n1), None);
     }
 
     #[test]
@@ -1093,15 +1073,11 @@ mod tests {
         let n2 = "fd5a:5052::3".parse().unwrap();
         let unknown = "fd5a:5052::4".parse().unwrap();
         let path = vec![n0, n1, n2];
-        assert_eq!(next_hop_in_path(&path, &n0, &n0), Some(&n1));
-        assert_eq!(next_hop_in_path(&path, &n1, &n0), Some(&n2));
-        assert_eq!(next_hop_in_path(&path, &n2, &n0), None);
+        assert_eq!(next_hop_in_path(&path, &n0), Some(&n1));
+        assert_eq!(next_hop_in_path(&path, &n1), Some(&n2));
+        assert_eq!(next_hop_in_path(&path, &n2), None);
 
-        assert_eq!(next_hop_in_path(&path, &n0, &n2), None);
-        assert_eq!(next_hop_in_path(&path, &n1, &n2), Some(&n0));
-        assert_eq!(next_hop_in_path(&path, &n2, &n2), Some(&n1));
-
-        assert_eq!(next_hop_in_path(&path, &unknown, &n2), None);
+        assert_eq!(next_hop_in_path(&path, &unknown), None);
     }
 
     #[tokio::test]
@@ -1640,14 +1616,16 @@ mod tests {
         assert!(result.dock_pep.is_some(), "egress returns full visa");
     }
 
-    /// Ingress context (last node + Reverse) → full visa with fwd_pep pointing to node before target.
+    /// A reverse-flow visa stores its own flow order [C, B, A], so C is the ingress end:
+    /// full visa with fwd_pep towards B.
     #[tokio::test]
     async fn test_actualize_ingress_reverse_sets_fwd_pep() {
         let mgr = make_mgr().await;
         let node_b: IpAddr = PATH_NODE_B.parse().unwrap();
         let node_c: IpAddr = PATH_NODE_C.parse().unwrap();
-        let visa =
-            store_test_visa_with_reqesting_node(&mgr, 1, Some(three_node_path()), node_c).await;
+        let mut path = three_node_path();
+        path.reverse();
+        let visa = store_test_visa(&mgr, 1, Some(path)).await;
 
         let result = mgr
             .actualize_visa_for_target_node(visa, &node_c)
@@ -1656,7 +1634,6 @@ mod tests {
         let fwd_pep = result
             .fwd_pep
             .expect("expected fwd_pep on ingress-reverse visa");
-        // Traversing in reverse from C, the next hop is B (the node immediately before C).
         assert_eq!(fwd_pep.next_hop, node_b);
         assert!(
             result.dock_pep.is_some(),
@@ -1664,15 +1641,14 @@ mod tests {
         );
     }
 
-    /// Egress context (first node + Reverse) → full visa returned unchanged.
+    /// The other end of that reverse-flow path [C, B, A]: A is egress, full visa unchanged.
     #[tokio::test]
     async fn test_actualize_egress_reverse_returns_full_visa() {
         let mgr = make_mgr().await;
-        let requesting_node: IpAddr = PATH_NODE_C.parse().unwrap();
         let node_a: IpAddr = PATH_NODE_A.parse().unwrap();
-        let visa =
-            store_test_visa_with_reqesting_node(&mgr, 1, Some(three_node_path()), requesting_node)
-                .await;
+        let mut path = three_node_path();
+        path.reverse();
+        let visa = store_test_visa(&mgr, 1, Some(path)).await;
 
         let result = mgr
             .actualize_visa_for_target_node(visa, &node_a)
@@ -1682,6 +1658,41 @@ mod tests {
         assert!(
             result.dock_pep.is_some(),
             "egress-reverse returns full visa"
+        );
+    }
+
+    /// The bug this geometry replaced: a visa the VS mints pre-emptively names the flow's
+    /// *destination* as the requesting node, and the destination must still come out egress.
+    /// Keying the role off `requesting_node` instead handed it a fwd_pep pointing back at the
+    /// node the packets arrived from, which ping-ponged binds between the two nodes.
+    #[tokio::test]
+    async fn test_actualize_role_ignores_requesting_node() {
+        let mgr = make_mgr().await;
+        let node_a: IpAddr = PATH_NODE_A.parse().unwrap();
+        let node_c: IpAddr = PATH_NODE_C.parse().unwrap();
+        // Flow runs A → C, but C is the node that asked for the visa.
+        let visa =
+            store_test_visa_with_reqesting_node(&mgr, 1, Some(three_node_path()), node_c).await;
+
+        let at_c = mgr
+            .actualize_visa_for_target_node(visa.clone(), &node_c)
+            .await
+            .unwrap();
+        assert!(
+            at_c.fwd_pep.is_none(),
+            "destination node must not be told to forward the flow onwards"
+        );
+        assert!(at_c.dock_pep.is_some(), "destination docks the flow");
+
+        let at_a = mgr
+            .actualize_visa_for_target_node(visa, &node_a)
+            .await
+            .unwrap();
+        assert_eq!(
+            at_a.fwd_pep
+                .expect("source node forwards into the fabric")
+                .next_hop,
+            PATH_NODE_B.parse::<IpAddr>().unwrap()
         );
     }
 
@@ -1739,12 +1750,16 @@ mod tests {
     use crate::assembly::tests::new_assembly_for_tests;
     use libeval::route::LinkId;
 
-    // Three nodes forming a linear chain: SRC → MID → DST (no direct SRC–DST link).
+    // Three nodes forming a linear chain: SRC → MID → DST (no direct SRC–DST link),
+    // with one adapter docked at each end.
     const MH_SRC: &str = "fd5a:5052::a1";
     const MH_MID: &str = "fd5a:5052::b1";
     const MH_DST: &str = "fd5a:5052::c1";
+    const MH_SRC_ADAPTER: &str = "fd5a:5052:1234::a100";
+    const MH_DST_ADAPTER: &str = "fd5a:5052:1234::a200";
 
-    /// Build an assembly with topology SRC→MID→DST and no direct SRC–DST link.
+    /// Build an assembly with topology SRC→MID→DST and no direct SRC–DST link. The end
+    /// adapters are docked so that [path_for_flow] can orient a flow between them.
     async fn make_multihop_assembly() -> Assembly {
         let asm = new_assembly_for_tests(None).await;
         let src: IpAddr = MH_SRC.parse().unwrap();
@@ -1759,6 +1774,15 @@ mod tests {
         asm.topo_mgr
             .add_link(mid, dst, LinkId("link-mid-dst".into()), vec![], 1)
             .unwrap();
+        for (adapter, node, cn) in [
+            (MH_SRC_ADAPTER, src, "mh-src-adapter"),
+            (MH_DST_ADAPTER, dst, "mh-dst-adapter"),
+        ] {
+            asm.actor_mgr
+                .add_adapter_via_node(&make_adapter_actor_defexp(adapter, cn), &node)
+                .await
+                .unwrap();
+        }
         asm
     }
 
@@ -1770,8 +1794,8 @@ mod tests {
         let mid: IpAddr = MH_MID.parse().unwrap();
         let dst: IpAddr = MH_DST.parse().unwrap();
 
-        let src_adapter: IpAddr = "fd5a:5052:1234::a100".parse().unwrap();
-        let dst_adapter: IpAddr = "fd5a:5052:1234::a200".parse().unwrap();
+        let src_adapter: IpAddr = MH_SRC_ADAPTER.parse().unwrap();
+        let dst_adapter: IpAddr = MH_DST_ADAPTER.parse().unwrap();
 
         let pdesc = PacketDesc::new_tcp_with_addr(src_adapter, dst_adapter, 12345, 80).unwrap();
         let hit = Hit::new_no_signal(0, Direction::Forward);
@@ -1798,8 +1822,8 @@ mod tests {
         let src: IpAddr = MH_SRC.parse().unwrap();
         let mid: IpAddr = MH_MID.parse().unwrap();
         let dst: IpAddr = MH_DST.parse().unwrap();
-        let src_adapter: IpAddr = "fd5a:5052:1234::a100".parse().unwrap();
-        let dst_adapter: IpAddr = "fd5a:5052:1234::a200".parse().unwrap();
+        let src_adapter: IpAddr = MH_SRC_ADAPTER.parse().unwrap();
+        let dst_adapter: IpAddr = MH_DST_ADAPTER.parse().unwrap();
         let pdesc = PacketDesc::new_tcp_with_addr(src_adapter, dst_adapter, 12345, 80).unwrap();
         let hit = Hit::new_no_signal(0, Direction::Forward);
         let route = asm.topo_mgr.get_best_route(&src, &dst).unwrap();
@@ -1828,22 +1852,16 @@ mod tests {
         assert!(pending_dst.iter().any(|v| v.issuer_id == visa_id));
     }
 
-    /// For a reverse multihop visa the requesting node is the reverse-direction ingress and
-    /// must receive fwd_pep pointing to the next hop toward the forward source.
-    ///
-    /// The bug: create_visa always passes requesting_node as starting_node to route_to_path,
-    /// so for a reverse hit where requesting_node == forward-egress (dst) the stored path is
-    /// [dst, mid, src].  actualize_visa_for_target_node then sees path.first()==dst with
-    /// Direction::Reverse → VCtx::Egress → no fwd_pep.  The fix is to reverse the stored
-    /// path for reverse hits so it is always in canonical forward order [src, mid, dst].
+    /// A reverse-direction visa covers packets sent by the forward flow's destination, so its
+    /// path starts at that end: dst is the ingress node and must get a fwd_pep towards mid.
     #[tokio::test]
     async fn test_create_visa_reverse_multihop_requesting_node_gets_fwd_pep() {
         let asm = make_multihop_assembly().await;
         let src: IpAddr = MH_SRC.parse().unwrap();
         let mid: IpAddr = MH_MID.parse().unwrap();
         let dst: IpAddr = MH_DST.parse().unwrap();
-        let src_adapter: IpAddr = "fd5a:5052:1234::a100".parse().unwrap();
-        let dst_adapter: IpAddr = "fd5a:5052:1234::a200".parse().unwrap();
+        let src_adapter: IpAddr = MH_SRC_ADAPTER.parse().unwrap();
+        let dst_adapter: IpAddr = MH_DST_ADAPTER.parse().unwrap();
 
         // Reverse packet: dst is the sender, src is the destination.
         let pdesc = PacketDesc::new_tcp_with_addr(dst_adapter, src_adapter, 54321, 80).unwrap();
@@ -1883,8 +1901,8 @@ mod tests {
         let src: IpAddr = MH_SRC.parse().unwrap();
         let mid: IpAddr = MH_MID.parse().unwrap();
         let dst: IpAddr = MH_DST.parse().unwrap();
-        let src_adapter: IpAddr = "fd5a:5052:1234::a100".parse().unwrap();
-        let dst_adapter: IpAddr = "fd5a:5052:1234::a200".parse().unwrap();
+        let src_adapter: IpAddr = MH_SRC_ADAPTER.parse().unwrap();
+        let dst_adapter: IpAddr = MH_DST_ADAPTER.parse().unwrap();
         let pdesc = PacketDesc::new_tcp_with_addr(src_adapter, dst_adapter, 12345, 80).unwrap();
         let hit = Hit::new_no_signal(0, Direction::Forward);
         let route = asm.topo_mgr.get_best_route(&src, &dst).unwrap();
@@ -2059,31 +2077,19 @@ mod tests {
         assert_eq!(res, VisaRecheck::Revoke);
     }
 
-    /// canonical_path returns None for a direct (same-node) route in either
-    /// direction -- a direct visa stores `path = None`, so recheck compares
-    /// None == None and stays AllowSameRoute.
+    /// path_for_flow returns None for a direct (same-node) route -- a direct visa
+    /// stores `path = None`, so recheck compares None == None and stays AllowSameRoute.
     #[tokio::test]
-    async fn test_canonical_path_direct_is_none() {
+    async fn test_path_for_flow_direct_is_none() {
         let asm = new_assembly_for_tests(None).await;
         let a: IpAddr = "fd5a:5052::1".parse().unwrap();
         asm.topo_mgr.add_node(a).unwrap();
         let route = asm.topo_mgr.get_best_route(&a, &a).unwrap();
-        assert_eq!(
-            canonical_path(&asm, &a, &route, Direction::Forward).unwrap(),
-            None
-        );
-        assert_eq!(
-            canonical_path(&asm, &a, &route, Direction::Reverse).unwrap(),
-            None
-        );
+        assert_eq!(path_for_flow(&asm, &a, &route).await.unwrap(), None);
     }
 
-    /// canonical_path yields the forward node order from the requesting node, and
-    /// a reverse hit flips it -- both are deterministic in (requesting_node,
-    /// direction), which is exactly why a re-derived path compares equal to the
-    /// one create_visa stored (same helper, same inputs).
-    #[tokio::test]
-    async fn test_canonical_path_multihop_forward_and_reverse() {
+    /// Build a—b—c with node actors for a and c, plus an adapter docked on c.
+    async fn make_abc_assembly() -> (Assembly, IpAddr, IpAddr, IpAddr) {
         let asm = new_assembly_for_tests(None).await;
         let a: IpAddr = "fd5a:5052::1".parse().unwrap();
         let b: IpAddr = "fd5a:5052::2".parse().unwrap();
@@ -2097,32 +2103,73 @@ mod tests {
         asm.topo_mgr
             .add_link(b, c, LinkId("bc".into()), vec![], 1)
             .unwrap();
-        let route = asm.topo_mgr.get_best_route(&a, &c).unwrap();
+        for (addr, cn) in [(a, "node-a"), (c, "node-c")] {
+            asm.actor_mgr
+                .add_node(
+                    &make_node_actor_defexp(&addr.to_string(), cn, "10.0.0.1:10001"),
+                    false,
+                )
+                .await
+                .unwrap();
+        }
+        (asm, a, b, c)
+    }
+
+    /// The path runs in flow order from wherever the *source* docks: from a it is
+    /// [a, b, c], from c it is [c, b, a], and an adapter docked on c is oriented
+    /// like c. This is what makes a node's actualization role positional.
+    #[tokio::test]
+    async fn test_path_for_flow_orients_on_source_dock() {
+        let (asm, a, b, c) = make_abc_assembly().await;
+        let adapter_on_c: IpAddr = "fd5a:5052:1234::c1".parse().unwrap();
+        asm.actor_mgr
+            .add_adapter_via_node(
+                &make_adapter_actor_defexp(&adapter_on_c.to_string(), "adapter-c"),
+                &c,
+            )
+            .await
+            .unwrap();
+
+        // A route's links are ordered from the source's end, exactly as the policy eval
+        // builds it (get_best_route(source dock, dest dock)), so each direction gets its own.
+        let a_to_c = asm.topo_mgr.get_best_route(&a, &c).unwrap();
+        let c_to_a = asm.topo_mgr.get_best_route(&c, &a).unwrap();
         assert_eq!(
-            canonical_path(&asm, &a, &route, Direction::Forward).unwrap(),
+            path_for_flow(&asm, &a, &a_to_c).await.unwrap(),
             Some(vec![a, b, c])
         );
         assert_eq!(
-            canonical_path(&asm, &a, &route, Direction::Reverse).unwrap(),
+            path_for_flow(&asm, &c, &c_to_a).await.unwrap(),
             Some(vec![c, b, a])
+        );
+        assert_eq!(
+            path_for_flow(&asm, &adapter_on_c, &c_to_a).await.unwrap(),
+            Some(vec![c, b, a]),
+            "an adapter's flow enters the fabric at its docking node"
         );
     }
 
-    /// canonical_path errors when the visa's requesting node is no longer on the
-    /// route (topology moved under us); recheck maps that Err to Revoke.
+    /// Two ways the path cannot be oriented, both of which recheck maps to Revoke:
+    /// an undocked source, and a source docked off the route (topology moved under us).
     #[tokio::test]
-    async fn test_canonical_path_bogus_start_errors() {
-        let asm = new_assembly_for_tests(None).await;
-        let a: IpAddr = "fd5a:5052::1".parse().unwrap();
-        let b: IpAddr = "fd5a:5052::2".parse().unwrap();
-        asm.topo_mgr.add_node(a).unwrap();
-        asm.topo_mgr.add_node(b).unwrap();
-        asm.topo_mgr
-            .add_link(a, b, LinkId("ab".into()), vec![], 1)
-            .unwrap();
+    async fn test_path_for_flow_unorientable_source_errors() {
+        let (asm, a, b, _c) = make_abc_assembly().await;
         let route = asm.topo_mgr.get_best_route(&a, &b).unwrap();
-        let bogus: IpAddr = "fd5a:5052::99".parse().unwrap();
-        assert!(canonical_path(&asm, &bogus, &route, Direction::Forward).is_err());
+
+        let undocked: IpAddr = "fd5a:5052:1234::99".parse().unwrap();
+        assert!(path_for_flow(&asm, &undocked, &route).await.is_err());
+
+        // Node d is docked (on itself) but the a—b route does not touch it.
+        let d: IpAddr = "fd5a:5052::4".parse().unwrap();
+        asm.topo_mgr.add_node(d).unwrap();
+        asm.actor_mgr
+            .add_node(
+                &make_node_actor_defexp(&d.to_string(), "node-d", "10.0.0.4:10001"),
+                false,
+            )
+            .await
+            .unwrap();
+        assert!(path_for_flow(&asm, &d, &route).await.is_err());
     }
 
     /// An adapter leaving while its node stays up: the visa on the live node is

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -86,6 +86,25 @@ fn canonical_path(
 ///
 /// The peer's own link is not in the router yet -- it only comes up when the peer
 /// connects -- so the first hop is stitched on from the peering rather than routed.
+/// True if the visa's dock PEP is for exactly this five-tuple: both addresses and both TCP
+/// ports. A visa with no dock PEP cannot match -- only full visas are stored, so that is a bug
+/// worth logging.
+fn dock_pep_matches_five_tuple(visa: &Visa, ft: &VsapiFiveTuple) -> bool {
+    let Some(dock_pep) = visa.dock_pep.as_ref() else {
+        warn!(target: VISA, "found visa in store with no dock_pep ID={}", visa.issuer_id);
+        return false;
+    };
+    if dock_pep.source_addr != ft.source_addr || dock_pep.dest_addr != ft.dest_addr {
+        return false;
+    }
+    match &dock_pep.pep {
+        DockPepType::TCP(tpep) => {
+            tpep.dest_port == ft.dest_port && tpep.source_port == ft.source_port
+        }
+        _ => false,
+    }
+}
+
 fn bootstrap_path(
     asm: &Assembly,
     future_peer: &IpAddr,
@@ -297,19 +316,24 @@ impl VisaMgr {
             0,
             asm.config.core.vsapi_port.unwrap_or(config::VSAPI_PORT),
         )?;
-        // Every connected neighbour of `future_peer` mints this same visa when it sends its
-        // topology, and those sends run concurrently (the policy-update fan-out, or every
-        // worker's initial sync after a VS restart). Without this the lookup below and the
-        // create further down interleave across their DB awaits and both neighbours mint,
-        // producing two visas with different IDs for one five-tuple.
+        // One neighbour can mint for the same peer from several places concurrently -- its
+        // topology sends (the policy-update fan-out, or every worker's initial sync after a VS
+        // restart) and a visa request pulling the visa. Without this the lookup below and the
+        // create further down interleave across their DB awaits and both mint, producing two
+        // visas with different IDs for one (peer, via_node).
         //
-        // NOTE: Using one global lock, not per-peer -- bootstrap minting only runs on topology
-        // sends. (Switch to per-peer if this ever lands on a hot path.)
+        // NOTE: Using one global lock, not per-peer -- bootstrap minting only happens while a
+        // peer is unconnected. (Switch to per-peer if this ever lands on a hot path.)
         let _guard = self.bootstrap_lock.lock().await;
 
         // A bootstrap visa is delivered inside a neighbour's topology message, so it stays
         // PendingInstall until `future_peer` itself connects and its own worker pushes it.
         // Match on that state too, otherwise every set_topology mints a duplicate.
+        //
+        // Dedup is per (peer, via_node), not per five-tuple: the path is baked into the visa,
+        // so a peer with two connected neighbours needs one visa per neighbour. Sharing one
+        // would leave the second neighbour off the visa's path -- its own copy could not be
+        // actualized, and the peer's copy would forward over the wrong link.
         if let Some(visa) = self
             .find_node_visa_by_five_tuple(
                 future_peer,
@@ -318,6 +342,7 @@ impl VisaMgr {
                     db::NodeVisaState::Installed,
                     db::NodeVisaState::PendingInstall,
                 ],
+                Some(via_node),
             )
             .await?
         {
@@ -357,44 +382,38 @@ impl VisaMgr {
         node_addr: &IpAddr,
         ft: &VsapiFiveTuple,
     ) -> Result<Option<Visa>, ServiceError> {
-        self.find_node_visa_by_five_tuple(node_addr, ft, &[db::NodeVisaState::Installed])
+        self.find_node_visa_by_five_tuple(node_addr, ft, &[db::NodeVisaState::Installed], None)
             .await
     }
 
     /// Use a linear search of the node's visas in any of `states` to find a five-tuple match.
+    ///
+    /// `relay`, when given, additionally requires the visa's path to hand off from `node_addr`
+    /// to that node. A five-tuple match alone is ambiguous once the path matters: a node with
+    /// several links needs one visa per link for the same flow, because each visa carries a
+    /// single path.
+    ///
     /// TODO: Need in-memory indexes for this.
     async fn find_node_visa_by_five_tuple(
         &self,
         node_addr: &IpAddr,
         ft: &VsapiFiveTuple,
         states: &[db::NodeVisaState],
+        relay: Option<&IpAddr>,
     ) -> Result<Option<Visa>, ServiceError> {
         for state in states {
             for visa in self.repo.get_visas_for_node_by_state(node_addr, *state)? {
-                if visa.dock_pep.is_none() {
-                    warn!(target: VISA, "found visa in store with no dock_pep ID={}", visa.issuer_id);
-                    continue; // not a full visa -- should not happen as only full visas are stored.
+                if !dock_pep_matches_five_tuple(&visa, ft) {
+                    continue;
                 }
-                let dock_pep = visa.dock_pep.as_ref().unwrap();
-                let vsource = &dock_pep.source_addr;
-                let vdest = &dock_pep.dest_addr;
-                if vsource == &ft.source_addr && vdest == &ft.dest_addr {
-                    // Is from VS -> NODE, check for VSS port match.
-                    match &dock_pep.pep {
-                        DockPepType::TCP(tpep) => {
-                            if tpep.dest_port == ft.dest_port && tpep.source_port == ft.source_port
-                            {
-                                // Found it
-                                return Ok(Some(visa));
-                            } else {
-                                continue; // not the right visa
-                            }
-                        }
-                        _ => {
-                            continue; // not the right visa
-                        }
+                if let Some(relay) = relay {
+                    // path[0] is `node_addr` itself, path[1] is the node it hands off to.
+                    let md = self.repo.get_visa_metadata_by_id(visa.issuer_id)?;
+                    if md.path.as_ref().and_then(|p| p.get(1)) != Some(relay) {
+                        continue;
                     }
                 }
+                return Ok(Some(visa));
             }
         }
         Ok(None)
@@ -1248,6 +1267,7 @@ mod tests {
                     db::NodeVisaState::Installed,
                     db::NodeVisaState::PendingInstall,
                 ],
+                None,
             )
             .await
             .unwrap();
@@ -1314,6 +1334,67 @@ mod tests {
         assert_eq!(
             again.issuer_id, visa.issuer_id,
             "second call must reuse the pending visa, not mint a duplicate"
+        );
+    }
+
+    /// A peer with two connected neighbours gets one bootstrap visa per neighbour: the path is
+    /// baked into the visa, so sharing one would leave the second neighbour off it. Deduping
+    /// still holds per neighbour -- asking twice for the same relay reuses.
+    #[tokio::test]
+    async fn test_bootstrap_visa_is_per_relay_not_per_five_tuple() {
+        let asm = crate::assembly::tests::new_assembly_for_tests(None).await;
+        let via_a = add_vs_docking_node(&asm).await; // docks the VS
+        let via_b: IpAddr = "fd5a:5052:3000::2".parse().unwrap();
+        let future_peer: IpAddr = "fd5a:5052:3000::7".parse().unwrap();
+
+        // via_b reaches the VS docking node through a link to via_a.
+        asm.topo_mgr.add_node(via_b).unwrap();
+        asm.topo_mgr
+            .add_link(via_a, via_b, LinkId("link-ab".into()), vec![], 1)
+            .unwrap();
+
+        let visa_a = asm
+            .visa_mgr
+            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_a)
+            .await
+            .unwrap();
+        let visa_b = asm
+            .visa_mgr
+            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_b)
+            .await
+            .unwrap();
+
+        assert_ne!(
+            visa_a.issuer_id, visa_b.issuer_id,
+            "each relay needs its own visa: one visa carries one path"
+        );
+
+        // Each visa hands off from the peer to its own relay, and stages that relay.
+        for (visa, via) in [(&visa_a, via_a), (&visa_b, via_b)] {
+            let md = asm
+                .visa_mgr
+                .repo
+                .get_visa_metadata_by_id(visa.issuer_id)
+                .unwrap();
+            let path = md.path.expect("bootstrap visa has an explicit path");
+            assert_eq!(path[0], future_peer, "the peer is the ingress node");
+            assert_eq!(path[1], via, "the peer hands off to its own relay");
+            assert_eq!(
+                asm.visa_mgr.repo.get_node_visa_state(visa.issuer_id, &via),
+                Some(db::NodeVisaState::PendingInstall),
+                "the relay on the path is staged"
+            );
+        }
+
+        // Dedup still applies per relay.
+        let again = asm
+            .visa_mgr
+            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_b)
+            .await
+            .unwrap();
+        assert_eq!(
+            again.issuer_id, visa_b.issuer_id,
+            "same relay must reuse its visa, not mint another"
         );
     }
 

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -31,6 +31,9 @@ const BOOTSTRAP_VISA_ZPL: &str = "<bootstrap: policy peering>";
 #[derive(Clone)]
 pub struct VisaMgr {
     repo: db::VisaRepo,
+    /// Serializes the check-then-create in [VisaMgr::vsapi_bootstrap_visa_for_future_peer].
+    /// Behind an `Arc` so every clone of the manager shares the one lock.
+    bootstrap_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 pub struct VisaWithMetadata {
@@ -85,7 +88,10 @@ impl VisaWithMetadata {
 
 impl VisaMgr {
     pub fn new(db: db::VisaRepo) -> Self {
-        VisaMgr { repo: db }
+        VisaMgr {
+            repo: db,
+            bootstrap_lock: Arc::new(tokio::sync::Mutex::new(())),
+        }
     }
 
     /// To "actualize" a visa means to adjust it for the context in which it is deployed.
@@ -251,6 +257,16 @@ impl VisaMgr {
             0,
             asm.config.core.vsapi_port.unwrap_or(config::VSAPI_PORT),
         )?;
+        // Every connected neighbour of `future_peer` mints this same visa when it sends its
+        // topology, and those sends run concurrently (the policy-update fan-out, or every
+        // worker's initial sync after a VS restart). Without this the lookup below and the
+        // create further down interleave across their DB awaits and both neighbours mint,
+        // producing two visas with different IDs for one five-tuple.
+        //
+        // NOTE: Using one global lock, not per-peer -- bootstrap minting only runs on topology
+        // sends. (Switch to per-peer if this ever lands on a hot path.)
+        let _guard = self.bootstrap_lock.lock().await;
+
         // A bootstrap visa is delivered inside a neighbour's topology message, so it stays
         // PendingInstall until `future_peer` itself connects and its own worker pushes it.
         // Match on that state too, otherwise every set_topology mints a duplicate.
@@ -1212,6 +1228,31 @@ mod tests {
             again.issuer_id, visa.issuer_id,
             "second call must reuse the pending visa, not mint a duplicate"
         );
+    }
+
+    /// The mint must hold `bootstrap_lock` across its whole check-then-create. Two neighbours
+    /// minting for the same future peer would otherwise interleave at the DB awaits, both see
+    /// no visa, and mint duplicates. Holding the lock here has to stall a concurrent mint;
+    /// with the clock paused the timeout can only fire because the mint is blocked on it.
+    #[tokio::test(start_paused = true)]
+    async fn test_vsapi_bootstrap_visa_mint_is_serialized() {
+        let asm = crate::assembly::tests::new_assembly_for_tests(None).await;
+        let future_peer: IpAddr = "fd5a:5052:3000::8".parse().unwrap();
+
+        let guard = asm.visa_mgr.bootstrap_lock.lock().await;
+        let mut mint = Box::pin(
+            asm.visa_mgr
+                .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer),
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), &mut mint)
+                .await
+                .is_err(),
+            "mint must block while the bootstrap lock is held"
+        );
+
+        drop(guard);
+        mint.await.expect("mint completes once the lock is free");
     }
 
     // --- actualize_visa_for_target_node tests ---

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -288,6 +288,7 @@ impl VisaMgr {
     /// peering declared in policy *is* the authorization for that peer to reach VSAPI.
     ///
     /// TODO: Added as a HACK to get initial MULTINODE working. Should be re-evaluated later.
+    /// See: https://github.com/org-zpr/zpr-visaservice/issues/301
     pub async fn vsapi_bootstrap_visa_for_future_peer(
         &self,
         asm: &Assembly,

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -676,7 +676,18 @@ impl VisaMgr {
             )
             .await?;
         if !applied {
-            debug!(target: VISA, "visa {visa_id} install ack for node {node_addr} did not apply (not PendingInstall); leaving state");
+            // The CAS misses for two very different reasons; say which. An already-Installed
+            // or PendingRevoke state is expected (a re-ack, or the sweep won the race), but a
+            // node with no entry at all means the visa was never staged for it -- e.g. the
+            // node is not on the visa's path, or the stored visa predates it being there.
+            match self.repo.get_node_visa_state(visa_id, node_addr) {
+                Some(state) => {
+                    debug!(target: VISA, "visa {visa_id} install ack for node {node_addr} did not apply: state is {state:?}, not PendingInstall; leaving it")
+                }
+                None => {
+                    warn!(target: VISA, "visa {visa_id} install ack for node {node_addr} did not apply: the visa is not staged for that node at all")
+                }
+            }
         }
         Ok(())
     }
@@ -1303,6 +1314,42 @@ mod tests {
         assert_eq!(
             again.issuer_id, visa.issuer_id,
             "second call must reuse the pending visa, not mint a duplicate"
+        );
+    }
+
+    /// The relaying node is on the bootstrap visa's path, so it is staged PendingInstall too
+    /// and its install ack applies. Without that staging the ack would find no entry and the
+    /// VS would never learn the relay installed the visa.
+    #[tokio::test]
+    async fn test_bootstrap_visa_stages_the_relaying_node() {
+        let asm = crate::assembly::tests::new_assembly_for_tests(None).await;
+        let via_node = add_vs_docking_node(&asm).await;
+        let future_peer: IpAddr = "fd5a:5052:3000::7".parse().unwrap();
+
+        let visa = asm
+            .visa_mgr
+            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_node)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            asm.visa_mgr
+                .repo
+                .get_node_visa_state(visa.issuer_id, &via_node),
+            Some(db::NodeVisaState::PendingInstall),
+            "the relaying node must be staged for the visa it forwards"
+        );
+
+        asm.visa_mgr
+            .visa_installed(visa.issuer_id, &via_node)
+            .await
+            .unwrap();
+        assert_eq!(
+            asm.visa_mgr
+                .repo
+                .get_node_visa_state(visa.issuer_id, &via_node),
+            Some(db::NodeVisaState::Installed),
+            "the relay's install ack must apply"
         );
     }
 

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -80,6 +80,44 @@ fn canonical_path(
     Ok(Some(node_id_path.into_iter().map(|id| id.into()).collect()))
 }
 
+/// Node path a future peer's VSAPI traffic will take: the peer itself, then `via_node`
+/// (the neighbour carrying the peer's topology message, hence its first hop), then
+/// `via_node`'s route to the node the visa service docks on.
+///
+/// The peer's own link is not in the router yet -- it only comes up when the peer
+/// connects -- so the first hop is stitched on from the peering rather than routed.
+fn bootstrap_path(
+    asm: &Assembly,
+    future_peer: &IpAddr,
+    via_node: &IpAddr,
+) -> Result<Vec<IpAddr>, ServiceError> {
+    let vs_addr = asm.config.get_vs_addr();
+    let vs_dock = asm
+        .actor_mgr
+        .get_docking_node_for_adapter(&vs_addr)
+        .ok_or_else(|| {
+            ServiceError::Internal(format!(
+                "visa service {vs_addr} is not docked to a node: cannot path bootstrap visa for {future_peer}"
+            ))
+        })?;
+    let route = asm
+        .topo_mgr
+        .get_best_route(via_node, &vs_dock)
+        .ok_or_else(|| {
+            ServiceError::Internal(format!(
+                "no route from {via_node} to visa service docking node {vs_dock}"
+            ))
+        })?;
+    let mut path = vec![*future_peer];
+    path.extend(
+        asm.topo_mgr
+            .route_to_path(&route, &NodeId(*via_node))?
+            .into_iter()
+            .map(IpAddr::from),
+    );
+    Ok(path)
+}
+
 impl VisaWithMetadata {
     pub fn new(visa: Visa, metadata: db::VisaMetadata) -> Self {
         VisaWithMetadata { visa, metadata }
@@ -237,9 +275,10 @@ impl VisaMgr {
     /// Mint (or reuse) the bootstrap visa that lets a not-yet-connected peer reach the
     /// visa service's VSAPI port, which is how it connects in the first place.
     ///
-    /// The visa belongs to `future_peer` and is stored pending-install against it. A
-    /// neighbour that is already connected receives a copy inside its topology message
-    /// and hands it off when the peer shows up.
+    /// The visa belongs to `future_peer` and is stored pending-install against it.
+    /// `via_node` is the already-connected neighbour whose topology message carries the
+    /// copy handed off when the peer shows up; it is also the peer's first hop, so the
+    /// path is anchored on it (see [bootstrap_path]).
     ///
     /// This deliberately bypasses policy evaluation. The peer cannot be evaluated --
     /// it has no actor and no route until the link comes up -- and it needs none: a
@@ -250,6 +289,7 @@ impl VisaMgr {
         &self,
         asm: &Assembly,
         future_peer: &IpAddr,
+        via_node: &IpAddr,
     ) -> Result<Visa, ServiceError> {
         let ft = make_fivetuple_tcp(
             future_peer.clone(),      // from future peer
@@ -288,21 +328,20 @@ impl VisaMgr {
                 comm_flags: CommFlag::BiDirectional,
             };
 
-            // A direct route keeps `canonical_path` from consulting the router at all
-            // (it short-circuits on any non-Multihop route), so an unconnected peer
-            // with no route cannot fail here. Forward + BiDirectional gives the ports
-            // we want: any source port -> VSAPI.
+            // The path cannot be routed -- the peer's link is not up -- so hand it in
+            // explicitly. It has to be there: without it the peer's copy gets no fwd_pep
+            // and the relaying nodes get no copy at all, leaving the visa unusable.
+            // Forward + BiDirectional gives the ports we want: any source port -> VSAPI.
             let policy = asm.policy_mgr.get_current();
             let hit = Hit::new_no_signal(0, Direction::Forward);
-            let route = Route::new_direct(NodeId(*future_peer));
+            let path = bootstrap_path(asm, future_peer, via_node)?;
 
             let visawmd = self
-                .create_visa(
-                    asm,
+                .create_visa_with_path(
                     future_peer,
                     &pkt_data,
                     &hit,
-                    &route,
+                    Some(path),
                     BOOTSTRAP_VISA_ZPL,
                     policy.get_version().unwrap_or(0),
                     policy.vinst(),
@@ -438,6 +477,32 @@ impl VisaMgr {
         policy_version: u64,
         vinst: u64,
     ) -> Result<VisaWithMetadata, ServiceError> {
+        let path = canonical_path(asm, requesting_node, route, hit.direction)?;
+        self.create_visa_with_path(
+            requesting_node,
+            pdesc,
+            hit,
+            path,
+            source_zpl,
+            policy_version,
+            vinst,
+        )
+        .await
+    }
+
+    /// As [VisaMgr::create_visa], but with the node path supplied rather than derived from
+    /// a route. For visas whose path cannot be routed -- see
+    /// [VisaMgr::vsapi_bootstrap_visa_for_future_peer].
+    async fn create_visa_with_path(
+        &self,
+        requesting_node: &IpAddr,
+        pdesc: &PacketDesc,
+        hit: &Hit,
+        path: Option<Vec<IpAddr>>,
+        source_zpl: impl Into<String>,
+        policy_version: u64,
+        vinst: u64,
+    ) -> Result<VisaWithMetadata, ServiceError> {
         // TODO: The visa expiration needs to be computed as watever is soonest:
         //   - expiration of authentication of source actor
         //   - expiration of authentication of destination actor
@@ -499,8 +564,6 @@ impl VisaMgr {
         };
 
         let visa_id = self.repo.get_next_visa_id().await?;
-
-        let path = canonical_path(asm, requesting_node, route, hit.direction)?;
 
         let mut metadata = db::VisaMetadata::new(
             requesting_node.clone(),
@@ -1181,21 +1244,34 @@ mod tests {
         assert_eq!(result.expect("pending visa should match").issuer_id, 4);
     }
 
-    /// A bootstrap visa must be mintable for a peer that has no actor and no route --
-    /// that is the entire point, the link is not up yet. Going through the normal visa
-    /// request pipeline would deny NoRoute here. Also asserts the dedup: a second call
-    /// reuses the first visa rather than minting a duplicate.
+    /// Stand up the minimum a bootstrap mint needs: one connected node, which the visa
+    /// service docks on. Returns that node's address, usable as `via_node`.
+    async fn add_vs_docking_node(asm: &Assembly) -> IpAddr {
+        let node_addr: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
+        asm.topo_mgr.add_node(node_addr).unwrap();
+        asm.actor_mgr
+            .hack_set_vs_docking_node(&node_addr)
+            .await
+            .unwrap();
+        node_addr
+    }
+
+    /// A bootstrap visa must be mintable for a peer that has no actor and no route of its
+    /// own -- that is the entire point, the link is not up yet. Going through the normal
+    /// visa request pipeline would deny NoRoute here. Also asserts the dedup: a second
+    /// call reuses the first visa rather than minting a duplicate.
     #[tokio::test]
     async fn test_vsapi_bootstrap_visa_for_future_peer_no_route_no_actor() {
         let asm = crate::assembly::tests::new_assembly_for_tests(None).await;
+        let via_node = add_vs_docking_node(&asm).await;
         // Never added to actor_mgr or topo_mgr: an unconnected peer.
         let future_peer: IpAddr = "fd5a:5052:3000::7".parse().unwrap();
 
         let visa = asm
             .visa_mgr
-            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer)
+            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_node)
             .await
-            .expect("bootstrap visa must not need a route");
+            .expect("bootstrap visa must not need a route from the peer itself");
 
         let dock_pep = visa.dock_pep.as_ref().expect("full visa has a dock_pep");
         assert_eq!(dock_pep.source_addr, future_peer);
@@ -1221,13 +1297,59 @@ mod tests {
 
         let again = asm
             .visa_mgr
-            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer)
+            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_node)
             .await
             .unwrap();
         assert_eq!(
             again.issuer_id, visa.issuer_id,
             "second call must reuse the pending visa, not mint a duplicate"
         );
+    }
+
+    /// The peer installs this visa as its own ingress node, so its copy must carry a
+    /// fwd_pep pointing at the neighbour that relays for it -- otherwise it has nowhere to
+    /// send its VSAPI traffic. The relaying neighbour must also be queued a copy.
+    #[tokio::test]
+    async fn test_vsapi_bootstrap_visa_actualizes_with_fwd_pep_to_via_node() {
+        let asm = crate::assembly::tests::new_assembly_for_tests(None).await;
+        let via_node = add_vs_docking_node(&asm).await;
+        let future_peer: IpAddr = "fd5a:5052:3000::9".parse().unwrap();
+
+        let visa = asm
+            .visa_mgr
+            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_node)
+            .await
+            .unwrap();
+        let md = asm
+            .visa_mgr
+            .get_visa_metadata_by_id(visa.issuer_id)
+            .await
+            .unwrap()
+            .expect("metadata for a just-created visa");
+        assert_eq!(
+            md.path,
+            Some(vec![future_peer, via_node]),
+            "path runs from the peer through its first hop to the VS docking node"
+        );
+
+        let actualized = asm
+            .visa_mgr
+            .actualize_visa_for_target_node(visa.clone(), &future_peer)
+            .await
+            .unwrap();
+        let fwd_pep = actualized
+            .fwd_pep
+            .as_ref()
+            .expect("the peer's copy must forward");
+        assert_eq!(fwd_pep.next_hop, via_node);
+
+        // The relaying neighbour needs its own copy to let the traffic through.
+        let pending = asm
+            .visa_mgr
+            .get_pending_visa_ids_for_node(&via_node)
+            .await
+            .unwrap();
+        assert!(pending.contains(&visa.issuer_id));
     }
 
     /// The mint must hold `bootstrap_lock` across its whole check-then-create. Two neighbours
@@ -1237,13 +1359,15 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn test_vsapi_bootstrap_visa_mint_is_serialized() {
         let asm = crate::assembly::tests::new_assembly_for_tests(None).await;
+        let via_node = add_vs_docking_node(&asm).await;
         let future_peer: IpAddr = "fd5a:5052:3000::8".parse().unwrap();
 
         let guard = asm.visa_mgr.bootstrap_lock.lock().await;
-        let mut mint = Box::pin(
-            asm.visa_mgr
-                .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer),
-        );
+        let mut mint = Box::pin(asm.visa_mgr.vsapi_bootstrap_visa_for_future_peer(
+            &asm,
+            &future_peer,
+            &via_node,
+        ));
         assert!(
             tokio::time::timeout(Duration::from_secs(1), &mut mint)
                 .await

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -12,11 +12,12 @@ use crate::error::{ServiceError, StoreError};
 use crate::logging::targets::VISA;
 use crate::packet::make_fivetuple_tcp;
 use crate::policy_mgr::PolicySnapshot;
+use crate::visa_bootstrap::{BOOTSTRAP_VISA_ZPL, path_for_future_peer};
 use crate::visa_policy::{PolicyOutcome, evaluate_against_policy, route_for_allow};
 use crate::visareq_worker::{VisaDecision, request_visa_wait_response};
 
 use libeval::eval_result::{Direction, Hit};
-use libeval::route::{LinkId, NodeId, Route, RouteKind};
+use libeval::route::{NodeId, Route};
 use zpr::vsapi_types::vsapi_ip_number as ip_proto;
 use zpr::vsapi_types::{
     CommFlag, DockPep, DockPepType, EndpointT, FwdPep, FwdPepStyle, IcmpPep, KeySet, PacketDesc,
@@ -24,9 +25,6 @@ use zpr::vsapi_types::{
 };
 
 use tracing::info;
-
-/// Stands in for the ZPL source on a bootstrap visa, which has no matching com policy.
-const BOOTSTRAP_VISA_ZPL: &str = "<bootstrap: policy peering>";
 
 #[derive(Clone)]
 pub struct VisaMgr {
@@ -117,82 +115,6 @@ fn path_neighbour_of_endpoint(path: &[IpAddr], node_addr: &IpAddr) -> Option<IpA
     } else {
         None
     }
-}
-
-/// The routed part of a future peer's path to VSAPI: `via_node` to the node the visa service
-/// docks on. The peer's own link is not in the router until it connects, so it is not in here --
-/// [bootstrap_path] and [bootstrap_route] each stitch it on.
-fn bootstrap_vs_segment(
-    asm: &Assembly,
-    future_peer: &IpAddr,
-    via_node: &IpAddr,
-) -> Result<Route, ServiceError> {
-    let vs_addr = asm.config.get_vs_addr();
-    let vs_dock = asm
-        .actor_mgr
-        .get_docking_node_for_adapter(&vs_addr)
-        .ok_or_else(|| {
-            ServiceError::Internal(format!(
-                "visa service {vs_addr} is not docked to a node: cannot path bootstrap visa for {future_peer}"
-            ))
-        })?;
-    asm.topo_mgr
-        .get_best_route(via_node, &vs_dock)
-        .ok_or_else(|| {
-            ServiceError::Internal(format!(
-                "no route from {via_node} to visa service docking node {vs_dock}"
-            ))
-        })
-}
-
-fn bootstrap_path(
-    asm: &Assembly,
-    future_peer: &IpAddr,
-    via_node: &IpAddr,
-) -> Result<Vec<IpAddr>, ServiceError> {
-    let segment = bootstrap_vs_segment(asm, future_peer, via_node)?;
-    let mut path = vec![*future_peer];
-    path.extend(
-        asm.topo_mgr
-            .route_to_path(&segment, &NodeId(*via_node))?
-            .into_iter()
-            .map(IpAddr::from),
-    );
-    Ok(path)
-}
-
-/// The route a future peer's VSAPI traffic takes in the given direction: its own link to
-/// `via_node`, then the routed segment on to the visa service's docking node.
-///
-/// It is always [RouteKind::Multihop] -- at least the peer's link is crossed -- and that link
-/// is described by policy rather than by the router, which does not know it yet.
-/// [Direction::Reverse] walks the same links from the far end, so the order flips.
-pub fn bootstrap_route(
-    asm: &Assembly,
-    future_peer: &IpAddr,
-    via_node: &IpAddr,
-    direction: Direction,
-) -> Result<Route, ServiceError> {
-    let segment = bootstrap_vs_segment(asm, future_peer, via_node)?;
-    let peer_link = asm
-        .policy_mgr
-        .get_current()
-        .describe_link(via_node, future_peer)
-        .map_err(|e| {
-            ServiceError::Internal(format!(
-                "no policy link between {via_node} and future peer {future_peer}: {e}"
-            ))
-        })?;
-    let mut links = vec![LinkId(peer_link.link_id)];
-    links.extend(segment.links);
-    if direction == Direction::Reverse {
-        links.reverse();
-    }
-    Ok(Route {
-        kind: RouteKind::Multihop,
-        links,
-        cost: segment.cost.saturating_add(peer_link.cost),
-    })
 }
 
 impl VisaWithMetadata {
@@ -352,10 +274,13 @@ impl VisaMgr {
     /// Mint (or reuse) one direction of the bootstrap flow that lets a not-yet-connected peer
     /// reach the visa service's VSAPI port, which is how it connects in the first place.
     ///
+    /// The rest of the bootstrap machinery lives in [crate::visa_bootstrap]; only the minting
+    /// is here, because it needs this module's private store and lookup helpers.
+    ///
     /// The visa belongs to `future_peer` and is stored pending-install against it.
     /// `via_node` is the already-connected neighbour whose topology message carries the
     /// copy handed off when the peer shows up; it is also the peer's first hop, so the
-    /// path is anchored on it (see [bootstrap_path]).
+    /// path is anchored on it (see [crate::visa_bootstrap::path_for_future_peer]).
     ///
     /// `direction` picks which half of the flow this visa is for. A visa carries exactly one
     /// dock PEP and one path orientation, so the two halves cannot share one:
@@ -431,14 +356,14 @@ impl VisaMgr {
             // and the relaying nodes get no copy at all, leaving the visa unusable.
             let policy = asm.policy_mgr.get_current();
             let hit = Hit::new_no_signal(0, direction);
-            // [bootstrap_path] is peer-first, which is the forward flow's orientation. The
+            // [path_for_future_peer] is peer-first, which is the forward flow's orientation. The
             // reply ingresses at the other end, so flip it: actualization decides each node's
             // role from the path plus the ingress node, and `path[0]` is that node either way.
-            let mut path = bootstrap_path(asm, future_peer, via_node)?;
+            let mut path = path_for_future_peer(asm, future_peer, via_node)?;
             if direction == Direction::Reverse {
                 path.reverse();
             }
-            let ingress_node = path[0]; // bootstrap_path is never empty
+            let ingress_node = path[0]; // path_for_future_peer is never empty
 
             let visawmd = self
                 .create_visa_with_path(

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -25,6 +25,9 @@ use zpr::vsapi_types::{
 
 use tracing::info;
 
+/// Stands in for the ZPL source on a bootstrap visa, which has no matching com policy.
+const BOOTSTRAP_VISA_ZPL: &str = "<bootstrap: policy peering>";
+
 #[derive(Clone)]
 pub struct VisaMgr {
     repo: db::VisaRepo,
@@ -225,37 +228,116 @@ impl VisaMgr {
         Ok(visas)
     }
 
-    /// Use a linear search of all visas installed on the node to find a match.
-    /// TODO: Need in-memory indexes for this.
+    /// Mint (or reuse) the bootstrap visa that lets a not-yet-connected peer reach the
+    /// visa service's VSAPI port, which is how it connects in the first place.
+    ///
+    /// The visa belongs to `future_peer` and is stored pending-install against it. A
+    /// neighbour that is already connected receives a copy inside its topology message
+    /// and hands it off when the peer shows up.
+    ///
+    /// This deliberately bypasses policy evaluation. The peer cannot be evaluated --
+    /// it has no actor and no route until the link comes up -- and it needs none: a
+    /// peering declared in policy *is* the authorization for that peer to reach VSAPI.
+    ///
+    /// TODO: Added as a HACK to get initial MULTINODE working. Should be re-evaluated later.
+    pub async fn vsapi_bootstrap_visa_for_future_peer(
+        &self,
+        asm: &Assembly,
+        future_peer: &IpAddr,
+    ) -> Result<Visa, ServiceError> {
+        let ft = make_fivetuple_tcp(
+            future_peer.clone(),      // from future peer
+            asm.config.get_vs_addr(), // to the visa service
+            0,
+            asm.config.core.vsapi_port.unwrap_or(config::VSAPI_PORT),
+        )?;
+        // A bootstrap visa is delivered inside a neighbour's topology message, so it stays
+        // PendingInstall until `future_peer` itself connects and its own worker pushes it.
+        // Match on that state too, otherwise every set_topology mints a duplicate.
+        if let Some(visa) = self
+            .find_node_visa_by_five_tuple(
+                future_peer,
+                &ft,
+                &[
+                    db::NodeVisaState::Installed,
+                    db::NodeVisaState::PendingInstall,
+                ],
+            )
+            .await?
+        {
+            Ok(visa)
+        } else {
+            let pkt_data = PacketDesc {
+                five_tuple: ft,
+                comm_flags: CommFlag::BiDirectional,
+            };
+
+            // A direct route keeps `canonical_path` from consulting the router at all
+            // (it short-circuits on any non-Multihop route), so an unconnected peer
+            // with no route cannot fail here. Forward + BiDirectional gives the ports
+            // we want: any source port -> VSAPI.
+            let policy = asm.policy_mgr.get_current();
+            let hit = Hit::new_no_signal(0, Direction::Forward);
+            let route = Route::new_direct(NodeId(*future_peer));
+
+            let visawmd = self
+                .create_visa(
+                    asm,
+                    future_peer,
+                    &pkt_data,
+                    &hit,
+                    &route,
+                    BOOTSTRAP_VISA_ZPL,
+                    policy.get_version().unwrap_or(0),
+                    policy.vinst(),
+                )
+                .await?;
+            Ok(visawmd.visa)
+        }
+    }
+
+    /// Find a visa *installed* on the node matching the given five-tuple.
     pub async fn get_node_visa_by_five_tuple(
         &self,
         node_addr: &IpAddr,
         ft: &VsapiFiveTuple,
     ) -> Result<Option<Visa>, ServiceError> {
-        for visa in self
-            .repo
-            .get_visas_for_node_by_state(node_addr, db::NodeVisaState::Installed)?
-        {
-            if visa.dock_pep.is_none() {
-                warn!(target: VISA, "found visa in store with no dock_pep ID={}", visa.issuer_id);
-                continue; // not a full visa -- should not happen as only full visas are stored.
-            }
-            let dock_pep = visa.dock_pep.as_ref().unwrap();
-            let vsource = &dock_pep.source_addr;
-            let vdest = &dock_pep.dest_addr;
-            if vsource == &ft.source_addr && vdest == &ft.dest_addr {
-                // Is from VS -> NODE, check for VSS port match.
-                match &dock_pep.pep {
-                    DockPepType::TCP(tpep) => {
-                        if tpep.dest_port == ft.dest_port && tpep.source_port == ft.source_port {
-                            // Found it
-                            return Ok(Some(visa));
-                        } else {
+        self.find_node_visa_by_five_tuple(node_addr, ft, &[db::NodeVisaState::Installed])
+            .await
+    }
+
+    /// Use a linear search of the node's visas in any of `states` to find a five-tuple match.
+    /// TODO: Need in-memory indexes for this.
+    async fn find_node_visa_by_five_tuple(
+        &self,
+        node_addr: &IpAddr,
+        ft: &VsapiFiveTuple,
+        states: &[db::NodeVisaState],
+    ) -> Result<Option<Visa>, ServiceError> {
+        for state in states {
+            for visa in self.repo.get_visas_for_node_by_state(node_addr, *state)? {
+                if visa.dock_pep.is_none() {
+                    warn!(target: VISA, "found visa in store with no dock_pep ID={}", visa.issuer_id);
+                    continue; // not a full visa -- should not happen as only full visas are stored.
+                }
+                let dock_pep = visa.dock_pep.as_ref().unwrap();
+                let vsource = &dock_pep.source_addr;
+                let vdest = &dock_pep.dest_addr;
+                if vsource == &ft.source_addr && vdest == &ft.dest_addr {
+                    // Is from VS -> NODE, check for VSS port match.
+                    match &dock_pep.pep {
+                        DockPepType::TCP(tpep) => {
+                            if tpep.dest_port == ft.dest_port && tpep.source_port == ft.source_port
+                            {
+                                // Found it
+                                return Ok(Some(visa));
+                            } else {
+                                continue; // not the right visa
+                            }
+                        }
+                        _ => {
                             continue; // not the right visa
                         }
-                    }
-                    _ => {
-                        continue; // not the right visa
                     }
                 }
             }
@@ -1036,6 +1118,100 @@ mod tests {
             .unwrap();
 
         assert!(result.is_none());
+    }
+
+    /// Callers that pass PendingInstall explicitly (the bootstrap-visa dedup) must match a
+    /// created-but-not-yet-delivered visa, otherwise they mint a duplicate on every pass.
+    #[tokio::test]
+    async fn test_find_node_visa_by_five_tuple_matches_pending_when_requested() {
+        let mgr = make_mgr().await;
+        let node_addr: IpAddr = NODE_ADDR.parse().unwrap();
+        let visa = make_visa(4, std::time::Duration::from_secs(60));
+        let metadata = db::VisaMetadata::new(
+            node_addr.clone(),
+            0,
+            0,
+            "zpl".to_string(),
+            Direction::Forward,
+            None,
+            &make_pdesc(),
+        );
+
+        mgr.repo
+            .store_visa(&visa, metadata, db::NodeVisaState::PendingInstall)
+            .await
+            .unwrap();
+
+        let ft = make_fivetuple_tcp(
+            SRC_ADDR.parse().unwrap(),
+            DST_ADDR.parse().unwrap(),
+            1234,
+            443,
+        )
+        .unwrap();
+
+        let result = mgr
+            .find_node_visa_by_five_tuple(
+                &node_addr,
+                &ft,
+                &[
+                    db::NodeVisaState::Installed,
+                    db::NodeVisaState::PendingInstall,
+                ],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.expect("pending visa should match").issuer_id, 4);
+    }
+
+    /// A bootstrap visa must be mintable for a peer that has no actor and no route --
+    /// that is the entire point, the link is not up yet. Going through the normal visa
+    /// request pipeline would deny NoRoute here. Also asserts the dedup: a second call
+    /// reuses the first visa rather than minting a duplicate.
+    #[tokio::test]
+    async fn test_vsapi_bootstrap_visa_for_future_peer_no_route_no_actor() {
+        let asm = crate::assembly::tests::new_assembly_for_tests(None).await;
+        // Never added to actor_mgr or topo_mgr: an unconnected peer.
+        let future_peer: IpAddr = "fd5a:5052:3000::7".parse().unwrap();
+
+        let visa = asm
+            .visa_mgr
+            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer)
+            .await
+            .expect("bootstrap visa must not need a route");
+
+        let dock_pep = visa.dock_pep.as_ref().expect("full visa has a dock_pep");
+        assert_eq!(dock_pep.source_addr, future_peer);
+        assert_eq!(dock_pep.dest_addr, asm.config.get_vs_addr());
+        match &dock_pep.pep {
+            DockPepType::TCP(tpep) => {
+                assert_eq!(tpep.source_port, 0, "any source port");
+                assert_eq!(
+                    tpep.dest_port,
+                    asm.config.core.vsapi_port.unwrap_or(config::VSAPI_PORT)
+                );
+            }
+            other => panic!("expected a TCP dock pep, got {other:?}"),
+        }
+
+        // Stored pending-install against the peer, so its own worker installs it on connect.
+        let pending = asm
+            .visa_mgr
+            .get_pending_visa_ids_for_node(&future_peer)
+            .await
+            .unwrap();
+        assert_eq!(pending, vec![visa.issuer_id]);
+
+        let again = asm
+            .visa_mgr
+            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer)
+            .await
+            .unwrap();
+        assert_eq!(
+            again.issuer_id, visa.issuer_id,
+            "second call must reuse the pending visa, not mint a duplicate"
+        );
     }
 
     // --- actualize_visa_for_target_node tests ---

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -16,7 +16,7 @@ use crate::visa_policy::{PolicyOutcome, evaluate_against_policy, route_for_allow
 use crate::visareq_worker::{VisaDecision, request_visa_wait_response};
 
 use libeval::eval_result::{Direction, Hit};
-use libeval::route::{NodeId, Route};
+use libeval::route::{LinkId, NodeId, Route, RouteKind};
 use zpr::vsapi_types::vsapi_ip_number as ip_proto;
 use zpr::vsapi_types::{
     CommFlag, DockPep, DockPepType, EndpointT, FwdPep, FwdPepStyle, IcmpPep, KeySet, PacketDesc,
@@ -105,11 +105,28 @@ fn dock_pep_matches_five_tuple(visa: &Visa, ft: &VsapiFiveTuple) -> bool {
     }
 }
 
-fn bootstrap_path(
+/// The node `node_addr` hands off to on `path`, given that it is one of the path's two ends.
+/// `None` if it is not an end (an intermediary has two neighbours, so the question is
+/// ambiguous). Bootstrap dedup asks "does this visa use the peer's link to that relay?", and
+/// the peer is always an end, so this answers it whichever way the path is oriented.
+fn path_neighbour_of_endpoint(path: &[IpAddr], node_addr: &IpAddr) -> Option<IpAddr> {
+    if path.first()? == node_addr {
+        path.get(1).copied()
+    } else if path.last()? == node_addr {
+        path.get(path.len().checked_sub(2)?).copied()
+    } else {
+        None
+    }
+}
+
+/// The routed part of a future peer's path to VSAPI: `via_node` to the node the visa service
+/// docks on. The peer's own link is not in the router until it connects, so it is not in here --
+/// [bootstrap_path] and [bootstrap_route] each stitch it on.
+fn bootstrap_vs_segment(
     asm: &Assembly,
     future_peer: &IpAddr,
     via_node: &IpAddr,
-) -> Result<Vec<IpAddr>, ServiceError> {
+) -> Result<Route, ServiceError> {
     let vs_addr = asm.config.get_vs_addr();
     let vs_dock = asm
         .actor_mgr
@@ -119,22 +136,63 @@ fn bootstrap_path(
                 "visa service {vs_addr} is not docked to a node: cannot path bootstrap visa for {future_peer}"
             ))
         })?;
-    let route = asm
-        .topo_mgr
+    asm.topo_mgr
         .get_best_route(via_node, &vs_dock)
         .ok_or_else(|| {
             ServiceError::Internal(format!(
                 "no route from {via_node} to visa service docking node {vs_dock}"
             ))
-        })?;
+        })
+}
+
+fn bootstrap_path(
+    asm: &Assembly,
+    future_peer: &IpAddr,
+    via_node: &IpAddr,
+) -> Result<Vec<IpAddr>, ServiceError> {
+    let segment = bootstrap_vs_segment(asm, future_peer, via_node)?;
     let mut path = vec![*future_peer];
     path.extend(
         asm.topo_mgr
-            .route_to_path(&route, &NodeId(*via_node))?
+            .route_to_path(&segment, &NodeId(*via_node))?
             .into_iter()
             .map(IpAddr::from),
     );
     Ok(path)
+}
+
+/// The route a future peer's VSAPI traffic takes in the given direction: its own link to
+/// `via_node`, then the routed segment on to the visa service's docking node.
+///
+/// It is always [RouteKind::Multihop] -- at least the peer's link is crossed -- and that link
+/// is described by policy rather than by the router, which does not know it yet.
+/// [Direction::Reverse] walks the same links from the far end, so the order flips.
+pub fn bootstrap_route(
+    asm: &Assembly,
+    future_peer: &IpAddr,
+    via_node: &IpAddr,
+    direction: Direction,
+) -> Result<Route, ServiceError> {
+    let segment = bootstrap_vs_segment(asm, future_peer, via_node)?;
+    let peer_link = asm
+        .policy_mgr
+        .get_current()
+        .describe_link(via_node, future_peer)
+        .map_err(|e| {
+            ServiceError::Internal(format!(
+                "no policy link between {via_node} and future peer {future_peer}: {e}"
+            ))
+        })?;
+    let mut links = vec![LinkId(peer_link.link_id)];
+    links.extend(segment.links);
+    if direction == Direction::Reverse {
+        links.reverse();
+    }
+    Ok(Route {
+        kind: RouteKind::Multihop,
+        links,
+        cost: segment.cost.saturating_add(peer_link.cost),
+    })
 }
 
 impl VisaWithMetadata {
@@ -291,13 +349,23 @@ impl VisaMgr {
         Ok(visas)
     }
 
-    /// Mint (or reuse) the bootstrap visa that lets a not-yet-connected peer reach the
-    /// visa service's VSAPI port, which is how it connects in the first place.
+    /// Mint (or reuse) one direction of the bootstrap flow that lets a not-yet-connected peer
+    /// reach the visa service's VSAPI port, which is how it connects in the first place.
     ///
     /// The visa belongs to `future_peer` and is stored pending-install against it.
     /// `via_node` is the already-connected neighbour whose topology message carries the
     /// copy handed off when the peer shows up; it is also the peer's first hop, so the
     /// path is anchored on it (see [bootstrap_path]).
+    ///
+    /// `direction` picks which half of the flow this visa is for. A visa carries exactly one
+    /// dock PEP and one path orientation, so the two halves cannot share one:
+    /// - [Direction::Forward] is the peer's own SYN, `peer:any -> vs:VSAPI`, ingressing at the
+    ///   peer and forwarded towards the node the visa service docks on.
+    /// - [Direction::Reverse] is the visa service's reply, `vs:VSAPI -> peer:any`, ingressing
+    ///   at the docking node and forwarded towards the peer.
+    ///
+    /// Call it once per direction: with only the forward visa the reply is dropped, because no
+    /// dock PEP matches it and no node on the forward path has a route back.
     ///
     /// This deliberately bypasses policy evaluation. The peer cannot be evaluated --
     /// it has no actor and no route until the link comes up -- and it needs none: a
@@ -309,13 +377,18 @@ impl VisaMgr {
         asm: &Assembly,
         future_peer: &IpAddr,
         via_node: &IpAddr,
+        direction: Direction,
     ) -> Result<Visa, ServiceError> {
-        let ft = make_fivetuple_tcp(
-            future_peer.clone(),      // from future peer
-            asm.config.get_vs_addr(), // to the visa service
-            0,
-            asm.config.core.vsapi_port.unwrap_or(config::VSAPI_PORT),
-        )?;
+        let vs_addr = asm.config.get_vs_addr();
+        let vsapi_port = asm.config.core.vsapi_port.unwrap_or(config::VSAPI_PORT);
+        // The wildcard port sits on the peer's side in both cases: it is the client, so its
+        // port is unknown until it picks one. This is also what `create_visa_with_path`
+        // derives for a BiDirectional packet in each direction, so the dedup lookup below
+        // compares equal to what was stored.
+        let ft = match direction {
+            Direction::Forward => make_fivetuple_tcp(*future_peer, vs_addr, 0, vsapi_port)?,
+            Direction::Reverse => make_fivetuple_tcp(vs_addr, *future_peer, vsapi_port, 0)?,
+        };
         // One neighbour can mint for the same peer from several places concurrently -- its
         // topology sends (the policy-update fan-out, or every worker's initial sync after a VS
         // restart) and a visa request pulling the visa. Without this the lookup below and the
@@ -356,14 +429,20 @@ impl VisaMgr {
             // The path cannot be routed -- the peer's link is not up -- so hand it in
             // explicitly. It has to be there: without it the peer's copy gets no fwd_pep
             // and the relaying nodes get no copy at all, leaving the visa unusable.
-            // Forward + BiDirectional gives the ports we want: any source port -> VSAPI.
             let policy = asm.policy_mgr.get_current();
-            let hit = Hit::new_no_signal(0, Direction::Forward);
-            let path = bootstrap_path(asm, future_peer, via_node)?;
+            let hit = Hit::new_no_signal(0, direction);
+            // [bootstrap_path] is peer-first, which is the forward flow's orientation. The
+            // reply ingresses at the other end, so flip it: actualization decides each node's
+            // role from the path plus the ingress node, and `path[0]` is that node either way.
+            let mut path = bootstrap_path(asm, future_peer, via_node)?;
+            if direction == Direction::Reverse {
+                path.reverse();
+            }
+            let ingress_node = path[0]; // bootstrap_path is never empty
 
             let visawmd = self
                 .create_visa_with_path(
-                    future_peer,
+                    &ingress_node,
                     &pkt_data,
                     &hit,
                     Some(path),
@@ -388,8 +467,8 @@ impl VisaMgr {
 
     /// Use a linear search of the node's visas in any of `states` to find a five-tuple match.
     ///
-    /// `relay`, when given, additionally requires the visa's path to hand off from `node_addr`
-    /// to that node. A five-tuple match alone is ambiguous once the path matters: a node with
+    /// `relay`, when given, additionally requires the visa's path to put that node next to
+    /// `node_addr`. A five-tuple match alone is ambiguous once the path matters: a node with
     /// several links needs one visa per link for the same flow, because each visa carries a
     /// single path.
     ///
@@ -407,9 +486,12 @@ impl VisaMgr {
                     continue;
                 }
                 if let Some(relay) = relay {
-                    // path[0] is `node_addr` itself, path[1] is the node it hands off to.
                     let md = self.repo.get_visa_metadata_by_id(visa.issuer_id)?;
-                    if md.path.as_ref().and_then(|p| p.get(1)) != Some(relay) {
+                    let neighbour = md
+                        .path
+                        .as_ref()
+                        .and_then(|p| path_neighbour_of_endpoint(p, node_addr));
+                    if neighbour.as_ref() != Some(relay) {
                         continue;
                     }
                 }
@@ -1300,7 +1382,7 @@ mod tests {
 
         let visa = asm
             .visa_mgr
-            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_node)
+            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_node, Direction::Forward)
             .await
             .expect("bootstrap visa must not need a route from the peer itself");
 
@@ -1328,7 +1410,7 @@ mod tests {
 
         let again = asm
             .visa_mgr
-            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_node)
+            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_node, Direction::Forward)
             .await
             .unwrap();
         assert_eq!(
@@ -1355,12 +1437,12 @@ mod tests {
 
         let visa_a = asm
             .visa_mgr
-            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_a)
+            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_a, Direction::Forward)
             .await
             .unwrap();
         let visa_b = asm
             .visa_mgr
-            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_b)
+            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_b, Direction::Forward)
             .await
             .unwrap();
 
@@ -1389,7 +1471,7 @@ mod tests {
         // Dedup still applies per relay.
         let again = asm
             .visa_mgr
-            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_b)
+            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_b, Direction::Forward)
             .await
             .unwrap();
         assert_eq!(
@@ -1409,7 +1491,7 @@ mod tests {
 
         let visa = asm
             .visa_mgr
-            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_node)
+            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_node, Direction::Forward)
             .await
             .unwrap();
 
@@ -1445,7 +1527,7 @@ mod tests {
 
         let visa = asm
             .visa_mgr
-            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_node)
+            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_node, Direction::Forward)
             .await
             .unwrap();
         let md = asm
@@ -1495,6 +1577,7 @@ mod tests {
             &asm,
             &future_peer,
             &via_node,
+            Direction::Forward,
         ));
         assert!(
             tokio::time::timeout(Duration::from_secs(1), &mut mint)

--- a/vs/src/visa_mgr.rs
+++ b/vs/src/visa_mgr.rs
@@ -19,6 +19,7 @@ use crate::visa_policy::{
 use crate::visareq_worker::{VisaDecision, request_visa_wait_response};
 
 use libeval::eval_result::{Direction, Hit};
+use libeval::policy::Policy;
 use libeval::route::{NodeId, Route};
 use zpr::vsapi_types::vsapi_ip_number as ip_proto;
 use zpr::vsapi_types::{
@@ -287,11 +288,17 @@ impl VisaMgr {
     /// it has no actor and no route until the link comes up -- and it needs none: a
     /// peering declared in policy *is* the authorization for that peer to reach VSAPI.
     ///
+    /// `policy` is the caller's view, not a fresh read: the peering that authorizes this
+    /// visa was selected by the caller from that same view, so the generation recorded on
+    /// the visa has to come from it too, or a policy install landing mid-call stamps the
+    /// visa with a generation that never authorized it.
+    ///
     /// TODO: Added as a HACK to get initial MULTINODE working. Should be re-evaluated later.
     /// See: https://github.com/org-zpr/zpr-visaservice/issues/301
     pub async fn vsapi_bootstrap_visa_for_future_peer(
         &self,
         asm: &Assembly,
+        policy: &Arc<Policy>,
         future_peer: &IpAddr,
         via_node: &IpAddr,
         direction: Direction,
@@ -346,7 +353,15 @@ impl VisaMgr {
             // The path cannot be routed -- the peer's link is not up -- so hand it in
             // explicitly. It has to be there: without it the peer's copy gets no fwd_pep
             // and the relaying nodes get no copy at all, leaving the visa unusable.
-            let policy = asm.policy_mgr.get_current();
+            //
+            // The path and the recorded generation come from different places on purpose.
+            // Everything policy-derived -- the peering that authorizes this visa, its
+            // link_id and cost, the generation stamped below -- comes from the caller's
+            // `policy`, so one mint cannot straddle two policy installs. The path is read
+            // live from the router instead, and has to be: actualization pushes a copy to
+            // every node on it, so it must name nodes whose links are actually up. A
+            // `PolicySnapshot` carries no topology at all (see `policy_mgr::PolicyState`),
+            // so there is no snapshot to take the path from.
             let hit = Hit::new_no_signal(0, direction);
             // [path_for_future_peer] is peer-first, which is the forward flow's orientation. The
             // reply ingresses at the other end, so flip it: actualization decides each node's
@@ -1284,7 +1299,13 @@ mod tests {
 
         let visa = asm
             .visa_mgr
-            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_node, Direction::Forward)
+            .vsapi_bootstrap_visa_for_future_peer(
+                &asm,
+                &asm.policy_mgr.get_current(),
+                &future_peer,
+                &via_node,
+                Direction::Forward,
+            )
             .await
             .expect("bootstrap visa must not need a route from the peer itself");
 
@@ -1312,7 +1333,13 @@ mod tests {
 
         let again = asm
             .visa_mgr
-            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_node, Direction::Forward)
+            .vsapi_bootstrap_visa_for_future_peer(
+                &asm,
+                &asm.policy_mgr.get_current(),
+                &future_peer,
+                &via_node,
+                Direction::Forward,
+            )
             .await
             .unwrap();
         assert_eq!(
@@ -1339,12 +1366,24 @@ mod tests {
 
         let visa_a = asm
             .visa_mgr
-            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_a, Direction::Forward)
+            .vsapi_bootstrap_visa_for_future_peer(
+                &asm,
+                &asm.policy_mgr.get_current(),
+                &future_peer,
+                &via_a,
+                Direction::Forward,
+            )
             .await
             .unwrap();
         let visa_b = asm
             .visa_mgr
-            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_b, Direction::Forward)
+            .vsapi_bootstrap_visa_for_future_peer(
+                &asm,
+                &asm.policy_mgr.get_current(),
+                &future_peer,
+                &via_b,
+                Direction::Forward,
+            )
             .await
             .unwrap();
 
@@ -1373,7 +1412,13 @@ mod tests {
         // Dedup still applies per relay.
         let again = asm
             .visa_mgr
-            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_b, Direction::Forward)
+            .vsapi_bootstrap_visa_for_future_peer(
+                &asm,
+                &asm.policy_mgr.get_current(),
+                &future_peer,
+                &via_b,
+                Direction::Forward,
+            )
             .await
             .unwrap();
         assert_eq!(
@@ -1393,7 +1438,13 @@ mod tests {
 
         let visa = asm
             .visa_mgr
-            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_node, Direction::Forward)
+            .vsapi_bootstrap_visa_for_future_peer(
+                &asm,
+                &asm.policy_mgr.get_current(),
+                &future_peer,
+                &via_node,
+                Direction::Forward,
+            )
             .await
             .unwrap();
 
@@ -1429,7 +1480,13 @@ mod tests {
 
         let visa = asm
             .visa_mgr
-            .vsapi_bootstrap_visa_for_future_peer(&asm, &future_peer, &via_node, Direction::Forward)
+            .vsapi_bootstrap_visa_for_future_peer(
+                &asm,
+                &asm.policy_mgr.get_current(),
+                &future_peer,
+                &via_node,
+                Direction::Forward,
+            )
             .await
             .unwrap();
         let md = asm
@@ -1475,8 +1532,11 @@ mod tests {
         let future_peer: IpAddr = "fd5a:5052:3000::8".parse().unwrap();
 
         let guard = asm.visa_mgr.bootstrap_lock.lock().await;
+        // Named local: the future outlives the statement, so this cannot be a temporary.
+        let policy = asm.policy_mgr.get_current();
         let mut mint = Box::pin(asm.visa_mgr.vsapi_bootstrap_visa_for_future_peer(
             &asm,
+            &policy,
             &future_peer,
             &via_node,
             Direction::Forward,

--- a/vs/src/visa_policy.rs
+++ b/vs/src/visa_policy.rs
@@ -46,6 +46,18 @@ fn resolve_docking_node(asm: &Assembly, actor: &Actor, zpr_addr: &IpAddr) -> Opt
         .or_else(|| asm.actor_mgr.get_docking_node_for_aaa(zpr_addr))
 }
 
+/// Docking node of whatever actor owns `zpr_addr` -- the node its traffic enters the fabric
+/// at. As [resolve_docking_node] but starting from the address alone, for callers holding a
+/// five-tuple rather than an actor. `None` if the actor is unknown or undocked.
+pub(crate) async fn docking_node_for_addr(asm: &Assembly, zpr_addr: &IpAddr) -> Option<IpAddr> {
+    match asm.actor_mgr.get_actor_by_zpr_addr(zpr_addr).await {
+        Ok(Some(actor)) => resolve_docking_node(asm, &actor, zpr_addr),
+        // Anonymous actors are fabricated per request and never stored, so for an AAA
+        // address the AAA table is the only record of where it docked.
+        _ => asm.actor_mgr.get_docking_node_for_aaa(zpr_addr),
+    }
+}
+
 /// Shared policy-evaluation core: resolve both docking nodes, require a route,
 /// then run the actors and packet through the policy (handling `NeedsRoute` route
 /// evaluation). An undocked endpoint or no best route falls out as `Deny`.

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -28,14 +28,13 @@ use futures::future::{FutureExt, join_all};
 
 use libeval::actor::Actor;
 use libeval::attribute::{Attribute, ROLE_ADAPTER, key};
-use libeval::eval_result::{Direction, Hit};
+use libeval::eval_result::Hit;
 use libeval::policy::Policy;
 use libeval::route::Route;
 
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, error, warn};
-use zpr::vsapi_types::vsapi_ip_number as ip_proto;
 use zpr::vsapi_types::{DenyCode, PacketDesc, Visa};
 
 use crate::actor_attributes::refresh_and_persist_actor;
@@ -44,7 +43,8 @@ use crate::counters::CounterType;
 use crate::error::ServiceError;
 use crate::logging::targets::VREQ;
 use crate::packet::describe_five_tuple;
-use crate::visa_mgr::{VisaWithMetadata, bootstrap_route};
+use crate::visa_bootstrap;
+use crate::visa_mgr::VisaWithMetadata;
 use crate::visa_policy::{PolicyOutcome, evaluate_against_policy, route_for_allow};
 use crate::{config, net_mgr};
 
@@ -214,7 +214,8 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
     // either; the pre-minted bootstrap visa can.
     if source_actor.is_none() || dest_actor.is_none() {
         if let Some(decision) =
-            bootstrap_visa_for_future_peer_request(&asm, job, &source_actor, &dest_actor).await
+            visa_bootstrap::visa_for_future_peer_request(&asm, job, &source_actor, &dest_actor)
+                .await
         {
             return Ok(decision);
         }
@@ -282,97 +283,16 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
     }
 }
 
-/// Answer a request for a not-yet-connected peer's VSAPI bootstrap flow from the visa we
-/// already minted, instead of from policy.
-///
-/// `vss_do_set_topology` pushes this visa to the peer's neighbours inside `Link.visas`, but a
-/// neighbour whose dataplane sees the peer's SYN before it installs that copy asks for it
-/// instead. Policy cannot answer: the peer has no actor and no route until it connects, and
-/// reaching VSAPI is how it connects. A peering declared in policy *is* the authorization --
-/// the same argument that justifies minting at topology-send time -- so hand the visa back.
-/// Minting is idempotent, so this returns the same visa the neighbours were pushed.
-///
-/// Either orientation counts -- the peer's own SYN (`peer:any -> vs:VSAPI`) or the reply
-/// (`vs:VSAPI -> peer:any`) -- and a node may ask about whichever it sees first. They are two
-/// visas, not one: a visa's dock PEP names a source and a destination, and its path has an
-/// ingress end, so the forward visa matches neither the reply's addresses nor its direction of
-/// travel. The direction detected here is what selects the right one.
-///
-/// Returns `None` when this is not that flow (including on a mint failure), leaving the
-/// request to normal evaluation.
-async fn bootstrap_visa_for_future_peer_request(
-    asm: &Arc<Assembly>,
-    job: &VisaRequestJob,
-    source_actor: &Option<Actor>,
-    dest_actor: &Option<Actor>,
-) -> Option<VisaDecision> {
-    let ft = &job.packet_desc.five_tuple;
-    if ft.l4_protocol != ip_proto::TCP {
-        return None;
-    }
-    let vs_addr = asm.config.get_vs_addr();
-    let vsapi_port = asm.config.core.vsapi_port.unwrap_or(config::VSAPI_PORT);
-
-    // Which end is the peer, which direction of the flow is this, and is the peer's actor the
-    // missing one? A connected peer's VSAPI traffic must go through policy like anything else.
-    let (peer_addr, direction, peer_actor_missing) =
-        if ft.dest_addr == vs_addr && ft.dest_port == vsapi_port {
-            (ft.source_addr, Direction::Forward, source_actor.is_none())
-        } else if ft.source_addr == vs_addr && ft.source_port == vsapi_port {
-            (ft.dest_addr, Direction::Reverse, dest_actor.is_none())
-        } else {
-            return None;
-        };
-    if !peer_actor_missing {
-        return None;
-    }
-
-    // Only for a peer the requesting node is declared to link with: that node is the one
-    // that would be handed the visa by a topology send, so it is the one allowed to pull it.
-    let policy = asm.policy_mgr.get_current();
-    let peers = policy
-        .get_peers_for_node(&job.requesting_node)
-        .unwrap_or(&[]);
-    if !peers.iter().any(|p| p.remote_zpr_addr == peer_addr) {
-        debug!(target: VREQ, "node {} asked about VSAPI flow with {peer_addr}, which is not one of its {} declared peers: not a bootstrap request", job.requesting_node, peers.len());
-        return None;
-    }
-
-    // The requesting node relays for the peer, so it is `via_node` of the minted path, and
-    // what it needs is its own actualized copy (forwarding-only, or full if it is an end of
-    // the path) -- not the copy the peer gets pushed in `Link.visas`.
-    let visa = match asm
-        .visa_mgr
-        .vsapi_bootstrap_visa_for_future_peer(asm, &peer_addr, &job.requesting_node, direction)
-        .await
-    {
-        Ok(visa) => visa,
-        Err(e) => {
-            warn!(target: VREQ, "failed to mint bootstrap visa for future peer {peer_addr} requested by node {}: {e}", job.requesting_node);
-            return None;
-        }
-    };
-    let route = match bootstrap_route(asm, &peer_addr, &job.requesting_node, direction) {
-        Ok(route) => route,
-        Err(e) => {
-            warn!(target: VREQ, "failed to build the bootstrap route for future peer {peer_addr} via node {}: {e}", job.requesting_node);
-            return None;
-        }
-    };
-    match asm
-        .visa_mgr
-        .actualize_visa_for_target_node(visa, &job.requesting_node)
-        .await
-    {
-        Ok(visa) => {
-            debug!(target: VREQ, "node {} requested the bootstrap visa for future peer {peer_addr}: returning visa {}", job.requesting_node, visa.issuer_id);
-            Some(VisaDecision::Allow(visa, route))
-        }
-        Err(e) => {
-            warn!(target: VREQ, "failed to actualize bootstrap visa for node {} relaying future peer {peer_addr}: {e}", job.requesting_node);
-            None
-        }
-    }
+/// Run one visa request end to end, for tests in other modules. A [VisaRequestJob]'s response
+/// channel is private, so they cannot drive [process_visa_request] themselves.
+#[cfg(test)]
+pub(crate) async fn process_visa_request_for_test(
+    asm: Arc<Assembly>,
+    requesting_node: IpAddr,
+    pkt: PacketDesc,
+) -> VisaDecision {
+    let (job, _rx) = VisaRequestJob::new(requesting_node, pkt);
+    process_visa_request(asm, &job).await.unwrap()
 }
 
 /// Fabricate an AAA actor for an anonymous endpoint at the given address.
@@ -1170,226 +1090,6 @@ mod tests {
         assert!(
             matches!(result, VisaDecision::Deny(DenyCode::NoMatch)),
             "expected NoMatch (policy eval reached)"
-        );
-    }
-
-    /// Assembly for the bootstrap tests: policy declares one `via_node`<->`future_peer`
-    /// peering, and `via_node` is connected and docks the visa service. The peer is left
-    /// unconnected (no actor, no route) -- callers that want it connected add its actor.
-    async fn build_bootstrap_test_asm(via_node: IpAddr, future_peer: IpAddr) -> Assembly {
-        use crate::db::PolicyRepo;
-        use crate::policy_mgr::PolicyMgr;
-        use crate::test_helpers::{FakeResolver, make_peering, policy_with_peerings};
-        use crate::trusted_services::TrustedServicesMgr;
-        use std::path::PathBuf;
-
-        let mut asm = new_assembly_for_tests(None).await;
-        asm.policy_mgr = PolicyMgr::new_with_initial_policy(
-            policy_with_peerings(&[make_peering(via_node, future_peer, "link-vp", vec![])]),
-            PolicyRepo::new(asm.state_db.clone()),
-            Arc::new(FakeResolver::ip_only()),
-            Arc::new(TrustedServicesMgr::new()),
-            PathBuf::from("."),
-        )
-        .await
-        .unwrap();
-        asm.topo_mgr.add_node(via_node).unwrap();
-        asm.actor_mgr
-            .hack_set_vs_docking_node(&via_node)
-            .await
-            .unwrap();
-        asm
-    }
-
-    /// The two directions of a future peer's VSAPI flow, as a node's dataplane would ask about
-    /// them: the peer's own SYN, and the visa service's reply to it.
-    fn bootstrap_flow_packets(asm: &Assembly, future_peer: &IpAddr) -> (PacketDesc, PacketDesc) {
-        let vs_addr = asm.config.get_vs_addr().to_string();
-        let peer = future_peer.to_string();
-        let vsapi_port = asm.config.core.vsapi_port.unwrap_or(config::VSAPI_PORT);
-        (
-            PacketDesc::new_tcp(&peer, &vs_addr, 40000, vsapi_port).unwrap(),
-            PacketDesc::new_tcp(&vs_addr, &peer, vsapi_port, 40000).unwrap(),
-        )
-    }
-
-    /// A visa request from a connected node on behalf of a policy-declared peer that has not
-    /// connected yet is answered from the pre-minted bootstrap visa. Policy cannot answer it:
-    /// the peer has no actor and no route, which is exactly what reaching VSAPI would fix.
-    #[tokio::test]
-    async fn bootstrap_visa_request_for_future_peer_is_allowed() {
-        let via_node: IpAddr = "fd5a:5052:3000::1".parse().unwrap(); // connected, docks the VS
-        let future_peer: IpAddr = "fd5a:5052:3000::7".parse().unwrap(); // no actor, no route
-        let asm = Arc::new(build_bootstrap_test_asm(via_node, future_peer).await);
-
-        let pkt = PacketDesc::new_tcp(
-            &future_peer.to_string(),
-            &asm.config.get_vs_addr().to_string(),
-            40000,
-            asm.config.core.vsapi_port.unwrap_or(config::VSAPI_PORT),
-        )
-        .unwrap();
-        let (job, _rx) = VisaRequestJob::new(via_node, pkt);
-
-        let visa = match process_visa_request(asm.clone(), &job).await.unwrap() {
-            VisaDecision::Allow(visa, _) => visa,
-            VisaDecision::Deny(code) => panic!("expected allow, got deny {code:?}"),
-        };
-
-        // It is the peer's own visa, held pending-install until the peer connects.
-        let pending = asm
-            .visa_mgr
-            .get_pending_visa_ids_for_node(&future_peer)
-            .await
-            .unwrap();
-        assert_eq!(pending, vec![visa.issuer_id]);
-    }
-
-    /// The reply direction gets its own visa. One visa carries one dock PEP and one path
-    /// orientation, so the forward visa (`peer -> vs:VSAPI`, pathed peer-first) cannot answer
-    /// `vs:VSAPI -> peer`: its PEP would not match the packet and no node on its path would
-    /// forward the reply. The reverse visa must be a distinct visa, addressed and pathed the
-    /// other way, with the requesting node forwarding towards the peer.
-    #[tokio::test]
-    async fn bootstrap_visa_reply_direction_gets_its_own_reverse_visa() {
-        use zpr::vsapi_types::{DockPepType, EndpointT};
-
-        let via_node: IpAddr = "fd5a:5052:3000::1".parse().unwrap(); // connected, docks the VS
-        let future_peer: IpAddr = "fd5a:5052:3000::7".parse().unwrap(); // no actor, no route
-        let asm = Arc::new(build_bootstrap_test_asm(via_node, future_peer).await);
-        let vs_addr = asm.config.get_vs_addr();
-        let vsapi_port = asm.config.core.vsapi_port.unwrap_or(config::VSAPI_PORT);
-        let (syn_pkt, reply_pkt) = bootstrap_flow_packets(&asm, &future_peer);
-
-        let (syn_job, _rx) = VisaRequestJob::new(via_node, syn_pkt);
-        let syn_visa = match process_visa_request(asm.clone(), &syn_job).await.unwrap() {
-            VisaDecision::Allow(visa, _) => visa,
-            VisaDecision::Deny(code) => panic!("expected allow for SYN direction, got {code:?}"),
-        };
-
-        let (reply_job, _rx) = VisaRequestJob::new(via_node, reply_pkt);
-        let reply_visa = match process_visa_request(asm.clone(), &reply_job).await.unwrap() {
-            VisaDecision::Allow(visa, _) => visa,
-            VisaDecision::Deny(code) => panic!("expected allow for reply direction, got {code:?}"),
-        };
-
-        assert_ne!(
-            reply_visa.issuer_id, syn_visa.issuer_id,
-            "the reply direction needs its own visa, not the forward one"
-        );
-
-        // The dock PEP must describe the reply packet: vs:VSAPI -> peer:any, server side.
-        let dock_pep = reply_visa.dock_pep.expect("reverse visa must be full");
-        assert_eq!(dock_pep.source_addr, vs_addr);
-        assert_eq!(dock_pep.dest_addr, future_peer);
-        match dock_pep.pep {
-            DockPepType::TCP(tpep) => {
-                assert_eq!(tpep.source_port, vsapi_port);
-                assert_eq!(tpep.dest_port, 0, "reply direction allows any dest port");
-                assert_eq!(tpep.endpoint, EndpointT::Server);
-            }
-            other => panic!("expected a TCP dock PEP, got {other:?}"),
-        }
-
-        // The requesting node is where the reply ingresses, so it must forward to the peer.
-        let fwd_pep = reply_visa
-            .fwd_pep
-            .expect("reply ingress node needs a forwarding PEP towards the peer");
-        assert_eq!(fwd_pep.next_hop, future_peer);
-
-        // Both directions are held for the peer until it connects.
-        let mut pending = asm
-            .visa_mgr
-            .get_pending_visa_ids_for_node(&future_peer)
-            .await
-            .unwrap();
-        pending.sort();
-        let mut expected = vec![syn_visa.issuer_id, reply_visa.issuer_id];
-        expected.sort();
-        assert_eq!(pending, expected);
-    }
-
-    /// The route returned with a bootstrap visa names the links the traffic really crosses: the
-    /// peer's own link, which only policy knows about, plus the routed segment on to the visa
-    /// service's docking node -- ordered from the ingress end of the direction asked about.
-    #[tokio::test]
-    async fn bootstrap_visa_route_spans_peer_link_and_routed_segment() {
-        use libeval::route::{LinkId, RouteKind};
-
-        let via_node: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
-        let dock_node: IpAddr = "fd5a:5052:3000::2".parse().unwrap(); // docks the VS, one hop on
-        let future_peer: IpAddr = "fd5a:5052:3000::7".parse().unwrap();
-
-        let asm = build_bootstrap_test_asm(via_node, future_peer).await;
-        asm.topo_mgr.add_node(dock_node).unwrap();
-        asm.topo_mgr
-            .add_link(via_node, dock_node, LinkId("link-vd".into()), vec![], 1)
-            .unwrap();
-        asm.actor_mgr
-            .hack_set_vs_docking_node(&dock_node)
-            .await
-            .unwrap();
-        let asm = Arc::new(asm);
-        let (syn_pkt, reply_pkt) = bootstrap_flow_packets(&asm, &future_peer);
-
-        let (syn_job, _rx) = VisaRequestJob::new(via_node, syn_pkt);
-        let syn_route = match process_visa_request(asm.clone(), &syn_job).await.unwrap() {
-            VisaDecision::Allow(_, route) => route,
-            VisaDecision::Deny(code) => panic!("expected allow for SYN direction, got {code:?}"),
-        };
-        assert!(
-            matches!(syn_route.kind, RouteKind::Multihop),
-            "the peer's own link is always crossed, so this is never a direct route"
-        );
-        assert_eq!(
-            syn_route.links,
-            vec![LinkId("link-vp".into()), LinkId("link-vd".into())],
-            "peer's link first, then the routed segment to the docking node"
-        );
-        assert_eq!(syn_route.cost, 2, "one policy link plus one router link");
-
-        let (reply_job, _rx) = VisaRequestJob::new(via_node, reply_pkt);
-        let reply_route = match process_visa_request(asm.clone(), &reply_job).await.unwrap() {
-            VisaDecision::Allow(_, route) => route,
-            VisaDecision::Deny(code) => panic!("expected allow for reply direction, got {code:?}"),
-        };
-        assert_eq!(
-            reply_route.links,
-            vec![LinkId("link-vd".into()), LinkId("link-vp".into())],
-            "the reply crosses the same links from the other end"
-        );
-    }
-
-    /// A connected peer's VSAPI traffic is not a bootstrap request: it has an actor, so it
-    /// goes through policy like anything else.
-    #[tokio::test]
-    async fn bootstrap_visa_request_declined_for_connected_peer() {
-        let via_node: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
-        let peer: IpAddr = "fd5a:5052:3000::7".parse().unwrap();
-
-        let asm = build_bootstrap_test_asm(via_node, peer).await;
-        // The peer is connected now, so it has an actor.
-        let peer_actor = make_node_actor_defexp(&peer.to_string(), "peer-node", "10.0.0.7:5001");
-        asm.actor_mgr.add_node(&peer_actor, false).await.unwrap();
-        let asm = Arc::new(asm);
-
-        let pkt = PacketDesc::new_tcp(
-            &peer.to_string(),
-            &asm.config.get_vs_addr().to_string(),
-            40000,
-            asm.config.core.vsapi_port.unwrap_or(config::VSAPI_PORT),
-        )
-        .unwrap();
-        let (job, _rx) = VisaRequestJob::new(via_node, pkt);
-
-        // Reaches policy evaluation (which has no matching comm policy) rather than being
-        // short-circuited into an allow.
-        assert!(
-            matches!(
-                process_visa_request(asm, &job).await.unwrap(),
-                VisaDecision::Deny(_)
-            ),
-            "a connected peer must not get a bootstrap visa"
         );
     }
 }

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -30,11 +30,12 @@ use libeval::actor::Actor;
 use libeval::attribute::{Attribute, ROLE_ADAPTER, key};
 use libeval::eval_result::Hit;
 use libeval::policy::Policy;
-use libeval::route::Route;
+use libeval::route::{NodeId, Route};
 
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, error, warn};
+use zpr::vsapi_types::vsapi_ip_number as ip_proto;
 use zpr::vsapi_types::{DenyCode, PacketDesc, Visa};
 
 use crate::actor_attributes::refresh_and_persist_actor;
@@ -206,6 +207,18 @@ async fn process_visa_request_job(asm: Arc<Assembly>, job: VisaRequestJob) {
 /// Run visa request.
 async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaRequestResult {
     let (source_actor, dest_actor) = get_actors(&asm, job).await?;
+
+    // An endpoint with no actor may be a peer that has not connected yet, on either end of a
+    // VSAPI flow: the peer's own SYN, or the reply direction of it. Policy cannot answer
+    // either; the pre-minted bootstrap visa can.
+    if source_actor.is_none() || dest_actor.is_none() {
+        if let Some(decision) =
+            bootstrap_visa_for_future_peer_request(&asm, job, &source_actor, &dest_actor).await
+        {
+            return Ok(decision);
+        }
+    }
+
     let (mut source_actor, mut dest_actor) =
         match resolve_actors_or_deny(&asm, job, source_actor, dest_actor).await {
             Ok(actors) => actors,
@@ -266,6 +279,101 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
         } => visa_from_allow(asm.clone(), job, &hits, &policy, default_route).await,
         PolicyOutcome::Deny(code) => Ok(VisaDecision::Deny(code)),
     }
+}
+
+/// Answer a request for a not-yet-connected peer's VSAPI bootstrap flow from the visa we
+/// already minted, instead of from policy.
+///
+/// `vss_do_set_topology` pushes this visa to the peer's neighbours inside `Link.visas`, but a
+/// neighbour whose dataplane sees the peer's SYN before it installs that copy asks for it
+/// instead. Policy cannot answer: the peer has no actor and no route until it connects, and
+/// reaching VSAPI is how it connects. A peering declared in policy *is* the authorization --
+/// the same argument that justifies minting at topology-send time -- so hand the visa back.
+/// Minting is idempotent, so this returns the same visa the neighbours were pushed.
+///
+/// Either orientation counts: the peer's own SYN (`peer:any -> vs:VSAPI`) and the reply
+/// direction (`vs:VSAPI -> peer:any`) are one bidirectional flow covered by one visa, and a
+/// node may request for whichever it sees first.
+///
+/// Returns `None` when this is not that flow (including on a mint failure), leaving the
+/// request to normal evaluation.
+async fn bootstrap_visa_for_future_peer_request(
+    asm: &Arc<Assembly>,
+    job: &VisaRequestJob,
+    source_actor: &Option<Actor>,
+    dest_actor: &Option<Actor>,
+) -> Option<VisaDecision> {
+    let ft = &job.packet_desc.five_tuple;
+    if ft.l4_protocol != ip_proto::TCP {
+        return None;
+    }
+    let vs_addr = asm.config.get_vs_addr();
+    let vsapi_port = asm.config.core.vsapi_port.unwrap_or(config::VSAPI_PORT);
+
+    // Which end is the peer, and is its actor the missing one? A connected peer's VSAPI
+    // traffic must go through policy like anything else.
+    let (peer_addr, peer_actor_missing) = if ft.dest_addr == vs_addr && ft.dest_port == vsapi_port {
+        (ft.source_addr, source_actor.is_none())
+    } else if ft.source_addr == vs_addr && ft.source_port == vsapi_port {
+        (ft.dest_addr, dest_actor.is_none())
+    } else {
+        return None;
+    };
+    if !peer_actor_missing {
+        return None;
+    }
+
+    // Only for a peer the *requesting* node is declared to link with: that node is the one
+    // that would be handed the visa by a topology send, so it is the one allowed to pull it.
+    let policy = asm.policy_mgr.get_current();
+    let peers = policy
+        .get_peers_for_node(&job.requesting_node)
+        .unwrap_or(&[]);
+    if !peers.iter().any(|p| p.remote_zpr_addr == peer_addr) {
+        debug!(target: VREQ, "node {} asked about VSAPI flow with {peer_addr}, which is not one of its {} declared peers: not a bootstrap request", job.requesting_node, peers.len());
+        return None;
+    }
+
+    // The requesting node relays for the peer, so it is `via_node` of the minted path, and
+    // what it needs is its own actualized copy (forwarding-only, or full if it is the egress
+    // node) -- not the ingress copy the peer gets pushed in `Link.visas`.
+    let visa = match asm
+        .visa_mgr
+        .vsapi_bootstrap_visa_for_future_peer(asm, &peer_addr, &job.requesting_node)
+        .await
+    {
+        Ok(visa) => visa,
+        Err(e) => {
+            warn!(target: VREQ, "failed to mint bootstrap visa for future peer {peer_addr} requested by node {}: {e}", job.requesting_node);
+            return None;
+        }
+    };
+    match asm
+        .visa_mgr
+        .actualize_visa_for_target_node(visa, &job.requesting_node)
+        .await
+    {
+        Ok(visa) => {
+            debug!(target: VREQ, "node {} requested the bootstrap visa for future peer {peer_addr}: returning visa {}", job.requesting_node, visa.issuer_id);
+            Some(VisaDecision::Allow(
+                visa,
+                Route::new_direct(NodeId(peer_addr)),
+            ))
+        }
+        Err(e) => {
+            warn!(target: VREQ, "failed to actualize bootstrap visa for node {} relaying future peer {peer_addr}: {e}", job.requesting_node);
+            None
+        }
+    }
+}
+
+/// One-line `src:port -> dst:port proto` for logging a request's flow.
+fn describe_five_tuple(pdesc: &PacketDesc) -> String {
+    let ft = &pdesc.five_tuple;
+    format!(
+        "{}:{} -> {}:{} proto {}",
+        ft.source_addr, ft.source_port, ft.dest_addr, ft.dest_port, ft.l4_protocol
+    )
 }
 
 /// Fabricate an AAA actor for an anonymous endpoint at the given address.
@@ -464,8 +572,11 @@ async fn resolve_actors_or_deny(
     {
         Some(actor) => actor,
         None => {
+            // Names the requesting node and the flow: without them a denial for an
+            // unconnected peer is indistinguishable from a genuine AAA miss.
             warn!(target: VREQ,
-                "visa denied: {anon_addr} is not a registered AAA address (peer {candidate_addr})"
+                "visa denied ({deny:?}) for node {}: {anon_addr} has no actor and is not a registered AAA address (peer {candidate_addr}, flow {})",
+                job.requesting_node, describe_five_tuple(&job.packet_desc)
             );
             return Err(VisaDecision::Deny(deny));
         }
@@ -1060,6 +1171,130 @@ mod tests {
         assert!(
             matches!(result, VisaDecision::Deny(DenyCode::NoMatch)),
             "expected NoMatch (policy eval reached)"
+        );
+    }
+
+    /// A visa request from a connected node on behalf of a policy-declared peer that has not
+    /// connected yet is answered from the pre-minted bootstrap visa. Policy cannot answer it:
+    /// the peer has no actor and no route, which is exactly what reaching VSAPI would fix.
+    #[tokio::test]
+    async fn bootstrap_visa_request_for_future_peer_is_allowed() {
+        use crate::db::PolicyRepo;
+        use crate::policy_mgr::PolicyMgr;
+        use crate::test_helpers::{FakeResolver, make_peering, policy_with_peerings};
+        use crate::trusted_services::TrustedServicesMgr;
+        use std::path::PathBuf;
+
+        let via_node: IpAddr = "fd5a:5052:3000::1".parse().unwrap(); // connected, docks the VS
+        let future_peer: IpAddr = "fd5a:5052:3000::7".parse().unwrap(); // no actor, no route
+
+        let mut asm = new_assembly_for_tests(None).await;
+        asm.policy_mgr = PolicyMgr::new_with_initial_policy(
+            policy_with_peerings(&[make_peering(via_node, future_peer, "link-vp", vec![])]),
+            PolicyRepo::new(asm.state_db.clone()),
+            Arc::new(FakeResolver::ip_only()),
+            Arc::new(TrustedServicesMgr::new()),
+            PathBuf::from("."),
+        )
+        .await
+        .unwrap();
+        asm.topo_mgr.add_node(via_node).unwrap();
+        asm.actor_mgr
+            .hack_set_vs_docking_node(&via_node)
+            .await
+            .unwrap();
+        let asm = Arc::new(asm);
+
+        let pkt = PacketDesc::new_tcp(
+            &future_peer.to_string(),
+            &asm.config.get_vs_addr().to_string(),
+            40000,
+            asm.config.core.vsapi_port.unwrap_or(config::VSAPI_PORT),
+        )
+        .unwrap();
+        let (job, _rx) = VisaRequestJob::new(via_node, pkt);
+
+        let visa = match process_visa_request(asm.clone(), &job).await.unwrap() {
+            VisaDecision::Allow(visa, _) => visa,
+            VisaDecision::Deny(code) => panic!("expected allow, got deny {code:?}"),
+        };
+
+        // It is the peer's own visa, held pending-install until the peer connects.
+        let pending = asm
+            .visa_mgr
+            .get_pending_visa_ids_for_node(&future_peer)
+            .await
+            .unwrap();
+        assert_eq!(pending, vec![visa.issuer_id]);
+
+        // The reply direction is the same flow and must resolve to the same visa: the node
+        // may see and ask about either direction first.
+        let reply_pkt = PacketDesc::new_tcp(
+            &asm.config.get_vs_addr().to_string(),
+            &future_peer.to_string(),
+            asm.config.core.vsapi_port.unwrap_or(config::VSAPI_PORT),
+            40000,
+        )
+        .unwrap();
+        let (reply_job, _rx) = VisaRequestJob::new(via_node, reply_pkt);
+        match process_visa_request(asm.clone(), &reply_job).await.unwrap() {
+            VisaDecision::Allow(reply_visa, _) => {
+                assert_eq!(reply_visa.issuer_id, visa.issuer_id)
+            }
+            VisaDecision::Deny(code) => panic!("expected allow for reply direction, got {code:?}"),
+        }
+    }
+
+    /// A connected peer's VSAPI traffic is not a bootstrap request: it has an actor, so it
+    /// goes through policy like anything else.
+    #[tokio::test]
+    async fn bootstrap_visa_request_declined_for_connected_peer() {
+        use crate::db::PolicyRepo;
+        use crate::policy_mgr::PolicyMgr;
+        use crate::test_helpers::{FakeResolver, make_peering, policy_with_peerings};
+        use crate::trusted_services::TrustedServicesMgr;
+        use std::path::PathBuf;
+
+        let via_node: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
+        let peer: IpAddr = "fd5a:5052:3000::7".parse().unwrap();
+
+        let mut asm = new_assembly_for_tests(None).await;
+        asm.policy_mgr = PolicyMgr::new_with_initial_policy(
+            policy_with_peerings(&[make_peering(via_node, peer, "link-vp", vec![])]),
+            PolicyRepo::new(asm.state_db.clone()),
+            Arc::new(FakeResolver::ip_only()),
+            Arc::new(TrustedServicesMgr::new()),
+            PathBuf::from("."),
+        )
+        .await
+        .unwrap();
+        asm.topo_mgr.add_node(via_node).unwrap();
+        asm.actor_mgr
+            .hack_set_vs_docking_node(&via_node)
+            .await
+            .unwrap();
+        // The peer is connected now, so it has an actor.
+        let peer_actor = make_node_actor_defexp(&peer.to_string(), "peer-node", "10.0.0.7:5001");
+        asm.actor_mgr.add_node(&peer_actor, false).await.unwrap();
+        let asm = Arc::new(asm);
+
+        let pkt = PacketDesc::new_tcp(
+            &peer.to_string(),
+            &asm.config.get_vs_addr().to_string(),
+            40000,
+            asm.config.core.vsapi_port.unwrap_or(config::VSAPI_PORT),
+        )
+        .unwrap();
+        let (job, _rx) = VisaRequestJob::new(via_node, pkt);
+
+        // Reaches policy evaluation (which has no matching comm policy) rather than being
+        // short-circuited into an allow.
+        assert!(
+            matches!(
+                process_visa_request(asm, &job).await.unwrap(),
+                VisaDecision::Deny(_)
+            ),
+            "a connected peer must not get a bootstrap visa"
         );
     }
 }

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -28,9 +28,9 @@ use futures::future::{FutureExt, join_all};
 
 use libeval::actor::Actor;
 use libeval::attribute::{Attribute, ROLE_ADAPTER, key};
-use libeval::eval_result::Hit;
+use libeval::eval_result::{Direction, Hit};
 use libeval::policy::Policy;
-use libeval::route::{NodeId, Route};
+use libeval::route::Route;
 
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
@@ -43,7 +43,8 @@ use crate::assembly::Assembly;
 use crate::counters::CounterType;
 use crate::error::ServiceError;
 use crate::logging::targets::VREQ;
-use crate::visa_mgr::VisaWithMetadata;
+use crate::packet::describe_five_tuple;
+use crate::visa_mgr::{VisaWithMetadata, bootstrap_route};
 use crate::visa_policy::{PolicyOutcome, evaluate_against_policy, route_for_allow};
 use crate::{config, net_mgr};
 
@@ -291,9 +292,11 @@ async fn process_visa_request(asm: Arc<Assembly>, job: &VisaRequestJob) -> VisaR
 /// the same argument that justifies minting at topology-send time -- so hand the visa back.
 /// Minting is idempotent, so this returns the same visa the neighbours were pushed.
 ///
-/// Either orientation counts: the peer's own SYN (`peer:any -> vs:VSAPI`) and the reply
-/// direction (`vs:VSAPI -> peer:any`) are one bidirectional flow covered by one visa, and a
-/// node may request for whichever it sees first.
+/// Either orientation counts -- the peer's own SYN (`peer:any -> vs:VSAPI`) or the reply
+/// (`vs:VSAPI -> peer:any`) -- and a node may ask about whichever it sees first. They are two
+/// visas, not one: a visa's dock PEP names a source and a destination, and its path has an
+/// ingress end, so the forward visa matches neither the reply's addresses nor its direction of
+/// travel. The direction detected here is what selects the right one.
 ///
 /// Returns `None` when this is not that flow (including on a mint failure), leaving the
 /// request to normal evaluation.
@@ -310,20 +313,21 @@ async fn bootstrap_visa_for_future_peer_request(
     let vs_addr = asm.config.get_vs_addr();
     let vsapi_port = asm.config.core.vsapi_port.unwrap_or(config::VSAPI_PORT);
 
-    // Which end is the peer, and is its actor the missing one? A connected peer's VSAPI
-    // traffic must go through policy like anything else.
-    let (peer_addr, peer_actor_missing) = if ft.dest_addr == vs_addr && ft.dest_port == vsapi_port {
-        (ft.source_addr, source_actor.is_none())
-    } else if ft.source_addr == vs_addr && ft.source_port == vsapi_port {
-        (ft.dest_addr, dest_actor.is_none())
-    } else {
-        return None;
-    };
+    // Which end is the peer, which direction of the flow is this, and is the peer's actor the
+    // missing one? A connected peer's VSAPI traffic must go through policy like anything else.
+    let (peer_addr, direction, peer_actor_missing) =
+        if ft.dest_addr == vs_addr && ft.dest_port == vsapi_port {
+            (ft.source_addr, Direction::Forward, source_actor.is_none())
+        } else if ft.source_addr == vs_addr && ft.source_port == vsapi_port {
+            (ft.dest_addr, Direction::Reverse, dest_actor.is_none())
+        } else {
+            return None;
+        };
     if !peer_actor_missing {
         return None;
     }
 
-    // Only for a peer the *requesting* node is declared to link with: that node is the one
+    // Only for a peer the requesting node is declared to link with: that node is the one
     // that would be handed the visa by a topology send, so it is the one allowed to pull it.
     let policy = asm.policy_mgr.get_current();
     let peers = policy
@@ -335,16 +339,23 @@ async fn bootstrap_visa_for_future_peer_request(
     }
 
     // The requesting node relays for the peer, so it is `via_node` of the minted path, and
-    // what it needs is its own actualized copy (forwarding-only, or full if it is the egress
-    // node) -- not the ingress copy the peer gets pushed in `Link.visas`.
+    // what it needs is its own actualized copy (forwarding-only, or full if it is an end of
+    // the path) -- not the copy the peer gets pushed in `Link.visas`.
     let visa = match asm
         .visa_mgr
-        .vsapi_bootstrap_visa_for_future_peer(asm, &peer_addr, &job.requesting_node)
+        .vsapi_bootstrap_visa_for_future_peer(asm, &peer_addr, &job.requesting_node, direction)
         .await
     {
         Ok(visa) => visa,
         Err(e) => {
             warn!(target: VREQ, "failed to mint bootstrap visa for future peer {peer_addr} requested by node {}: {e}", job.requesting_node);
+            return None;
+        }
+    };
+    let route = match bootstrap_route(asm, &peer_addr, &job.requesting_node, direction) {
+        Ok(route) => route,
+        Err(e) => {
+            warn!(target: VREQ, "failed to build the bootstrap route for future peer {peer_addr} via node {}: {e}", job.requesting_node);
             return None;
         }
     };
@@ -355,25 +366,13 @@ async fn bootstrap_visa_for_future_peer_request(
     {
         Ok(visa) => {
             debug!(target: VREQ, "node {} requested the bootstrap visa for future peer {peer_addr}: returning visa {}", job.requesting_node, visa.issuer_id);
-            Some(VisaDecision::Allow(
-                visa,
-                Route::new_direct(NodeId(peer_addr)),
-            ))
+            Some(VisaDecision::Allow(visa, route))
         }
         Err(e) => {
             warn!(target: VREQ, "failed to actualize bootstrap visa for node {} relaying future peer {peer_addr}: {e}", job.requesting_node);
             None
         }
     }
-}
-
-/// One-line `src:port -> dst:port proto` for logging a request's flow.
-fn describe_five_tuple(pdesc: &PacketDesc) -> String {
-    let ft = &pdesc.five_tuple;
-    format!(
-        "{}:{} -> {}:{} proto {}",
-        ft.source_addr, ft.source_port, ft.dest_addr, ft.dest_port, ft.l4_protocol
-    )
 }
 
 /// Fabricate an AAA actor for an anonymous endpoint at the given address.
@@ -1174,19 +1173,15 @@ mod tests {
         );
     }
 
-    /// A visa request from a connected node on behalf of a policy-declared peer that has not
-    /// connected yet is answered from the pre-minted bootstrap visa. Policy cannot answer it:
-    /// the peer has no actor and no route, which is exactly what reaching VSAPI would fix.
-    #[tokio::test]
-    async fn bootstrap_visa_request_for_future_peer_is_allowed() {
+    /// Assembly for the bootstrap tests: policy declares one `via_node`<->`future_peer`
+    /// peering, and `via_node` is connected and docks the visa service. The peer is left
+    /// unconnected (no actor, no route) -- callers that want it connected add its actor.
+    async fn build_bootstrap_test_asm(via_node: IpAddr, future_peer: IpAddr) -> Assembly {
         use crate::db::PolicyRepo;
         use crate::policy_mgr::PolicyMgr;
         use crate::test_helpers::{FakeResolver, make_peering, policy_with_peerings};
         use crate::trusted_services::TrustedServicesMgr;
         use std::path::PathBuf;
-
-        let via_node: IpAddr = "fd5a:5052:3000::1".parse().unwrap(); // connected, docks the VS
-        let future_peer: IpAddr = "fd5a:5052:3000::7".parse().unwrap(); // no actor, no route
 
         let mut asm = new_assembly_for_tests(None).await;
         asm.policy_mgr = PolicyMgr::new_with_initial_policy(
@@ -1203,7 +1198,29 @@ mod tests {
             .hack_set_vs_docking_node(&via_node)
             .await
             .unwrap();
-        let asm = Arc::new(asm);
+        asm
+    }
+
+    /// The two directions of a future peer's VSAPI flow, as a node's dataplane would ask about
+    /// them: the peer's own SYN, and the visa service's reply to it.
+    fn bootstrap_flow_packets(asm: &Assembly, future_peer: &IpAddr) -> (PacketDesc, PacketDesc) {
+        let vs_addr = asm.config.get_vs_addr().to_string();
+        let peer = future_peer.to_string();
+        let vsapi_port = asm.config.core.vsapi_port.unwrap_or(config::VSAPI_PORT);
+        (
+            PacketDesc::new_tcp(&peer, &vs_addr, 40000, vsapi_port).unwrap(),
+            PacketDesc::new_tcp(&vs_addr, &peer, vsapi_port, 40000).unwrap(),
+        )
+    }
+
+    /// A visa request from a connected node on behalf of a policy-declared peer that has not
+    /// connected yet is answered from the pre-minted bootstrap visa. Policy cannot answer it:
+    /// the peer has no actor and no route, which is exactly what reaching VSAPI would fix.
+    #[tokio::test]
+    async fn bootstrap_visa_request_for_future_peer_is_allowed() {
+        let via_node: IpAddr = "fd5a:5052:3000::1".parse().unwrap(); // connected, docks the VS
+        let future_peer: IpAddr = "fd5a:5052:3000::7".parse().unwrap(); // no actor, no route
+        let asm = Arc::new(build_bootstrap_test_asm(via_node, future_peer).await);
 
         let pkt = PacketDesc::new_tcp(
             &future_peer.to_string(),
@@ -1226,53 +1243,131 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(pending, vec![visa.issuer_id]);
+    }
 
-        // The reply direction is the same flow and must resolve to the same visa: the node
-        // may see and ask about either direction first.
-        let reply_pkt = PacketDesc::new_tcp(
-            &asm.config.get_vs_addr().to_string(),
-            &future_peer.to_string(),
-            asm.config.core.vsapi_port.unwrap_or(config::VSAPI_PORT),
-            40000,
-        )
-        .unwrap();
+    /// The reply direction gets its own visa. One visa carries one dock PEP and one path
+    /// orientation, so the forward visa (`peer -> vs:VSAPI`, pathed peer-first) cannot answer
+    /// `vs:VSAPI -> peer`: its PEP would not match the packet and no node on its path would
+    /// forward the reply. The reverse visa must be a distinct visa, addressed and pathed the
+    /// other way, with the requesting node forwarding towards the peer.
+    #[tokio::test]
+    async fn bootstrap_visa_reply_direction_gets_its_own_reverse_visa() {
+        use zpr::vsapi_types::{DockPepType, EndpointT};
+
+        let via_node: IpAddr = "fd5a:5052:3000::1".parse().unwrap(); // connected, docks the VS
+        let future_peer: IpAddr = "fd5a:5052:3000::7".parse().unwrap(); // no actor, no route
+        let asm = Arc::new(build_bootstrap_test_asm(via_node, future_peer).await);
+        let vs_addr = asm.config.get_vs_addr();
+        let vsapi_port = asm.config.core.vsapi_port.unwrap_or(config::VSAPI_PORT);
+        let (syn_pkt, reply_pkt) = bootstrap_flow_packets(&asm, &future_peer);
+
+        let (syn_job, _rx) = VisaRequestJob::new(via_node, syn_pkt);
+        let syn_visa = match process_visa_request(asm.clone(), &syn_job).await.unwrap() {
+            VisaDecision::Allow(visa, _) => visa,
+            VisaDecision::Deny(code) => panic!("expected allow for SYN direction, got {code:?}"),
+        };
+
         let (reply_job, _rx) = VisaRequestJob::new(via_node, reply_pkt);
-        match process_visa_request(asm.clone(), &reply_job).await.unwrap() {
-            VisaDecision::Allow(reply_visa, _) => {
-                assert_eq!(reply_visa.issuer_id, visa.issuer_id)
-            }
+        let reply_visa = match process_visa_request(asm.clone(), &reply_job).await.unwrap() {
+            VisaDecision::Allow(visa, _) => visa,
             VisaDecision::Deny(code) => panic!("expected allow for reply direction, got {code:?}"),
+        };
+
+        assert_ne!(
+            reply_visa.issuer_id, syn_visa.issuer_id,
+            "the reply direction needs its own visa, not the forward one"
+        );
+
+        // The dock PEP must describe the reply packet: vs:VSAPI -> peer:any, server side.
+        let dock_pep = reply_visa.dock_pep.expect("reverse visa must be full");
+        assert_eq!(dock_pep.source_addr, vs_addr);
+        assert_eq!(dock_pep.dest_addr, future_peer);
+        match dock_pep.pep {
+            DockPepType::TCP(tpep) => {
+                assert_eq!(tpep.source_port, vsapi_port);
+                assert_eq!(tpep.dest_port, 0, "reply direction allows any dest port");
+                assert_eq!(tpep.endpoint, EndpointT::Server);
+            }
+            other => panic!("expected a TCP dock PEP, got {other:?}"),
         }
+
+        // The requesting node is where the reply ingresses, so it must forward to the peer.
+        let fwd_pep = reply_visa
+            .fwd_pep
+            .expect("reply ingress node needs a forwarding PEP towards the peer");
+        assert_eq!(fwd_pep.next_hop, future_peer);
+
+        // Both directions are held for the peer until it connects.
+        let mut pending = asm
+            .visa_mgr
+            .get_pending_visa_ids_for_node(&future_peer)
+            .await
+            .unwrap();
+        pending.sort();
+        let mut expected = vec![syn_visa.issuer_id, reply_visa.issuer_id];
+        expected.sort();
+        assert_eq!(pending, expected);
+    }
+
+    /// The route returned with a bootstrap visa names the links the traffic really crosses: the
+    /// peer's own link, which only policy knows about, plus the routed segment on to the visa
+    /// service's docking node -- ordered from the ingress end of the direction asked about.
+    #[tokio::test]
+    async fn bootstrap_visa_route_spans_peer_link_and_routed_segment() {
+        use libeval::route::{LinkId, RouteKind};
+
+        let via_node: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
+        let dock_node: IpAddr = "fd5a:5052:3000::2".parse().unwrap(); // docks the VS, one hop on
+        let future_peer: IpAddr = "fd5a:5052:3000::7".parse().unwrap();
+
+        let asm = build_bootstrap_test_asm(via_node, future_peer).await;
+        asm.topo_mgr.add_node(dock_node).unwrap();
+        asm.topo_mgr
+            .add_link(via_node, dock_node, LinkId("link-vd".into()), vec![], 1)
+            .unwrap();
+        asm.actor_mgr
+            .hack_set_vs_docking_node(&dock_node)
+            .await
+            .unwrap();
+        let asm = Arc::new(asm);
+        let (syn_pkt, reply_pkt) = bootstrap_flow_packets(&asm, &future_peer);
+
+        let (syn_job, _rx) = VisaRequestJob::new(via_node, syn_pkt);
+        let syn_route = match process_visa_request(asm.clone(), &syn_job).await.unwrap() {
+            VisaDecision::Allow(_, route) => route,
+            VisaDecision::Deny(code) => panic!("expected allow for SYN direction, got {code:?}"),
+        };
+        assert!(
+            matches!(syn_route.kind, RouteKind::Multihop),
+            "the peer's own link is always crossed, so this is never a direct route"
+        );
+        assert_eq!(
+            syn_route.links,
+            vec![LinkId("link-vp".into()), LinkId("link-vd".into())],
+            "peer's link first, then the routed segment to the docking node"
+        );
+        assert_eq!(syn_route.cost, 2, "one policy link plus one router link");
+
+        let (reply_job, _rx) = VisaRequestJob::new(via_node, reply_pkt);
+        let reply_route = match process_visa_request(asm.clone(), &reply_job).await.unwrap() {
+            VisaDecision::Allow(_, route) => route,
+            VisaDecision::Deny(code) => panic!("expected allow for reply direction, got {code:?}"),
+        };
+        assert_eq!(
+            reply_route.links,
+            vec![LinkId("link-vd".into()), LinkId("link-vp".into())],
+            "the reply crosses the same links from the other end"
+        );
     }
 
     /// A connected peer's VSAPI traffic is not a bootstrap request: it has an actor, so it
     /// goes through policy like anything else.
     #[tokio::test]
     async fn bootstrap_visa_request_declined_for_connected_peer() {
-        use crate::db::PolicyRepo;
-        use crate::policy_mgr::PolicyMgr;
-        use crate::test_helpers::{FakeResolver, make_peering, policy_with_peerings};
-        use crate::trusted_services::TrustedServicesMgr;
-        use std::path::PathBuf;
-
         let via_node: IpAddr = "fd5a:5052:3000::1".parse().unwrap();
         let peer: IpAddr = "fd5a:5052:3000::7".parse().unwrap();
 
-        let mut asm = new_assembly_for_tests(None).await;
-        asm.policy_mgr = PolicyMgr::new_with_initial_policy(
-            policy_with_peerings(&[make_peering(via_node, peer, "link-vp", vec![])]),
-            PolicyRepo::new(asm.state_db.clone()),
-            Arc::new(FakeResolver::ip_only()),
-            Arc::new(TrustedServicesMgr::new()),
-            PathBuf::from("."),
-        )
-        .await
-        .unwrap();
-        asm.topo_mgr.add_node(via_node).unwrap();
-        asm.actor_mgr
-            .hack_set_vs_docking_node(&via_node)
-            .await
-            .unwrap();
+        let asm = build_bootstrap_test_asm(via_node, peer).await;
         // The peer is connected now, so it has an actor.
         let peer_actor = make_node_actor_defexp(&peer.to_string(), "peer-node", "10.0.0.7:5001");
         asm.actor_mgr.add_node(&peer_actor, false).await.unwrap();

--- a/vs/src/visareq_worker.rs
+++ b/vs/src/visareq_worker.rs
@@ -413,8 +413,9 @@ async fn distribute_visa_on_path(
     join_all(push_futures).await;
 }
 
-/// Resolves a pair of optional actors into concrete actors, handling the case where one is
-/// missing because it is an unauthenticated actor reaching an auth service via an AAA address.
+/// Resolves a pair of optional actors into concrete actors. One side may be missing because
+/// it is an unauthenticated actor reaching an auth service over an AAA address, in which case
+/// we fabricate it; anything else missing is a deny.
 ///
 /// Returns `Ok((source, dest))` when both actors are resolved, or `Err(decision)` for an
 /// early deny that should be returned directly to the caller.
@@ -424,88 +425,113 @@ async fn resolve_actors_or_deny(
     mut source_actor: Option<Actor>,
     mut dest_actor: Option<Actor>,
 ) -> Result<(Actor, Actor), VisaDecision> {
+    if source_actor.is_some() && dest_actor.is_some() {
+        return Ok((source_actor.unwrap(), dest_actor.unwrap()));
+    }
     if source_actor.is_none() && dest_actor.is_none() {
         return Err(VisaDecision::Deny(DenyCode::SourceNotFound));
     }
 
-    if source_actor.is_none() || dest_actor.is_none() {
-        // This might be an actor trying to talk to an authentication service.
-        //
-        // To check this we confirm that one actor is using an AAA network address
-        // from its node, and the other is an installed authentication service.
-        //
+    // Exactly one side is missing from here on.
+    let missing_source = source_actor.is_none();
 
-        let missing_source = source_actor.is_none();
+    // "candidate" => the known actor's address, "anon_addr" => the missing actor's address.
+    let (candidate_addr, anon_addr) = if missing_source {
+        (job.packet_desc.dest_addr(), job.packet_desc.source_addr())
+    } else {
+        (job.packet_desc.source_addr(), job.packet_desc.dest_addr())
+    };
 
-        // "candidate" => the possible auth service, "anon_addr" => possible actor using AAA addr.
-        let (candidate_addr, anon_addr) = if missing_source {
-            (job.packet_desc.dest_addr(), job.packet_desc.source_addr())
-        } else {
-            (job.packet_desc.source_addr(), job.packet_desc.dest_addr())
-        };
+    let expiration = SystemTime::now() + config::DEFAULT_ANON_AUTH_EXPIRATION;
 
-        let expiration = SystemTime::now() + config::DEFAULT_ANON_AUTH_EXPIRATION;
+    // The missing side names its own deny code.
+    let deny = if missing_source {
+        DenyCode::SourceNotFound
+    } else {
+        DenyCode::DestNotFound
+    };
 
-        if missing_source {
-            // Request side: assume this is an unauthenticated adapter → auth service.
-            // Validate that the source is in the requesting node's AAA subnet and that the
-            // destination is a registered auth service, then record the docking node.
-            let node_aaa_net = net_mgr::aaa_network_for_node(&job.requesting_node);
-            if !node_aaa_net.contains(anon_addr) {
-                debug!(target: VREQ,
-                    "visa denied: unknown source {anon_addr} is not in the AAA network for node {:?}",
-                    job.requesting_node
-                );
-                return Err(VisaDecision::Deny(DenyCode::SourceNotFound));
-            }
-
-            match asm
-                .actor_mgr
-                .has_auth_services(asm.clone(), candidate_addr)
-                .await
-            {
-                Ok(true) => (),
-                Ok(false) => {
-                    warn!(target: VREQ, "visa denied: actor using AAA addr attempting to contact non-authentication service at {candidate_addr}");
-                    return Err(VisaDecision::Deny(DenyCode::DestNotFound));
-                }
-                Err(e) => {
-                    debug!(target: VREQ, "visa denied: error checking authentication services for actor at {candidate_addr}: {}", e);
-                    return Err(VisaDecision::Deny(DenyCode::DestNotFound));
-                }
-            };
-
-            // Record the docking node so the response side can resolve it correctly,
-            // even when the response arrives via a different requesting node.
-            asm.actor_mgr
-                .register_aaa(*anon_addr, job.requesting_node, expiration);
-
-            let anon_actor = fabricate_aaa_actor(anon_addr, expiration);
-            debug!(target: VREQ, "fabricated AAA actor for anonymous request: {:?} -> {candidate_addr}", anon_actor);
-            source_actor = Some(anon_actor);
-        } else {
-            // Response side: assume "auth service" → unauthenticated adapter.
-            // On this side we don't bother checking to see if source is an auth-service.
-            // The policy eval will flag that.
-            //
-            // The AAA address must already be in the table (registered on the request side).
-            match asm.actor_mgr.get_docking_node_for_aaa(anon_addr) {
-                Some(_) => {}
-                None => {
-                    warn!(target: VREQ,
-                        "visa denied: AAA address {anon_addr} not found in AAA table (expired or never registered)"
-                    );
-                    return Err(VisaDecision::Deny(DenyCode::DestNotFound));
-                }
-            }
-
-            let anon_actor = fabricate_aaa_actor(anon_addr, expiration);
-            debug!(target: VREQ, "fabricated AAA actor for anonymous response: {candidate_addr} -> {:?}", anon_actor);
-            dest_actor = Some(anon_actor);
+    let actor = match try_aaa_actor(
+        asm,
+        job,
+        anon_addr,
+        candidate_addr,
+        missing_source,
+        expiration,
+    )
+    .await
+    .map_err(VisaDecision::Deny)?
+    {
+        Some(actor) => actor,
+        None => {
+            warn!(target: VREQ,
+                "visa denied: {anon_addr} is not a registered AAA address (peer {candidate_addr})"
+            );
+            return Err(VisaDecision::Deny(deny));
         }
+    };
+
+    if missing_source {
+        source_actor = Some(actor);
+    } else {
+        dest_actor = Some(actor);
     }
 
     Ok((source_actor.unwrap(), dest_actor.unwrap()))
+}
+
+/// Tries to resolve `anon_addr` as an unauthenticated actor using an AAA address to reach an
+/// authentication service.
+///
+/// `Ok(None)` means this is not an AAA case at all, so the caller should deny with the
+/// missing side's code. `Err(code)` means it is an AAA case but a denied one, and the code
+/// names whichever endpoint is actually at fault.
+async fn try_aaa_actor(
+    asm: &Arc<Assembly>,
+    job: &VisaRequestJob,
+    anon_addr: &IpAddr,
+    candidate_addr: &IpAddr,
+    missing_source: bool,
+    expiration: SystemTime,
+) -> Result<Option<Actor>, DenyCode> {
+    if missing_source {
+        // Request side: the anonymous actor must be in the requesting node's AAA subnet,
+        // and the destination must actually be a registered auth service.
+        if !net_mgr::aaa_network_for_node(&job.requesting_node).contains(anon_addr) {
+            return Ok(None);
+        }
+
+        match asm
+            .actor_mgr
+            .has_auth_services(asm.clone(), candidate_addr)
+            .await
+        {
+            Ok(true) => (),
+            Ok(false) => {
+                warn!(target: VREQ, "visa denied: actor using AAA addr attempting to contact non-authentication service at {candidate_addr}");
+                // Names the candidate rather than the missing side: the dest is the problem.
+                return Err(DenyCode::DestNotFound);
+            }
+            Err(e) => {
+                debug!(target: VREQ, "visa denied: error checking authentication services for actor at {candidate_addr}: {e}");
+                return Err(DenyCode::DestNotFound);
+            }
+        }
+
+        // Record the docking node so the response side can resolve it correctly,
+        // even when the response arrives via a different requesting node.
+        asm.actor_mgr
+            .register_aaa(*anon_addr, job.requesting_node, expiration);
+    } else {
+        // Response side: the AAA address must already be in the table, put there by the
+        // request side. Whether the peer is really an auth service is left to policy eval.
+        if asm.actor_mgr.get_docking_node_for_aaa(anon_addr).is_none() {
+            return Ok(None);
+        }
+    }
+
+    debug!(target: VREQ, "fabricated AAA actor for anonymous endpoint {anon_addr} (peer {candidate_addr})");
+    Ok(Some(fabricate_aaa_actor(anon_addr, expiration)))
 }
 
 // Lookup source and destination actors in the DB based on ZPR address.

--- a/vs/src/vsapi_worker.rs
+++ b/vs/src/vsapi_worker.rs
@@ -311,6 +311,7 @@ fn write_error(bldr: &mut vsapi::error::Builder, code: vsapi::ErrorCode, message
 /// report the link it came in over as a connect param.
 ///
 /// TODO: Rethink this: do we really node connect and open in VSAPI?
+/// See: https://github.com/org-zpr/zpr-visaservice/issues/302
 async fn install_policy_links_for_node(asm: &Assembly, node_actor: &Actor, node_addr: &IpAddr) {
     let psnap = asm.policy_mgr.get_current_snapshot();
     let Some(peers) = psnap.policy().get_peers_for_node(node_addr) else {
@@ -494,11 +495,14 @@ impl vsapi::visa_service::Server for VisaServiceImpl {
 
         info!(target: API, "node {} requests zpr addr {} (CONNECT_TYPE={:?})", vs_connect_request.cn, node_zpr_addr, vs_connect_request.ctype);
 
-        // The requested address is an unauthenticated claim. A node that joins over a link
-        // reaches VSAPI from its ZPR address using a bootstrap visa pinned to that address,
-        // so the address it claims must be the one we are talking to. Only the first node
-        // connects over the substrate, where the remote is not a ZPR address and there is
-        // nothing to compare against.
+        // The requested address is an unauthenticated claim. A node reaches VSAPI from its ZPR
+        // address using a bootstrap visa pinned to that address, so the address it claims must
+        // be the one we are talking to; past this point `node_zpr_addr` is source-verified.
+        //
+        // The check is skipped when VSAPI is not bound to a ZPR address (`vs_addr` set to
+        // loopback or a substrate address for local development) -- there is no fabric
+        // enforcing the source there, so there is nothing to compare against. Not a supported
+        // production configuration.
         let remote_ip = self.remote.ip();
         if net_mgr::is_zpr_addr(&remote_ip) && remote_ip != node_zpr_addr {
             warn!(target: API, "node {} connecting from ZPR addr {} claims addr {}: rejected", vs_connect_request.cn, remote_ip, node_zpr_addr);

--- a/vs/src/vsapi_worker.rs
+++ b/vs/src/vsapi_worker.rs
@@ -302,8 +302,20 @@ fn write_error(bldr: &mut vsapi::error::Builder, code: vsapi::ErrorCode, message
 /// `authorize_connect`, so nothing else installs its links: it would land in the router
 /// with no edges at all and every visa request involving it would deny `NoRoute`.
 ///
-/// Failures are logged, not fatal -- the node is authenticated either way, and the
-/// housekeeping revalidation pass repairs router/state drift later.
+/// Failures are logged, not fatal -- the node is authenticated either way. Nothing
+/// reconciles the missing edge afterwards: every `add_linked_node` failure path leaves it
+/// in neither the router nor persisted state, and `revalidate_against_policy` only works
+/// the union of those two stores, so it never installs a policy-declared edge absent from
+/// both. The link stays missing until one of its endpoints reconnects and re-runs this or
+/// `authorize_connect`. Meanwhile the node is still *told* the link exists -- topology
+/// sends come from policy, not the router -- so its visa requests over that link deny
+/// `NoRoute` with nothing on the node side to explain why.
+///
+/// TODO: retry instead of just logging. `add_linked_node` is idempotent (tolerates
+/// `LinkExists`, re-persists on the already-connected path), so a "links dirty" flag on
+/// `VssState` next to `needs_set_topology` would let `do_housekeeping` re-run this on the
+/// next tick -- no new machinery required.
+/// See: https://github.com/org-zpr/zpr-visaservice/issues/302
 ///
 /// TODO: a declared peering between two connected nodes is taken as evidence that the
 /// link is up. VS cannot see which peer forwarded the VSAPI connection, so a node with
@@ -344,7 +356,8 @@ async fn install_policy_links_for_node(asm: &Assembly, node_actor: &Actor, node_
                 info!(target: API, "installed link {} between node {node_addr} and peer {}", peer.link_id, peer.remote_zpr_addr)
             }
             Err(e) => {
-                warn!(target: API, "failed to install link {} between node {node_addr} and peer {}: {e} -- node has no route over that link", peer.link_id, peer.remote_zpr_addr)
+                error!(target: API, "failed to install link {} between node {node_addr} and peer {}: {e} -- node has no route over that link until an endpoint reconnects", peer.link_id, peer.remote_zpr_addr);
+                asm.counters.incr(CounterType::LinkInstallFailed);
             }
         }
     }

--- a/vs/src/vsapi_worker.rs
+++ b/vs/src/vsapi_worker.rs
@@ -292,6 +292,60 @@ fn write_error(bldr: &mut vsapi::error::Builder, code: vsapi::ErrorCode, message
     bldr.set_retry_in(0);
 }
 
+/// Install router edges for every policy-declared peering between `node_addr` and a node
+/// that is already connected, persisting each edge.
+///
+/// A node that joins by calling `connect` over a link never passes through its peer's
+/// `authorize_connect`, so nothing else installs its links: it would land in the router
+/// with no edges at all and every visa request involving it would deny `NoRoute`.
+///
+/// Failures are logged, not fatal -- the node is authenticated either way, and the
+/// housekeeping revalidation pass repairs router/state drift later.
+///
+/// TODO: a declared peering between two connected nodes is taken as evidence that the
+/// link is up. VS cannot see which peer forwarded the VSAPI connection, so a node with
+/// more than one connected peer gets edges for all of them. Upgrade path: have the node
+/// report the link it came in over as a connect param.
+///
+/// TODO: Rethink this: do we really node connect and open in VSAPI?
+async fn install_policy_links_for_node(asm: &Assembly, node_actor: &Actor, node_addr: &IpAddr) {
+    let psnap = asm.policy_mgr.get_current_snapshot();
+    let Some(peers) = psnap.policy().get_peers_for_node(node_addr) else {
+        return; // No peerings declared for this node.
+    };
+    let connected = match asm.actor_mgr.list_node_addrs().await {
+        Ok(addrs) => addrs,
+        Err(e) => {
+            warn!(target: API, "cannot install links for node {node_addr}: node list unavailable: {e}");
+            return;
+        }
+    };
+    for peer in peers {
+        if !connected.contains(&peer.remote_zpr_addr) {
+            debug!(target: API, "peer {} of node {node_addr} is not connected: link {} deferred", peer.remote_zpr_addr, peer.link_id);
+            continue;
+        }
+        match asm
+            .topo_mgr
+            .add_linked_node(
+                &psnap,
+                &asm.actor_mgr,
+                node_actor,
+                &peer.remote_zpr_addr,
+                node_addr,
+            )
+            .await
+        {
+            Ok(()) => {
+                info!(target: API, "installed link {} between node {node_addr} and peer {}", peer.link_id, peer.remote_zpr_addr)
+            }
+            Err(e) => {
+                warn!(target: API, "failed to install link {} between node {node_addr} and peer {}: {e} -- node has no route over that link", peer.link_id, peer.remote_zpr_addr)
+            }
+        }
+    }
+}
+
 /// Convert a vsapi schema IpAddr into a rust ip address.
 fn ipaddr_from_capnp(addr: vsapi::ip_addr::Reader) -> Result<std::net::IpAddr, capnp::Error> {
     match addr.which()? {
@@ -436,6 +490,21 @@ impl vsapi::visa_service::Server for VisaServiceImpl {
         };
 
         info!(target: API, "node {} requests zpr addr {} (CONNECT_TYPE={:?})", vs_connect_request.cn, node_zpr_addr, vs_connect_request.ctype);
+
+        // The requested address is an unauthenticated claim. A node that joins over a link
+        // reaches VSAPI from its ZPR address using a bootstrap visa pinned to that address,
+        // so the address it claims must be the one we are talking to. Only the first node
+        // connects over the substrate, where the remote is not a ZPR address and there is
+        // nothing to compare against.
+        let remote_ip = self.remote.ip();
+        if net_mgr::is_zpr_addr(&remote_ip) && remote_ip != node_zpr_addr {
+            warn!(target: API, "node {} connecting from ZPR addr {} claims addr {}: rejected", vs_connect_request.cn, remote_ip, node_zpr_addr);
+            return self.ok_with_connect_error(
+                results,
+                vsapi::ErrorCode::ParamError,
+                "zpr addr does not match connection source",
+            );
+        }
 
         match vs_connect_request.ctype {
             ConnectType::Reset => {}
@@ -699,6 +768,22 @@ impl vsapi::v_s_gate::Server for VSGateImpl {
             undo.took_zpr_addr(&node_zpr_addr);
         }
 
+        // Policy can hand back a different address than the node asked for: the requested
+        // address is an unauthenticated claim, scrubbed unless a join policy matched it, in
+        // which case an address is allocated instead. A node that joined over a link is only
+        // reachable at the address it claimed -- its bootstrap visa and its peering are keyed
+        // to it -- so a substitution leaves it unroutable. Fail rather than authenticate it
+        // at an address it cannot use.
+        if node_zpr_addr != self.req_zpr_addr && net_mgr::is_zpr_addr(&self.remote.ip()) {
+            warn!(target: API, "node {} requested addr {} but policy granted {}: rejecting, it joined over a link at the requested addr", self.remote_cn, self.req_zpr_addr, node_zpr_addr);
+            undo.undo(&self.asm).await;
+            return self.ok_with_authenticate_error(
+                results,
+                vsapi::ErrorCode::AuthError,
+                "requested zpr address not granted by policy",
+            );
+        }
+
         let node_cn = match node_actor.get_cn() {
             Some(cn) => cn.to_owned(),
             None => {
@@ -807,6 +892,10 @@ impl vsapi::v_s_gate::Server for VSGateImpl {
             // Node exists already.
             info!(target: API, "node {:?} already present in router on (re)connect; keeping existing node and links", &node_cn);
         }
+
+        // Install the node's policy-declared links to already-connected peers. Must happen
+        // before ActorJoins: that event drives the topology fan-out, which reads the router.
+        install_policy_links_for_node(&self.asm, &node_actor, &node_zpr_addr).await;
 
         let evt = VsEvent::ActorJoins(node_zpr_addr);
         if let Err(e) = self.asm.event_mgr.record_event(evt).await {
@@ -1477,6 +1566,54 @@ mod tests {
 
         let reader: vsapi::v_s_connect_request::Reader = message.get_root().unwrap();
         assert!(VSConnectRequest::try_from(reader).is_err());
+    }
+
+    /// A node joining via `connect` gets router edges for its policy-declared peers that
+    /// are already connected, and none for peers that are not.
+    #[tokio::test]
+    async fn test_install_policy_links_only_for_connected_peers() {
+        use crate::assembly::tests::new_assembly_for_tests;
+        use crate::db::PolicyRepo;
+        use crate::policy_mgr::PolicyMgr;
+        use crate::test_helpers::{
+            FakeResolver, make_node_actor_defexp, make_peering, policy_with_peerings,
+        };
+        use crate::trusted_services::TrustedServicesMgr;
+        use std::path::PathBuf;
+
+        let a: IpAddr = "fd5a:5052:90de:1::1".parse().unwrap(); // connected peer
+        let b: IpAddr = "fd5a:5052:90de:1::2".parse().unwrap(); // the joining node
+        let c: IpAddr = "fd5a:5052:90de:1::3".parse().unwrap(); // declared but absent peer
+
+        let mut asm = new_assembly_for_tests(None).await;
+        asm.policy_mgr = PolicyMgr::new_with_initial_policy(
+            policy_with_peerings(&[
+                make_peering(a, b, "link-ab", vec![]),
+                make_peering(b, c, "link-bc", vec![]),
+            ]),
+            PolicyRepo::new(asm.state_db.clone()),
+            Arc::new(FakeResolver::ip_only()),
+            Arc::new(TrustedServicesMgr::new()),
+            PathBuf::from("."),
+        )
+        .await
+        .unwrap();
+
+        // Both A and B are authenticated nodes in the router; C is not connected at all.
+        for (addr, cn) in [(a, "node-a"), (b, "node-b")] {
+            let actor = make_node_actor_defexp(&addr.to_string(), cn, "[fd5a:5052::100]:1234");
+            asm.actor_mgr.add_node(&actor, false).await.unwrap();
+            asm.topo_mgr.add_node(addr).unwrap();
+        }
+        let actor_b = make_node_actor_defexp(&b.to_string(), "node-b", "[fd5a:5052::100]:1234");
+
+        install_policy_links_for_node(&asm, &actor_b, &b).await;
+
+        assert_eq!(
+            asm.topo_mgr.get_peers(&b),
+            vec![a],
+            "expected exactly the link to the connected peer A"
+        );
     }
 
     mod authenticate_undo {

--- a/vs/src/vsapi_worker.rs
+++ b/vs/src/vsapi_worker.rs
@@ -27,6 +27,7 @@ use crate::error::ServiceError;
 use crate::event_mgr::{self, VsEvent};
 use crate::logging::targets::API;
 use crate::net_mgr;
+use crate::packet::describe_five_tuple;
 use crate::topology_mgr::{AddLinkedNodeError, TopologyMgr};
 use crate::visareq_worker::{VisaDecision, request_visa_wait_response};
 
@@ -270,6 +271,8 @@ impl VSHandleImpl {
                 ));
             }
         };
+
+        debug!(target: API, "preparing visa request from node {} for packet {}", requestor_ip, describe_five_tuple(&pdesc));
 
         // Note that we assume that everything above this has taken no time.
         match request_visa_wait_response(&self.asm, requestor_ip, pdesc, timeout).await {

--- a/vs/src/vss.rs
+++ b/vs/src/vss.rs
@@ -1,8 +1,10 @@
 //! Shared VSS related types.
 
 use std::net::IpAddr;
+use std::sync::Arc;
 use tokio::sync::oneshot;
 
+use libeval::policy::Policy;
 use zpr::vsapi_types::{Link, Param, ServiceDescriptor, Visa};
 
 use crate::error::VssSyncError;
@@ -25,5 +27,11 @@ pub enum VssCmd {
         oneshot::Sender<VssSetServicesResponse>,
     ), // (version, services-descriptor-list, channel)
     Configure(Vec<Param>, oneshot::Sender<VssConfigureResponse>),
-    SetTopology(Vec<Link>, oneshot::Sender<VssSetTopologyResponse>),
+    /// The links plus the policy snapshot they were computed from. The snapshot rides along
+    /// so bootstrap-visa minting resolves peers against the same view that produced the links.
+    SetTopology(
+        Vec<Link>,
+        Arc<Policy>,
+        oneshot::Sender<VssSetTopologyResponse>,
+    ),
 }

--- a/vs/src/vss_mgr.rs
+++ b/vs/src/vss_mgr.rs
@@ -7,6 +7,7 @@ use tokio::sync::oneshot;
 use tokio::task::LocalSet;
 use tracing::{debug, info};
 
+use libeval::policy::Policy;
 use zpr::vsapi_types::{Link, ServiceDescriptor, Visa};
 
 use crate::assembly::Assembly;
@@ -205,10 +206,15 @@ impl VssHandle {
         resp_rx.await.map_err(|_| VssSyncError::ConnClosed)?
     }
 
-    /// Send a `setTopology` message to the node.
-    pub async fn set_topology(&self, links: Vec<Link>) -> Result<(), VssSyncError> {
+    /// Send a `setTopology` message to the node. `policy` must be the snapshot `links` was
+    /// computed from -- the worker resolves peers against it to mint bootstrap visas.
+    pub async fn set_topology(
+        &self,
+        links: Vec<Link>,
+        policy: Arc<Policy>,
+    ) -> Result<(), VssSyncError> {
         let (resp_tx, resp_rx) = oneshot::channel();
-        let cmd = VssCmd::SetTopology(links, resp_tx);
+        let cmd = VssCmd::SetTopology(links, policy, resp_tx);
         self.send_command(cmd).await?;
         resp_rx.await.map_err(|_| VssSyncError::ConnClosed)?
     }

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -176,7 +176,7 @@ pub async fn vss_worker_loop(
                         }
                         VssCmd::SetTopology(links, resp_tx) => {
                             state.mark_topology_updated();
-                            if let Err(e) = resp_tx.send(vss_do_set_topology(&vss_handle, &links).await) {
+                            if let Err(e) = resp_tx.send(vss_do_set_topology(&vss_handle, asm.clone(), &node_addr.ip(), links).await) {
                                 error!(target: VSS, "failed to send response for set-topology command: {:?}", e);
                                 asm.counters.incr(CounterType::VssErrors);
                             }
@@ -463,7 +463,7 @@ async fn send_topology(
     let links = asm.policy_mgr.resolved_links_for_node(node_addr);
 
     debug!(target: VSS, "sending initial topology to VSS at {}", node_addr);
-    if let Err(e) = vss_do_set_topology(vss_handle, &links).await {
+    if let Err(e) = vss_do_set_topology(vss_handle, asm.clone(), node_addr, links).await {
         error!(target: VSS, "failed to send initial topology to VSS at {}: {}", node_addr, e);
         asm.counters.incr(CounterType::VssErrors);
     } else {
@@ -660,12 +660,55 @@ async fn vss_do_configure(
     check_ok_or_error(configure_response_ok_or_err.get_res().unwrap())
 }
 
-/// Pass an empty slice to indicate no peers.
+/// Send the node's links via the `setTopology` RPC. Pass an empty slice to indicate no peers.
 ///
+/// `node_addr` is the ZPR address of the node on the other end of `vss_handle`; the links are
+/// that node's view of the topology, so the peer lookup below must be keyed by it.
 async fn vss_do_set_topology(
     vss_handle: &v1::v_s_s_handle::Client,
-    peers: &[Link],
+    asm: Arc<Assembly>,
+    node_addr: &IpAddr,
+    mut peers: Vec<Link>,
 ) -> Result<(), VssSyncError> {
+    // HACK -> This hack here is to support our intial MULTINODE implementation.
+    // We create "bootstrap" visas for each peer in the topology message.
+    // Every time we send the topology message.
+    //
+    // The visa belongs to the peer, not to this node: this node holds it and hands it
+    // off when the peer connects. Minting bypasses policy evaluation entirely -- see
+    // `VisaMgr::vsapi_bootstrap_visa_for_future_peer`.
+    //
+    // TODO: Reevaluate this.
+
+    let policy = asm.policy_mgr.get_current();
+    // Both ends of an edge share a link_id, and each end's `remote_zpr_addr` is only
+    // meaningful under its own node key -- so resolve the link within `node_addr`'s peers.
+    let node_peers = policy.get_peers_for_node(node_addr).unwrap_or_default();
+    for link in &mut peers {
+        if let Some(peer) = node_peers.iter().find(|p| p.link_id == link.link_id) {
+            // The link is between `node_addr` and `peer.remote_zpr_addr`.
+            // The visa needs to look like:
+            //
+            //     peer:ANYPORT -> vs.zpr:VSAPI_PORT TCP
+            //
+            match asm
+                .visa_mgr
+                .vsapi_bootstrap_visa_for_future_peer(&asm, &peer.remote_zpr_addr)
+                .await
+            {
+                Ok(visa) => {
+                    debug!(target: VSS, "created bootstrap visa for future peer {}: {}", peer.remote_zpr_addr, visa.issuer_id);
+                    link.visas.push(visa);
+                }
+                Err(e) => {
+                    error!(target: VSS, "failed to create bootstrap visa for future peer {}: {:?}", peer.remote_zpr_addr, e);
+                }
+            }
+        } else {
+            warn!(target: VSS, "no peer entry for link {} under node {node_addr}; sending it without a bootstrap visa", link.link_id);
+        }
+    }
+
     let mut req = vss_handle.set_topology_request();
     let req_builder = req.get();
     let mut peer_list_builder = req_builder.init_links(peers.len() as u32);

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -13,7 +13,6 @@ use tokio_rustls::TlsConnector;
 use tokio_util::compat::*;
 use tracing::{debug, error, info, trace, warn};
 
-use libeval::eval_result::Direction;
 use libeval::policy::Policy;
 use zpr::vsapi::v1;
 use zpr::vsapi_types::{ApiResponseError, Link, Param, ServiceDescriptor, Visa, VisaOp, pname};
@@ -25,6 +24,7 @@ use crate::counters::CounterType;
 use crate::error::VssSyncError;
 use crate::logging::targets::VSS;
 use crate::net_mgr;
+use crate::visa_bootstrap;
 use crate::vss::VssCmd;
 
 /// Default timeout for a single Cap'n Proto RPC call.
@@ -687,12 +687,11 @@ async fn vss_do_set_topology(
     mut peers: Vec<Link>,
 ) -> Result<(), VssSyncError> {
     // HACK -> This hack here is to support our intial MULTINODE implementation.
-    // We create "bootstrap" visas for each peer in the topology message.
-    // Every time we send the topology message.
+    // We create "bootstrap" visas for each peer in the topology message, every time we send it.
     //
-    // The visa belongs to the peer, not to this node: this node holds it and hands it
-    // off when the peer connects. Minting bypasses policy evaluation entirely -- see
-    // `VisaMgr::vsapi_bootstrap_visa_for_future_peer`.
+    // The visa belongs to the peer, not to this node: this node holds it and hands it off when
+    // the peer connects. Minting bypasses policy evaluation entirely -- see
+    // [crate::visa_bootstrap], which is where all of this lives and where it gets deleted from.
     //
     // TODO: Reevaluate this.
 
@@ -704,49 +703,19 @@ async fn vss_do_set_topology(
             warn!(target: VSS, "no peer entry for link {} under node {node_addr}; sending it without a bootstrap visa", link.link_id);
             continue;
         };
-        // The link is between `node_addr` and `peer.remote_zpr_addr`.
-        // Both halves of the VSAPI session are needed, one visa each:
-        //
-        //     peer:ANYPORT     -> vs.zpr:VSAPI_PORT TCP    (the peer's SYN)
-        //     vs.zpr:VSAPI_PORT -> peer:ANYPORT TCP        (the visa service's reply)
-        //
-        // Fail the whole call rather than sending the link bare: without both visas the peer
-        // cannot complete a VSAPI session, so the link is useless, and returning Ok would let
-        // `send_topology` mark topology synced and stop housekeeping from ever retrying.
-        // Minting is idempotent (it returns any existing visa), so the retry is free.
-        for direction in [Direction::Forward, Direction::Reverse] {
-            let visa = asm
-                .visa_mgr
-                .vsapi_bootstrap_visa_for_future_peer(
-                    &asm,
-                    &peer.remote_zpr_addr,
-                    node_addr,
-                    direction,
-                )
-                .await
-                .map_err(|e| {
-                    VssSyncError::Internal(format!(
-                        "failed to create {direction:?} bootstrap visa for future peer {}: {e}",
-                        peer.remote_zpr_addr
-                    ))
-                })?;
-            // Actualizing for the peer gives it the copy for its end of the path: ingress with
-            // a fwd_pep handing its VSAPI traffic to `node_addr` on the forward visa, egress
-            // with no forwarding on the reply visa. Nodes further along the path get their own
-            // copies via the pending-install queue.
-            let visa = asm
-                .visa_mgr
-                .actualize_visa_for_target_node(visa, &peer.remote_zpr_addr)
-                .await
-                .map_err(|e| {
-                    VssSyncError::Internal(format!(
-                        "failed to actualize {direction:?} bootstrap visa for future peer {}: {e}",
-                        peer.remote_zpr_addr
-                    ))
-                })?;
-            debug!(target: VSS, "created {direction:?} bootstrap visa for future peer {}: {}", peer.remote_zpr_addr, visa.issuer_id);
-            link.visas.push(visa);
-        }
+        // The link is between `node_addr` and `peer.remote_zpr_addr`. Fail the whole call rather
+        // than sending the link bare: without the visa the peer cannot reach VSAPI, so the link
+        // is useless, and returning Ok would let `send_topology` mark topology synced and stop
+        // housekeeping from ever retrying. Minting is idempotent, so the retry is free.
+        let visa = visa_bootstrap::visa_for_link(&asm, &peer.remote_zpr_addr, node_addr)
+            .await
+            .map_err(|e| {
+                VssSyncError::Internal(format!(
+                    "failed to create bootstrap visa for future peer {}: {e}",
+                    peer.remote_zpr_addr
+                ))
+            })?;
+        link.visas.push(visa);
     }
 
     let mut req = vss_handle.set_topology_request();

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -687,11 +687,16 @@ async fn vss_do_set_topology(
     mut peers: Vec<Link>,
 ) -> Result<(), VssSyncError> {
     // HACK -> This hack here is to support our intial MULTINODE implementation.
-    // We create "bootstrap" visas for each peer in the topology message, every time we send it.
+    // We create "bootstrap" visas for each peer in the topology message, every
+    // time we send it: one for the peer's own SYN to VSAPI, one for the visa
+    // service's reply to it.
     //
-    // The visa belongs to the peer, not to this node: this node holds it and hands it off when
-    // the peer connects. Minting bypasses policy evaluation entirely -- see
-    // [crate::visa_bootstrap], which is where all of this lives and where it gets deleted from.
+    // The visas belong to the peer, not to the node to whom we are sending the
+    // message: that node holds them and hands them off when the peer connects.
+    //
+    // Minting bypasses policy evaluation entirely -- see
+    // [crate::visa_bootstrap], which is where all of this lives and where it
+    // gets deleted from.
     //
     // TODO: Reevaluate this.
 
@@ -700,22 +705,22 @@ async fn vss_do_set_topology(
     let node_peers = policy.get_peers_for_node(node_addr).unwrap_or_default();
     for link in &mut peers {
         let Some(peer) = node_peers.iter().find(|p| p.link_id == link.link_id) else {
-            warn!(target: VSS, "no peer entry for link {} under node {node_addr}; sending it without a bootstrap visa", link.link_id);
+            warn!(target: VSS, "no peer entry for link {} under node {node_addr}; sending it without bootstrap visas", link.link_id);
             continue;
         };
         // The link is between `node_addr` and `peer.remote_zpr_addr`. Fail the whole call rather
-        // than sending the link bare: without the visa the peer cannot reach VSAPI, so the link
+        // than sending the link bare: without the visas the peer cannot reach VSAPI, so the link
         // is useless, and returning Ok would let `send_topology` mark topology synced and stop
         // housekeeping from ever retrying. Minting is idempotent, so the retry is free.
-        let visa = visa_bootstrap::visa_for_link(&asm, &peer.remote_zpr_addr, node_addr)
+        let visas = visa_bootstrap::visas_for_link(&asm, &peer.remote_zpr_addr, node_addr)
             .await
             .map_err(|e| {
                 VssSyncError::Internal(format!(
-                    "failed to create bootstrap visa for future peer {}: {e}",
+                    "failed to create bootstrap visas for future peer {}: {e}",
                     peer.remote_zpr_addr
                 ))
             })?;
-        link.visas.push(visa);
+        link.visas.extend(visas);
     }
 
     let mut req = vss_handle.set_topology_request();

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -13,6 +13,7 @@ use tokio_rustls::TlsConnector;
 use tokio_util::compat::*;
 use tracing::{debug, error, info, trace, warn};
 
+use libeval::eval_result::Direction;
 use libeval::policy::Policy;
 use zpr::vsapi::v1;
 use zpr::vsapi_types::{ApiResponseError, Link, Param, ServiceDescriptor, Visa, VisaOp, pname};
@@ -704,39 +705,48 @@ async fn vss_do_set_topology(
             continue;
         };
         // The link is between `node_addr` and `peer.remote_zpr_addr`.
-        // The visa needs to look like:
+        // Both halves of the VSAPI session are needed, one visa each:
         //
-        //     peer:ANYPORT -> vs.zpr:VSAPI_PORT TCP
+        //     peer:ANYPORT     -> vs.zpr:VSAPI_PORT TCP    (the peer's SYN)
+        //     vs.zpr:VSAPI_PORT -> peer:ANYPORT TCP        (the visa service's reply)
         //
-        // Fail the whole call rather than sending the link bare: without the visa the peer
-        // cannot reach VSAPI, so the link is useless, and returning Ok would let
+        // Fail the whole call rather than sending the link bare: without both visas the peer
+        // cannot complete a VSAPI session, so the link is useless, and returning Ok would let
         // `send_topology` mark topology synced and stop housekeeping from ever retrying.
         // Minting is idempotent (it returns any existing visa), so the retry is free.
-        let visa = asm
-            .visa_mgr
-            .vsapi_bootstrap_visa_for_future_peer(&asm, &peer.remote_zpr_addr, node_addr)
-            .await
-            .map_err(|e| {
-                VssSyncError::Internal(format!(
-                    "failed to create bootstrap visa for future peer {}: {e}",
-                    peer.remote_zpr_addr
-                ))
-            })?;
-        // The peer is the ingress node of this visa, so actualizing for it attaches the
-        // fwd_pep it needs to hand its VSAPI traffic to `node_addr` for relaying. Nodes
-        // further along the path get their own copies via the pending-install queue.
-        let visa = asm
-            .visa_mgr
-            .actualize_visa_for_target_node(visa, &peer.remote_zpr_addr)
-            .await
-            .map_err(|e| {
-                VssSyncError::Internal(format!(
-                    "failed to actualize bootstrap visa for future peer {}: {e}",
-                    peer.remote_zpr_addr
-                ))
-            })?;
-        debug!(target: VSS, "created bootstrap visa for future peer {}: {}", peer.remote_zpr_addr, visa.issuer_id);
-        link.visas.push(visa);
+        for direction in [Direction::Forward, Direction::Reverse] {
+            let visa = asm
+                .visa_mgr
+                .vsapi_bootstrap_visa_for_future_peer(
+                    &asm,
+                    &peer.remote_zpr_addr,
+                    node_addr,
+                    direction,
+                )
+                .await
+                .map_err(|e| {
+                    VssSyncError::Internal(format!(
+                        "failed to create {direction:?} bootstrap visa for future peer {}: {e}",
+                        peer.remote_zpr_addr
+                    ))
+                })?;
+            // Actualizing for the peer gives it the copy for its end of the path: ingress with
+            // a fwd_pep handing its VSAPI traffic to `node_addr` on the forward visa, egress
+            // with no forwarding on the reply visa. Nodes further along the path get their own
+            // copies via the pending-install queue.
+            let visa = asm
+                .visa_mgr
+                .actualize_visa_for_target_node(visa, &peer.remote_zpr_addr)
+                .await
+                .map_err(|e| {
+                    VssSyncError::Internal(format!(
+                        "failed to actualize {direction:?} bootstrap visa for future peer {}: {e}",
+                        peer.remote_zpr_addr
+                    ))
+                })?;
+            debug!(target: VSS, "created {direction:?} bootstrap visa for future peer {}: {}", peer.remote_zpr_addr, visa.issuer_id);
+            link.visas.push(visa);
+        }
     }
 
     let mut req = vss_handle.set_topology_request();

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -715,7 +715,7 @@ async fn vss_do_set_topology(
         //
         // An already-connected peer is the exception and yields no visas -- it has a VSAPI
         // session of its own and asks for what it needs.
-        let visas = visa_bootstrap::visas_for_link(&asm, &peer.remote_zpr_addr, node_addr)
+        let visas = visa_bootstrap::visas_for_link(&asm, &policy, &peer.remote_zpr_addr, node_addr)
             .await
             .map_err(|e| {
                 VssSyncError::Internal(format!(

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -699,28 +699,31 @@ async fn vss_do_set_topology(
     // meaningful under its own node key -- so resolve the link within `node_addr`'s peers.
     let node_peers = policy.get_peers_for_node(node_addr).unwrap_or_default();
     for link in &mut peers {
-        if let Some(peer) = node_peers.iter().find(|p| p.link_id == link.link_id) {
-            // The link is between `node_addr` and `peer.remote_zpr_addr`.
-            // The visa needs to look like:
-            //
-            //     peer:ANYPORT -> vs.zpr:VSAPI_PORT TCP
-            //
-            match asm
-                .visa_mgr
-                .vsapi_bootstrap_visa_for_future_peer(&asm, &peer.remote_zpr_addr)
-                .await
-            {
-                Ok(visa) => {
-                    debug!(target: VSS, "created bootstrap visa for future peer {}: {}", peer.remote_zpr_addr, visa.issuer_id);
-                    link.visas.push(visa);
-                }
-                Err(e) => {
-                    error!(target: VSS, "failed to create bootstrap visa for future peer {}: {:?}", peer.remote_zpr_addr, e);
-                }
-            }
-        } else {
+        let Some(peer) = node_peers.iter().find(|p| p.link_id == link.link_id) else {
             warn!(target: VSS, "no peer entry for link {} under node {node_addr}; sending it without a bootstrap visa", link.link_id);
-        }
+            continue;
+        };
+        // The link is between `node_addr` and `peer.remote_zpr_addr`.
+        // The visa needs to look like:
+        //
+        //     peer:ANYPORT -> vs.zpr:VSAPI_PORT TCP
+        //
+        // Fail the whole call rather than sending the link bare: without the visa the peer
+        // cannot reach VSAPI, so the link is useless, and returning Ok would let
+        // `send_topology` mark topology synced and stop housekeeping from ever retrying.
+        // Minting is idempotent (it returns any existing visa), so the retry is free.
+        let visa = asm
+            .visa_mgr
+            .vsapi_bootstrap_visa_for_future_peer(&asm, &peer.remote_zpr_addr)
+            .await
+            .map_err(|e| {
+                VssSyncError::Internal(format!(
+                    "failed to create bootstrap visa for future peer {}: {e}",
+                    peer.remote_zpr_addr
+                ))
+            })?;
+        debug!(target: VSS, "created bootstrap visa for future peer {}: {}", peer.remote_zpr_addr, visa.issuer_id);
+        link.visas.push(visa);
     }
 
     let mut req = vss_handle.set_topology_request();

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -13,6 +13,7 @@ use tokio_rustls::TlsConnector;
 use tokio_util::compat::*;
 use tracing::{debug, error, info, trace, warn};
 
+use libeval::policy::Policy;
 use zpr::vsapi::v1;
 use zpr::vsapi_types::{ApiResponseError, Link, Param, ServiceDescriptor, Visa, VisaOp, pname};
 use zpr::write_to::WriteTo;
@@ -174,9 +175,9 @@ pub async fn vss_worker_loop(
                                 asm.counters.incr(CounterType::VssErrors);
                             }
                         }
-                        VssCmd::SetTopology(links, resp_tx) => {
+                        VssCmd::SetTopology(links, policy, resp_tx) => {
                             state.mark_topology_updated();
-                            if let Err(e) = resp_tx.send(vss_do_set_topology(&vss_handle, asm.clone(), &node_addr.ip(), links).await) {
+                            if let Err(e) = resp_tx.send(vss_do_set_topology(&vss_handle, asm.clone(), &node_addr.ip(), policy, links).await) {
                                 error!(target: VSS, "failed to send response for set-topology command: {:?}", e);
                                 asm.counters.incr(CounterType::VssErrors);
                             }
@@ -460,10 +461,20 @@ async fn send_topology(
     node_addr: &IpAddr,
     vss_handle: &v1::v_s_s_handle::Client,
 ) {
-    let links = asm.policy_mgr.resolved_links_for_node(node_addr);
+    // One snapshot for both the links and the bootstrap-visa peer lookup inside.
+    let psnap = asm.policy_mgr.get_current_snapshot();
+    let links = psnap.links_for_node(node_addr);
 
     debug!(target: VSS, "sending initial topology to VSS at {}", node_addr);
-    if let Err(e) = vss_do_set_topology(vss_handle, asm.clone(), node_addr, links).await {
+    if let Err(e) = vss_do_set_topology(
+        vss_handle,
+        asm.clone(),
+        node_addr,
+        psnap.policy_arc(),
+        links,
+    )
+    .await
+    {
         error!(target: VSS, "failed to send initial topology to VSS at {}: {}", node_addr, e);
         asm.counters.incr(CounterType::VssErrors);
     } else {
@@ -664,10 +675,14 @@ async fn vss_do_configure(
 ///
 /// `node_addr` is the ZPR address of the node on the other end of `vss_handle`; the links are
 /// that node's view of the topology, so the peer lookup below must be keyed by it.
+///
+/// `policy` must be the snapshot `peers` was computed from. Reacquiring the current policy here
+/// would let a newly installed one pair its peers with the older snapshot's links.
 async fn vss_do_set_topology(
     vss_handle: &v1::v_s_s_handle::Client,
     asm: Arc<Assembly>,
     node_addr: &IpAddr,
+    policy: Arc<Policy>,
     mut peers: Vec<Link>,
 ) -> Result<(), VssSyncError> {
     // HACK -> This hack here is to support our intial MULTINODE implementation.
@@ -680,7 +695,6 @@ async fn vss_do_set_topology(
     //
     // TODO: Reevaluate this.
 
-    let policy = asm.policy_mgr.get_current();
     // Both ends of an edge share a link_id, and each end's `remote_zpr_addr` is only
     // meaningful under its own node key -- so resolve the link within `node_addr`'s peers.
     let node_peers = policy.get_peers_for_node(node_addr).unwrap_or_default();

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -714,11 +714,24 @@ async fn vss_do_set_topology(
         // Minting is idempotent (it returns any existing visa), so the retry is free.
         let visa = asm
             .visa_mgr
-            .vsapi_bootstrap_visa_for_future_peer(&asm, &peer.remote_zpr_addr)
+            .vsapi_bootstrap_visa_for_future_peer(&asm, &peer.remote_zpr_addr, node_addr)
             .await
             .map_err(|e| {
                 VssSyncError::Internal(format!(
                     "failed to create bootstrap visa for future peer {}: {e}",
+                    peer.remote_zpr_addr
+                ))
+            })?;
+        // The peer is the ingress node of this visa, so actualizing for it attaches the
+        // fwd_pep it needs to hand its VSAPI traffic to `node_addr` for relaying. Nodes
+        // further along the path get their own copies via the pending-install queue.
+        let visa = asm
+            .visa_mgr
+            .actualize_visa_for_target_node(visa, &peer.remote_zpr_addr)
+            .await
+            .map_err(|e| {
+                VssSyncError::Internal(format!(
+                    "failed to actualize bootstrap visa for future peer {}: {e}",
                     peer.remote_zpr_addr
                 ))
             })?;

--- a/vs/src/vss_worker.rs
+++ b/vs/src/vss_worker.rs
@@ -712,6 +712,9 @@ async fn vss_do_set_topology(
         // than sending the link bare: without the visas the peer cannot reach VSAPI, so the link
         // is useless, and returning Ok would let `send_topology` mark topology synced and stop
         // housekeeping from ever retrying. Minting is idempotent, so the retry is free.
+        //
+        // An already-connected peer is the exception and yields no visas -- it has a VSAPI
+        // session of its own and asks for what it needs.
         let visas = visa_bootstrap::visas_for_link(&asm, &peer.remote_zpr_addr, node_addr)
             .await
             .map_err(|e| {


### PR DESCRIPTION
Enabled multi-node connectivity though bootstrap visas.  This is the code that ran for the demo.

- Pre-mints forward and reverse visas so an unconnected, policy-declared peer can reach VSAPI through an existing node; these visas are delivered with topology updates and deduplicated.

- Refactors visa pathing/actualization and request handling to support relayed flows correctly.

- Installs policy-defined topology links when nodes connect and improves substrate-address derivation.

- Adds extensive coverage and bumps the workspace to 0.16.0 / zpr-common to 0.22.1.